### PR TITLE
Improve default app_path detection

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,8 @@
 0.8.0
 -----
 
+- Improved default app_path to include entire application code, excluding vendor. (#89)
+
 0.7.0
 -----
 

--- a/src/Sentry/SentryLaravel/SentryLaravelServiceProvider.php
+++ b/src/Sentry/SentryLaravel/SentryLaravelServiceProvider.php
@@ -96,11 +96,12 @@ class SentryLaravelServiceProvider extends ServiceProvider
 
         $this->app->singleton(static::$abstract, function ($app) {
             $user_config = $app[static::$abstract . '.config'];
-
+            $base_path = base_path();
             $client = SentryLaravel::getClient(array_merge(array(
                 'environment' => $app->environment(),
-                'prefixes' => array(base_path()),
-                'app_path' => app_path(),
+                'prefixes' => array($base_path),
+                'app_path' => $base_path,
+                'excluded_app_paths' => array($base_path . '/vendor'),
             ), $user_config));
 
             // In Laravel <5.3 we can get the user context from here


### PR DESCRIPTION
This uses the root of the directory which ensures things like routes and core versioned code are managed, but explicitly excludes vendor.

Refs GH-86