### PR TITLE
fix: user_context default tracking to false

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -2,6 +2,7 @@
 -----
 
 - Improved default app_path for Lumen to include entire application code, excluding vendor. (#128)
+- Set 'user_context' configuration default to false.
 
 0.8.0
 -----

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ return array(
     'breadcrumbs.sql_bindings' => true,
 
     // Capture default user context
-    'user_context' => true,
+    'user_context' => false,
 );
 ```
 

--- a/examples/laravel-5.4/config/sentry.php
+++ b/examples/laravel-5.4/config/sentry.php
@@ -10,7 +10,7 @@ return array(
     'breadcrumbs.sql_bindings' => true,
 
     // Capture default user context
-    'user_context' => true,
+    'user_context' => false,
 
     'release' => '1.0',
 );

--- a/examples/laravel-5.5/config/sentry.php
+++ b/examples/laravel-5.5/config/sentry.php
@@ -10,5 +10,5 @@ return array(
     'breadcrumbs.sql_bindings' => true,
 
     // Capture default user context
-    'user_context' => true,
+    'user_context' => false,
 );

--- a/src/Sentry/SentryLaravel/config.php
+++ b/src/Sentry/SentryLaravel/config.php
@@ -10,5 +10,5 @@ return array(
     'breadcrumbs.sql_bindings' => true,
 
     // Capture default user context
-    'user_context' => true,
+    'user_context' => false,
 );


### PR DESCRIPTION
We decided to disable user tracking by default in all SDKs.
This is only to make sure users of the SDK really have to opt-in to track user information.