### PR TITLE
Add /examples to export-ignore

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+/examples export-ignore


### PR DESCRIPTION
According to the internet, this might stop ``php artisan optimize`` from including files we don't want to be part of the build.