### PR TITLE
Added missing queueJobProcessedHandler method

### DIFF
--- a/src/Sentry/Laravel/EventHandler.php
+++ b/src/Sentry/Laravel/EventHandler.php
@@ -224,6 +224,34 @@ class EventHandler
     }
 
     /**
+     * Since Laravel 5.2
+     *
+     * @param \Illuminate\Queue\Events\JobProcessed $event
+     */
+    protected function queueJobProcessedHandler(JobProcessed $event)
+    {
+        $job = [
+            'job' => $event->job->getName(),
+            'queue' => $event->job->getQueue(),
+            'attempts' => $event->job->attempts(),
+            'connection' => $event->connectionName,
+        ];
+
+        // Resolve name exists only from Laravel 5.3+
+        if (method_exists($event->job, 'resolveName')) {
+            $job['resolved'] = $event->job->resolveName();
+        }
+
+        Integration::addBreadcrumb(new Breadcrumb(
+            Breadcrumb::LEVEL_INFO,
+            Breadcrumb::TYPE_USER,
+            'queue.job',
+            'Processed queue job',
+            $job
+        ));
+    }
+
+    /**
      * Since Laravel 5.5
      *
      * @param \Illuminate\Console\Events\CommandStarting $event


### PR DESCRIPTION
I'm not sure why this method was missing or if it was intentional, but adding the method in will resolve #178. The only thing modified in the method compared to the `queueJobProcessingHandler` is the 4th parameter in the breadcrumb creation. Could easily be refactored to reduce the code duplication.
