### PR TITLE
Fix Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
+
 language: php
+sudo: false
 
 php:
   - 5.3
@@ -7,22 +9,31 @@ php:
   - 5.6
   - 7.0
   - 7.1
-  - hhvm
+  - nightly
+env:
+  - REMOVE_XDEBUG="0"
+  - REMOVE_XDEBUG="1"
 
 matrix:
+  allow_failures:
+    - php: hhvm-3.12
+    - php: nightly
   fast_finish: true
-
-sudo: false
+  include:
+    - php: hhvm-3.12
+      env: REMOVE_XDEBUG="0" HHVM="1"
+      dist: trusty
 
 cache:
   directories:
     - $HOME/.composer/cache
 
 before_install:
+  - if [ "$REMOVE_XDEBUG" = "1" ]; then phpenv config-rm xdebug.ini; fi
   - composer self-update
 
-install: travis_retry composer install --no-interaction --prefer-source
+install: travis_retry composer install --no-interaction --prefer-dist
 
 script:
-  - vendor/bin/php-cs-fixer fix --config-file=.php_cs --verbose --diff --dry-run
-  - vendor/bin/phpunit
+  - composer phpcs
+  - composer tests-travis

--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,20 @@
             "Sentry\\SentryLaravel\\": "src/"
         }
     },
+    "scripts": {
+        "tests": [
+            "vendor/bin/phpunit --verbose"
+        ],
+        "tests-travis": [
+            "vendor/bin/phpunit --verbose --configuration phpunit.xml --coverage-clover test/clover.xml"
+        ],
+        "tests-report": [
+            "vendor/bin/phpunit --verbose --configuration phpunit.xml --coverage-html test/html-report"
+        ],
+        "phpcs": [
+            "vendor/bin/php-cs-fixer fix --config-file=.php_cs --verbose --diff --dry-run"
+        ]
+    },
     "extra": {
         "branch-alias": {
             "dev-master": "0.8.x-dev"


### PR DESCRIPTION
Use the same Travis config as sentry/sentry-php.

This fixes HHVM testing and more...

Looking at ways to actually test something that also can test different Laravel versions.