### PR TITLE
Added support for Laravel 5.7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,12 +13,12 @@
     ],
     "require": {
         "php": "^5.4||^7.0",
-        "illuminate/support": "5.0.*|5.1.*|5.2.*|5.3.*|5.4.*|5.5.*|5.6.*",
+        "illuminate/support": "5.0.*|5.1.*|5.2.*|5.3.*|5.4.*|5.5.*|5.6.*|5.7.*",
         "sentry/sentry": "^1.9.0"
     },
     "require-dev": {
         "phpunit/phpunit": "7.0.*",
-        "laravel/framework": "5.6.*",
+        "laravel/framework": "5.7.*",
         "orchestra/testbench": "3.6.*",
         "friendsofphp/php-cs-fixer": "2.2.*"
     },


### PR DESCRIPTION
Laravel just released its newest major version update, Laravel 5.7. This pull request adds support for Laravel 5.7.

https://laravel.com/docs/5.7/releases#laravel-5.7