### PR TITLE
Also test against laravel 5.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,31 +1,38 @@
 language: php
+
 sudo: false
+
+cache:
+  directories:
+    - $HOME/.composer/cache
 php:
   - 5.6
   - 7.0
   - 7.1
   - 7.2
+
 env:
   matrix:
-  - LARAVEL=5.0 TESTBENCH=3.0.*
-  - LARAVEL=5.1 TESTBENCH=3.1.*
-  - LARAVEL=5.2 TESTBENCH=3.2.*
-  - LARAVEL=5.3 TESTBENCH=3.3.*
-  - LARAVEL=5.4 TESTBENCH=3.4.*
-  - LARAVEL=5.5 TESTBENCH=3.5.*
+  - LARAVEL=5.0.* TESTBENCH=3.0.* PHPUNIT=4.8.*
+  - LARAVEL=5.1.* TESTBENCH=3.1.* PHPUNIT=5.7.*
+  - LARAVEL=5.2.* TESTBENCH=3.2.* PHPUNIT=5.7.*
+  - LARAVEL=5.3.* TESTBENCH=3.3.* PHPUNIT=5.7.*
+  - LARAVEL=5.4.* TESTBENCH=3.4.* PHPUNIT=5.7.*
+  - LARAVEL=5.5.* TESTBENCH=3.5.* PHPUNIT=~6.0
+
 matrix:
   exclude:
     - php: 5.6
-      env: LARAVEL=5.5 TESTBENCH=3.5.*
-cache:
-  directories:
-    - $HOME/.composer/cache
+      env: LARAVEL=5.5 TESTBENCH=3.5.* PHPUNIT=~6.0
+    - php: 7.2
+      env: LARAVEL=5.0.* TESTBENCH=3.0.* PHPUNIT=4.8.*
+
 before_install:
-  - composer self-update
+  - composer self-update --stable --no-interaction
+  - composer require laravel/framework:$LARAVEL orchestra/testbench:$TESTBENCH phpunit/phpunit:$PHPUNIT --no-update --no-interaction --dev
 
 install:
-  - composer require -n orchestra/testbench:$TESTBENCH laravel/framework:$LARAVEL
-  - travis_retry composer install --no-interaction --prefer-dist
+  - travis_retry composer install --no-suggest --no-interaction
   - composer info
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ sudo: false
 cache:
   directories:
     - $HOME/.composer/cache
+
 php:
   - 5.6
   - 7.0
@@ -23,7 +24,7 @@ env:
 matrix:
   exclude:
     - php: 5.6
-      env: LARAVEL=5.5 TESTBENCH=3.5.* PHPUNIT=~6.0
+      env: LARAVEL=5.5.* TESTBENCH=3.5.* PHPUNIT=~6.0
     - php: 7.2
       env: LARAVEL=5.0.* TESTBENCH=3.0.* PHPUNIT=4.8.*
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ env:
   - LARAVEL=5.2 TESTBENCH=3.2.*
   - LARAVEL=5.3 TESTBENCH=3.3.*
   - LARAVEL=5.4 TESTBENCH=3.4.*
+  - LARAVEL=5.5 TESTBENCH=3.5.*
 cache:
   directories:
     - $HOME/.composer/cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ language: php
 sudo: false
 php:
   - 5.6
+  - 7.0
+  - 7.1
+  - 7.2
 env:
   matrix:
   - LARAVEL=5.0 TESTBENCH=3.0.*
@@ -10,6 +13,10 @@ env:
   - LARAVEL=5.3 TESTBENCH=3.3.*
   - LARAVEL=5.4 TESTBENCH=3.4.*
   - LARAVEL=5.5 TESTBENCH=3.5.*
+matrix:
+  exclude:
+    - php: 5.6
+      env: LARAVEL=5.5 TESTBENCH=3.5.*
 cache:
   directories:
     - $HOME/.composer/cache


### PR DESCRIPTION
Travis now tests PHP versions `5.6`, `7.0`, `7.1`, `7.2` against all Laravel versions `>=5.0`.
Exception:

- Laravel `5.5` on PHP `5.6`
- Laravel `5.0` on PHP `7.2`
  
Results in 22 tests on Travis.

Cheers,
Chris