### PR TITLE
Hide error message with enabled release option

### DIFF
--- a/src/config/config.php
+++ b/src/config/config.php
@@ -4,5 +4,5 @@ return array(
     'dsn' => '',
 
     // capture release as git sha
-    // 'release' => trim(exec('git log --pretty="%h" -n1 HEAD')),
+    // 'release' => trim(exec('git log --pretty="%h" -n1 HEAD 2>&1')),
 );


### PR DESCRIPTION
In the different environments, git folder can exist or not.
If this part uncommented but git folder does not exist, this command throws a message in the console with error:
`fatal: Not a git repository (or any parent up to mount point /var/www)`
My changes hide this error even if the .git folder does not exist.