### PR TITLE
Force sentry to use the absolute git path

### DIFF
--- a/src/config/config.php
+++ b/src/config/config.php
@@ -4,5 +4,5 @@ return array(
     'dsn' => '',
 
     // capture release as git sha
-    // 'release' => trim(exec('git log --pretty="%h" -n1 HEAD')),
+    // 'release' => trim(exec('git --git-dir ' . base_path('.git') . ' log --pretty="%h" -n1 HEAD')),
 );


### PR DESCRIPTION
![https://i.imgur.com/Q4ywKhF.png](https://i.imgur.com/Q4ywKhF.png)

I was running into issues when running artisan from a directory that did not have a git repository. It was because sentry config `exec` was using the directory the command was executed in, not the path Laravel is installed. This simple fix forces it to use the correct path.
