### PR TITLE
don't-discover value needs to be an array

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@ The namespace `\App\Support` can be anything you want in the examples above.
 ```json
 "extra": {
     "laravel": {
-        "dont-discover": "sentry/sentry-laravel"
+        "dont-discover": ["sentry/sentry-laravel"]
     }
 }
 ```


### PR DESCRIPTION
or else `in_array() expects parameter 2 to be array, string given`.

vendor/laravel/framework/src/Illuminate/Foundation/PackageManifest.php
line 117 - is where it’s affected.

This will simply fix the readme.