### PR TITLE
Pass logging config to monolog handler preparation to allow custom formatter

### DIFF
--- a/src/Sentry/SentryLaravel/SentryLogChannel.php
+++ b/src/Sentry/SentryLaravel/SentryLogChannel.php
@@ -21,6 +21,6 @@ class SentryLogChannel extends LogManager
             isset($config['bubble']) ? $config['bubble'] : true
         );
 
-        return new Logger($this->parseChannel($config), [$this->prepareHandler($handler)]);
+        return new Logger($this->parseChannel($config), [$this->prepareHandler($handler, $config)]);
     }
 }


### PR DESCRIPTION
Add possibility to set custom formatter in `config/logging.php` channels config.

Example of channel config:
```
        'sentry' => [
            'level' => 'error',
            'driver' => 'sentry',
            'formatter' => App\Logging\CustomFormatter::class,
        ],
```
Example of custom formatter:
```
<?php

namespace App\Logging;

use Monolog\Formatter\LineFormatter;

class CustomLineFormatter extends LineFormatter
{
    const SIMPLE_FORMAT = "%channel%.%level_name%: %message% %context% %extra%\n";
}
```
[Laravel documentation](https://laravel.com/docs/5.6/logging#creating-monolog-handler-channels) (See Monolog Formatters)


resolves #142