### PR TITLE
Optional user_context

### DIFF
--- a/src/Sentry/SentryLaravel/SentryLaravelServiceProvider.php
+++ b/src/Sentry/SentryLaravel/SentryLaravelServiceProvider.php
@@ -86,16 +86,18 @@ class SentryLaravelServiceProvider extends ServiceProvider
                 'app_path' => app_path(),
             ), $user_config));
 
-            // bind user context if available
-            try {
-                if ($app['auth']->check()) {
-                    $user = $app['auth']->user();
-                    $client->user_context(array(
-                        'id' => $user->getAuthIdentifier(),
-                    ));
+            if($user_config['breadcrumbs.user_context']) {
+                // bind user context if available
+                try {
+                    if ($app['auth']->check()) {
+                        $user = $app['auth']->user();
+                        $client->user_context(array(
+                            'id' => $user->getAuthIdentifier(),
+                        ));
+                    }
+                } catch (\Exception $e) {
+                    error_log(sprintf('sentry.breadcrumbs error=%s', $e->getMessage()));
                 }
-            } catch (\Exception $e) {
-                error_log(sprintf('sentry.breadcrumbs error=%s', $e->getMessage()));
             }
 
             return $client;

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -5,4 +5,7 @@ return array(
 
     // capture release as git sha
     // 'release' => trim(exec('git --git-dir ' . base_path('.git') . ' log --pretty="%h" -n1 HEAD')),
+    
+    // capture user context for breadcrumbs
+    'breadcrumbs.user_context' => true,
 );


### PR DESCRIPTION
The current implementation assumes the default Laravel auth implementation. For anyone who uses auth schemes that aren't part of the core, this leaves lots of debris on the command line: `sentry.breadcrumbs error=Auth guard driver [api] is not defined.`

This change makes this optional behavior and doesn't alter it in any way.