### PR TITLE
Adds missing query bindings to breadcrumbs

### DIFF
--- a/src/Sentry/SentryLaravel/SentryLaravelEventHandler.php
+++ b/src/Sentry/SentryLaravel/SentryLaravelEventHandler.php
@@ -148,7 +148,7 @@ class SentryLaravelEventHandler
             'connectionName' => $query->connectionName,
         ];
 
-        if ($this->sqlBindings && !empty($bindings)) {
+        if ($this->sqlBindings && !empty($query->bindings)) {
             $data['bindings'] = $query->bindings;
         }
 

--- a/src/Sentry/SentryLaravel/SentryLaravelEventHandler.php
+++ b/src/Sentry/SentryLaravel/SentryLaravelEventHandler.php
@@ -133,6 +133,7 @@ class SentryLaravelEventHandler
         $this->record([
             'message'  => $query,
             'category' => 'sql.query',
+            'data'     => $data
         ]);
     }
 


### PR DESCRIPTION
I've been using this package on a project, and I've noticed that the `breadcrumbs.sql_binding` config value currently isn't having an effect.

This is down to a couple of small issues - a missing `data` parameter in the `<= 5.1` handler, and an incorrect `isset()` check in the `>= 5.2` handler.

Let me know if you need any more info.