### PR TITLE
Lumen app_path

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,7 +1,7 @@
 0.9.0 (unreleased)
 -----
 
-- Improved default app_path to include entire application code for Lumen, excluding vendor.
+- Improved default app_path for Lumen to include entire application code, excluding vendor. (#128)
 
 0.8.0
 -----

--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,8 @@
 0.9.0 (unreleased)
 -----
 
+- Improved default app_path to include entire application code for Lumen, excluding vendor.
+
 0.8.0
 -----
 

--- a/src/Sentry/SentryLaravel/SentryLumenServiceProvider.php
+++ b/src/Sentry/SentryLaravel/SentryLumenServiceProvider.php
@@ -54,10 +54,12 @@ class SentryLumenServiceProvider extends ServiceProvider
         $this->app->singleton('sentry', function ($app) {
             $user_config = $app['sentry.config'];
 
+            $base_path = base_path();
             $client = SentryLaravel::getClient(array_merge(array(
                 'environment' => $app->environment(),
-                'prefixes' => array(base_path()),
-                'app_path' => base_path() . '/app',
+                'prefixes' => array($base_path),
+                'app_path' => $base_path,
+                'excluded_app_paths' => array($base_path . '/vendor'),
             ), $user_config));
 
             // bind user context if available


### PR DESCRIPTION
This uses the root of the directory which ensures things like routes and core versioned code are managed but explicitly excludes vendor.

This pull request is to apply in Lumen, the same changes applied for Laravel in #89.

Refs GH-86 and #89