### PR TITLE
Remove wrong import from middleware context example

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,6 @@ In the following example, we'll use a middleware:
 ```php
 namespace App\Http\Middleware;
 
-use Context;
 use Closure;
 
 class SentryContext


### PR DESCRIPTION
I just noticed I left this import in my example code (A)