### PR TITLE
Fixing syntax used for config params

### DIFF
--- a/config/sentry.php
+++ b/config/sentry.php
@@ -7,5 +7,5 @@ return array(
     // 'release' => trim(exec('git --git-dir ' . base_path('.git') . ' log --pretty="%h" -n1 HEAD')),
 
     // Capture bindings on SQL queries
-    'breadcrumbs.sql_bindings' => true,
+    'breadcrumbs' => array('sql_bindings' => true),
 );

--- a/src/Sentry/Laravel/EventHandler.php
+++ b/src/Sentry/Laravel/EventHandler.php
@@ -65,7 +65,7 @@ class EventHandler
      */
     public function __construct(array $config)
     {
-        $this->sqlBindings = isset($config['breadcrumbs.sql_bindings']) ? $config['breadcrumbs.sql_bindings'] === true : true;
+        $this->sqlBindings = isset($config['breadcrumbs']['sql_bindings']) ? $config['breadcrumbs']['sql_bindings'] === true : true;
     }
 
     /**


### PR DESCRIPTION
This wasn't following Laravel syntax making it impossible to overload.

This is the normal way to overload a config param in Laravel
```
config(['sentry.breadcrumbs.sql_bindings' => false]);
```
this uses dot syntax.

The problem is that the config/sentry.php file uses `breadcrumbs.sql_bindings` which won't be overwrite-able with Laravel.

```
dump(config('sentry'));
config(['sentry.breadcrumbs.sql_bindings' => false]);
dd(config('sentry'));
```
will generate
```
array:2 [
  "dsn" => ""
  "breadcrumbs.sql_bindings" => true
]
array:2 [
  "dsn" => null
  "breadcrumbs.sql_bindings" => true
  "breadcrumbs" => array:1 [
    "sql_bindings" => false
  ]
]
```
The config param wasn't overwritten because `config()` can't accept a config param with a `.` in the name, it will map that to a multi-dimensional array.