### PR TITLE
Ensure all code is PHP 5.3 compatible

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,16 +12,16 @@
         }
     ],
     "require": {
-        "php": ">=5.2.4",
+        "php": ">=5.3.0",
         "illuminate/support": "4.*|5.*",
-        "sentry/sentry": ">=1.6.0"
+        "sentry/sentry": ">=1.7.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^1.8.0",
         "phpunit/phpunit": "^4.6.6"
     },
     "autoload": {
-        "psr-0" : {
+        "psr-0": {
             "Sentry\\SentryLaravel\\": "src/"
         }
     },

--- a/src/Sentry/SentryLaravel/SentryLaravelServiceProvider.php
+++ b/src/Sentry/SentryLaravel/SentryLaravelServiceProvider.php
@@ -14,13 +14,6 @@ class SentryLaravelServiceProvider extends ServiceProvider
     public static $abstract = 'sentry';
 
     /**
-     * Indicates if loading of the provider is deferred.
-     *
-     * @var bool
-     */
-    protected $defer = false;
-
-    /**
      * Bootstrap the application events.
      *
      * @return void
@@ -55,17 +48,17 @@ class SentryLaravelServiceProvider extends ServiceProvider
         }
     }
 
-    protected function registerArtisanCommands()
-    {
-        $this->commands([
-            SentryTestCommand::class,
-        ]);
-    }
-
     protected function bindEvents($app)
     {
         $handler = new SentryLaravelEventHandler($app[static::$abstract], $app[static::$abstract . '.config']);
         $handler->subscribe($app->events);
+    }
+
+    protected function registerArtisanCommands()
+    {
+        $this->commands(array(
+            'Sentry\SentryLaravel\SentryTestCommand',
+        ));
     }
 
     /**
@@ -81,7 +74,7 @@ class SentryLaravelServiceProvider extends ServiceProvider
 
             // Make sure we don't crash when we did not publish the config file
             if (is_null($user_config)) {
-                $user_config = [];
+                $user_config = array();
             }
 
             return $user_config;

--- a/src/Sentry/SentryLaravel/SentryLumenServiceProvider.php
+++ b/src/Sentry/SentryLaravel/SentryLumenServiceProvider.php
@@ -7,13 +7,6 @@ use Illuminate\Support\ServiceProvider;
 class SentryLumenServiceProvider extends ServiceProvider
 {
     /**
-     * Indicates if loading of the provider is deferred.
-     *
-     * @var bool
-     */
-    protected $defer = false;
-
-    /**
      * Bootstrap the application events.
      *
      * @return void
@@ -27,17 +20,17 @@ class SentryLumenServiceProvider extends ServiceProvider
         }
     }
 
-    protected function registerArtisanCommands()
-    {
-        $this->commands([
-            SentryTestCommand::class,
-        ]);
-    }
-
     protected function bindEvents($app)
     {
         $handler = new SentryLaravelEventHandler($app['sentry'], $app['sentry.config']);
         $handler->subscribe($app->events);
+    }
+
+    protected function registerArtisanCommands()
+    {
+        $this->commands(array(
+            'Sentry\SentryLaravel\SentryTestCommand',
+        ));
     }
 
     /**
@@ -52,7 +45,7 @@ class SentryLumenServiceProvider extends ServiceProvider
 
             // Make sure we don't crash when we did not publish the config file
             if (is_null($user_config)) {
-                $user_config = [];
+                $user_config = array();
             }
 
             return $user_config;

--- a/src/Sentry/SentryLaravel/SentryTestCommand.php
+++ b/src/Sentry/SentryLaravel/SentryTestCommand.php
@@ -55,13 +55,14 @@ class SentryTestCommand extends Command
             $config = get_object_vars($client);
             $required_keys = array('server', 'project', 'public_key', 'secret_key');
 
-            $output = "";
+            $output = '';
             foreach ($required_keys as $key) {
                 if (empty($config[$key])) {
                     $this->error("[sentry] ERROR: Missing configuration for $key");
                 }
+
                 if (is_array($config[$key])) {
-                    $output .= "-> $key: [".implode(", ", $config[$key])."]\n";
+                    $output .= "-> $key: [" . implode(', ', $config[$key]) . "]\n";
                 } else {
                     $output .= "-> $key: $config[$key]\n";
                 }
@@ -71,7 +72,7 @@ class SentryTestCommand extends Command
 
             $this->info('[sentry] Generating test event');
 
-            $ex = $this->generateTestException("command name", array("foo" => "bar"));
+            $ex = $this->generateTestException('command name', array('foo' => 'bar'));
 
             $event_id = $client->captureException($ex);
 
@@ -81,11 +82,21 @@ class SentryTestCommand extends Command
             if (!empty($last_error)) {
                 $this->error("[sentry] There was an error sending the test event:\n $last_error");
             }
-        } finally {
-            error_reporting($old_error_reporting);
+        } catch (\Exception $e) {
+            // Ignore any exceptions
         }
+
+        error_reporting($old_error_reporting);
     }
 
+    /**
+     * Generate a test exception to send to Sentry.
+     *
+     * @param $command
+     * @param $arg
+     *
+     * @return \Exception
+     */
     protected function generateTestException($command, $arg)
     {
         // Do something silly


### PR DESCRIPTION
Why? Because we define php as `>=5.3.0` in composer.json.

Actually we had `>=5.2.4` but that makes no sense since Laravel 4.0 requires `>=5.3.0`.