### PR TITLE
Converting to long form array syntax for poor SoBs using PHP 5.3

### DIFF
--- a/src/Sentry/SentryLaravel/SentryLaravelEventHandler.php
+++ b/src/Sentry/SentryLaravel/SentryLaravelEventHandler.php
@@ -21,7 +21,7 @@ class SentryLaravelEventHandler
     public function subscribe(Dispatcher $events)
     {
         $this->events = $events;
-        $events->listen('*', [$this, 'onWildcardEvent']);
+        $events->listen('*', array($this, 'onWildcardEvent'));
     }
 
     public function onWildcardEvent()

--- a/src/Sentry/SentryLaravel/SentryLaravelServiceProvider.php
+++ b/src/Sentry/SentryLaravel/SentryLaravelServiceProvider.php
@@ -65,7 +65,7 @@ class SentryLaravelServiceProvider extends ServiceProvider
 
             // Make sure we don't crash when we did not publish the config file
             if (is_null($user_config)) {
-                $user_config = [];
+                $user_config = array();
             }
 
             return $user_config;

--- a/src/Sentry/SentryLaravel/SentryLumenServiceProvider.php
+++ b/src/Sentry/SentryLaravel/SentryLumenServiceProvider.php
@@ -42,7 +42,7 @@ class SentryLumenServiceProvider extends ServiceProvider
 
             // Make sure we don't crash when we did not publish the config file
             if (is_null($user_config)) {
-                $user_config = [];
+                $user_config = array();
             }
 
             return $user_config;


### PR DESCRIPTION
Yeah I know.  I know.  But we’re still stuck on a legacy server with legacy Laravel and need to get Sentry up and running on it.  Since most other place use the long-form array syntax, there were only a few small changes needed.

Signed-off-by: Michael Soileau <rsoileau@no-ip.com>