### PR TITLE
Do not call boot method on Laravel Service Provider

### DIFF
--- a/src/Sentry/SentryLaravel/SentryLaravelServiceProvider.php
+++ b/src/Sentry/SentryLaravel/SentryLaravelServiceProvider.php
@@ -21,8 +21,6 @@ class SentryLaravelServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        parent::boot();
-
         $app = $this->app;
 
         // Laravel 4.x compatibility


### PR DESCRIPTION
The base Laravel serviceprovider does not have a boot method defined.