### PR TITLE
Replace call to get user then id, with just id()

### DIFF
--- a/src/Sentry/SentryLaravel/SentryLaravelServiceProvider.php
+++ b/src/Sentry/SentryLaravel/SentryLaravelServiceProvider.php
@@ -90,9 +90,8 @@ class SentryLaravelServiceProvider extends ServiceProvider
                 // bind user context if available
                 try {
                     if ($app['auth']->check()) {
-                        $user = $app['auth']->user();
                         $client->user_context(array(
-                            'id' => $user->getAuthIdentifier(),
+                            'id' => $app['auth']->id(),
                         ));
                     }
                 } catch (\Exception $e) {


### PR DESCRIPTION
No need to retrieve the full user object to get the id from it as the auth guard interface `$app['auth']` has a method for this: https://github.com/laravel/framework/blob/5.4/src/Illuminate/Contracts/Auth/Guard.php#L29
