### PR TITLE
Cleanup

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 /examples export-ignore
+/test export-ignore

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "php": ">=5.2.4",
+        "php": ">=5.5.9",
         "illuminate/support": "4.*|5.*",
         "sentry/sentry": ">=0.16.0"
     },

--- a/src/Sentry/SentryLaravel/SentryFacade.php
+++ b/src/Sentry/SentryLaravel/SentryFacade.php
@@ -6,6 +6,11 @@ use Illuminate\Support\Facades\Facade;
 
 class SentryFacade extends Facade
 {
+    /**
+     * Get the registered name of the component.
+     *
+     * @return string
+     */
     protected static function getFacadeAccessor()
     {
         return 'sentry';

--- a/src/Sentry/SentryLaravel/SentryLaravel.php
+++ b/src/Sentry/SentryLaravel/SentryLaravel.php
@@ -2,19 +2,28 @@
 
 namespace Sentry\SentryLaravel;
 
+use Raven_Client;
+
 class SentryLaravel
 {
     const VERSION = '0.4.0.dev0';
 
+    /**
+     * Get the raven client instance.
+     *
+     * @param array $user_config
+     *
+     * @return \Raven_Client
+     */
     public static function getClient($user_config)
     {
-        $config = array_merge(array(
-            'sdk' => array(
+        $config = array_merge([
+            'sdk' => [
                 'name' => 'sentry-laravel',
                 'version' => self::VERSION,
-            ),
-        ), $user_config);
+            ],
+        ], $user_config);
 
-        return new \Raven_Client($config);
+        return new Raven_Client($config);
     }
 }

--- a/src/Sentry/SentryLaravel/SentryLumenServiceProvider.php
+++ b/src/Sentry/SentryLaravel/SentryLumenServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace Sentry\SentryLaravel;
 
+use Exception;
 use Illuminate\Support\ServiceProvider;
 
 class SentryLumenServiceProvider extends ServiceProvider
@@ -38,21 +39,21 @@ class SentryLumenServiceProvider extends ServiceProvider
                 $user_config = [];
             }
 
-            $client = SentryLaravel::getClient(array_merge(array(
+            $client = SentryLaravel::getClient(array_merge([
                 'environment' => $app->environment(),
-                'prefixes' => array(base_path()),
-                'app_path' => base_path() . '/app',
-            ), $user_config));
+                'prefixes'    => [base_path()],
+                'app_path'    => base_path() . '/app',
+            ], $user_config));
 
             // bind user context if available
             try {
                 if ($app['auth']->check()) {
                     $user = $app['auth']->user();
-                    $client->user_context(array(
+                    $client->user_context([
                         'id' => $user->getAuthIdentifier(),
-                    ));
+                    ]);
                 }
-            } catch (\Exception $e) {
+            } catch (Exception $e) {
             }
 
             return $client;
@@ -66,6 +67,6 @@ class SentryLumenServiceProvider extends ServiceProvider
      */
     public function provides()
     {
-        return array('sentry');
+        return ['sentry'];
     }
 }

--- a/src/Sentry/SentryLaravel/config.php
+++ b/src/Sentry/SentryLaravel/config.php
@@ -1,8 +1,8 @@
 <?php
 
-return array(
+return [
     'dsn' => env('SENTRY_DSN'),
 
     // capture release as git sha
     // 'release' => trim(exec('git log --pretty="%h" -n1 HEAD')),
-);
+];


### PR DESCRIPTION
- Laravel has a min PHP constraint on 5.5.9, so we're now matching that.
- Since we're using at least PHP 5.4 we're now using short arrays everywhere. There was already one array using this syntax (so the code was immediately incompatible with 5.2.4 anyway).
- I've imported all namespaces, rather than using the lazy syntax. Also, we're importing the `Log` facade. It's possible that someone would remove the `Log` alias from `config/app.php` so this import would fail.

I think next I'll switch to PSR-4 (which I think can just be a `composer.json` modification) and then write some tests, if I get enough time.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry-laravel/26)

<!-- Reviewable:end -->
