### PR TITLE
Prevent crashes if config file is not published

### DIFF
--- a/src/Sentry/SentryLaravel/SentryLaravelServiceProvider.php
+++ b/src/Sentry/SentryLaravel/SentryLaravelServiceProvider.php
@@ -64,6 +64,11 @@ class SentryLaravelServiceProvider extends ServiceProvider
         $this->app->singleton('sentry', function ($app) {
             // sentry::config is Laravel 4.x
             $user_config = $app['config']['sentry'] ?: $app['config']['sentry::config'];
+            
+            // Make sure we don't crash when we did not publish the config file
+            if (is_null($user_config)) {
+                $user_config = [];
+            }
 
             $config = array_merge(array(
                 'environment' => $app->environment(),

--- a/src/Sentry/SentryLaravel/SentryLumenServiceProvider.php
+++ b/src/Sentry/SentryLaravel/SentryLumenServiceProvider.php
@@ -32,6 +32,11 @@ class SentryLumenServiceProvider extends ServiceProvider
     {
         $this->app->singleton('sentry', function ($app) {
             $user_config = $app['config']['sentry'];
+            
+            // Make sure we don't crash when we did not publish the config file
+            if (is_null($user_config)) {
+                $user_config = [];
+            }
 
             $config = array_merge(array(
                 'environment' => $app->environment(),


### PR DESCRIPTION
If the config files are not published the user config that is retrieved is not an empty array but `null`.

Check for that so we do not get a crash when the user config is merged with the defaults.

This also makes it impossible to publish the config file since the provider must be registered but when the provider is registered it tries to merge the config and errors out. 