### PR TITLE
Add check if Sentry was loaded before reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,10 @@ Add Sentry reporting to ``app/Exceptions/Handler.php``:
 ```php
 public function report(Exception $exception)
 {
-    if ($this->shouldReport($exception)) {
+    if (app()->bound('sentry') && $this->shouldReport($exception)) {
         app('sentry')->captureException($exception);
     }
+
     parent::report($exception);
 }
 ```
@@ -99,9 +100,10 @@ Add Sentry reporting to ``app/Exceptions/Handler.php``:
 ```php
 public function report(Exception $e)
 {
-    if ($this->shouldReport($e)) {
+    if (app()->bound('sentry') && $this->shouldReport($e)) {
         app('sentry')->captureException($e);
     }
+
     parent::report($e);
 }
 ```


### PR DESCRIPTION
Preventing extra exceptions when config has not been published for example (or old config is still cached).