### PR TITLE
Support for Laravel 5.8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,9 +17,9 @@
     "sentry/sdk": "^2.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "7.3.*",
-    "laravel/framework": "5.7.*",
-    "orchestra/testbench": "3.7.*",
+    "phpunit/phpunit": "7.5.*",
+    "laravel/framework": "5.8.*",
+    "orchestra/testbench": "3.8.*",
     "friendsofphp/php-cs-fixer": "2.14.*"
   },
   "autoload": {


### PR DESCRIPTION
I've updated some of the dependencies in this package so that the Sentry package for Laravel supports the latest version, 5.8 which was released yesterday.