### PR TITLE
Type hint interface instead of class

### DIFF
--- a/src/Sentry/SentryLaravel/SentryLaravelEventHandler.php
+++ b/src/Sentry/SentryLaravel/SentryLaravelEventHandler.php
@@ -5,7 +5,7 @@ namespace Sentry\SentryLaravel;
 use Exception;
 use Raven_Client;
 use Illuminate\Routing\Route;
-use Illuminate\Events\Dispatcher;
+use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Log\Events\MessageLogged;
 use Illuminate\Auth\Events\Authenticated;
 use Illuminate\Routing\Events\RouteMatched;
@@ -67,7 +67,7 @@ class SentryLaravelEventHandler
     /**
      * Attach all event handlers.
      *
-     * @param \Illuminate\Events\Dispatcher $events
+     * @param \Illuminate\Contracts\Events\Dispatcher $events
      */
     public function subscribe(Dispatcher $events)
     {
@@ -79,7 +79,7 @@ class SentryLaravelEventHandler
     /**
      * Attach all authentication event handlers.
      *
-     * @param \Illuminate\Events\Dispatcher $events
+     * @param \Illuminate\Contracts\Events\Dispatcher $events
      */
     public function subscribeAuthEvents(Dispatcher $events)
     {


### PR DESCRIPTION
**Introduction:** I'm using OctoberCMS, which is made on the top of Laravel 5.5 framework.

**Problem:** OctoberCMS uses own implementation of Event Dispatcher and when using Sentry in OctoberCMS, I'm getting this error:

```
TypeError: Argument 1 passed to Sentry\SentryLaravel\SentryLaravelEventHandler::subscribe() must be an instance of Illuminate\Events\Dispatcher, instance of October\Rain\Events\Dispatcher given, called in /home/ubuntu/sites.com/vendor/sentry/sentry-laravel/src/Sentry/SentryLaravel/SentryLaravelServiceProvider.php on line 72
```

**Solution:** Type-hint interface instead of particular class.
