### PR TITLE
Add tag with name of console command

### DIFF
--- a/src/Sentry/SentryLaravel/SentryLaravelEventHandler.php
+++ b/src/Sentry/SentryLaravel/SentryLaravelEventHandler.php
@@ -10,6 +10,8 @@ use Illuminate\Auth\Events\Authenticated;
 use Illuminate\Routing\Events\RouteMatched;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Database\Events\QueryExecuted;
+use Illuminate\Console\Events\CommandStarting;
+use Illuminate\Console\Events\CommandFinished;
 
 class SentryLaravelEventHandler
 {
@@ -27,8 +29,9 @@ class SentryLaravelEventHandler
 
         'illuminate.log' => 'log',           // Until Laravel 5.3
         'Illuminate\Log\Events\MessageLogged' => 'messageLogged', // Since Laravel 5.4
-        
+
         'Illuminate\Console\Events\CommandStarting' => 'commandStarting', // Since Laravel 5.5
+        'Illuminate\Console\Events\CommandFinished' => 'commandFinished', // Since Laravel 5.5
     );
 
     /**
@@ -226,18 +229,6 @@ class SentryLaravelEventHandler
     }
 
     /**
-     * Since Laravel 5.5
-     *
-     * @param Illuminate\Console\Events\CommandStarting $event
-     */
-    protected function commandStartingHandler($event)
-    {
-        $this->client->tags_context(array(
-            'command' => $event->command,
-        ));
-    }
-    
-    /**
      * Since Laravel 5.3
      *
      * @param \Illuminate\Auth\Events\Authenticated $event
@@ -246,6 +237,30 @@ class SentryLaravelEventHandler
     {
         $this->client->user_context(array(
             'id' => $event->user->getAuthIdentifier(),
+        ));
+    }
+
+    /**
+     * Since Laravel 5.5
+     *
+     * @param \Illuminate\Console\Events\CommandStarting $event
+     */
+    protected function commandStartingHandler(CommandStarting $event)
+    {
+        $this->client->tags_context(array(
+            'command' => $event->command,
+        ));
+    }
+
+    /**
+     * Since Laravel 5.5
+     *
+     * @param \Illuminate\Console\Events\CommandFinished $event
+     */
+    protected function commandFinishedHandler(CommandFinished $event)
+    {
+        $this->client->tags_context(array(
+            'command' => null,
         ));
     }
 }

--- a/src/Sentry/SentryLaravel/SentryLaravelEventHandler.php
+++ b/src/Sentry/SentryLaravel/SentryLaravelEventHandler.php
@@ -27,6 +27,8 @@ class SentryLaravelEventHandler
 
         'illuminate.log' => 'log',           // Until Laravel 5.3
         'Illuminate\Log\Events\MessageLogged' => 'messageLogged', // Since Laravel 5.4
+        
+        'Illuminate\Console\Events\CommandStarting' => 'commandStarting', // Since Laravel 5.5
     );
 
     /**
@@ -223,6 +225,18 @@ class SentryLaravelEventHandler
         ));
     }
 
+    /**
+     * Since Laravel 5.5
+     *
+     * @param Illuminate\Console\Events\CommandStarting $event
+     */
+    protected function commandStartingHandler($event)
+    {
+        $this->client->tags_context(array(
+            'command' => $event->command,
+        ));
+    }
+    
     /**
      * Since Laravel 5.3
      *


### PR DESCRIPTION
Listen for the `CommandStarting` event and add a tag with the name of the console command. This makes it easy to know which console command has the error.

Note: I did not typehint `ComandStarting` in `commandStartingHandler` because then I think it would only work on Laravel >=5.5 and based on the documentation this package supports Laravel 5.*. I'm surprised that the typehint of `MessageLogged` on  `messageLoggedHandler` does not cause issues for people trying to use older versions of Laravel since `MessageLogged` was not added until Laravel 5.4.