### PR TITLE
Hide error message with enabled release option

### DIFF
--- a/config/sentry.php
+++ b/config/sentry.php
@@ -4,7 +4,7 @@ return array(
     'dsn' => env('SENTRY_LARAVEL_DSN'),
 
     // capture release as git sha
-    // 'release' => trim(exec('git --git-dir ' . base_path('.git') . ' log --pretty="%h" -n1 HEAD')),
+    // 'release' => trim(exec('git --git-dir ' . base_path('.git') . ' log --pretty="%h" -n1 HEAD 2>&1')),
 
     // Capture bindings on SQL queries
     'breadcrumbs.sql_bindings' => true,


### PR DESCRIPTION
In the different environments, git folder can exist or not.
If this part uncommented but git folder does not exist, this command throws a message in the console with error:
`fatal: Not a git repository (or any parent up to mount point /var/www)`
My changes hide this error even if the .git folder does not exist.