### PR TITLE
Fixing config syntax

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ jobs:
 
 before_install:
   - if [ "$USE_COMPOSER_JSON" != "1" ]; then composer remove friendsofphp/php-cs-fixer --dev --no-update; fi;
-  - if [ "$USE_COMPOSER_JSON" != "1" ]; then composer require laravel/framework:$LARAVEL illuminate/support:$LARAVEL orchestra/testbench:$TESTBENCH phpunit/phpunit:$PHPUNIT php-http/curl-client guzzlehttp/psr7 --no-update --no-interaction --dev; fi;
+  - if [ "$USE_COMPOSER_JSON" != "1" ]; then composer require laravel/framework:$LARAVEL illuminate/support:$LARAVEL orchestra/testbench:$TESTBENCH phpunit/phpunit:$PHPUNIT --no-update --no-interaction --dev; fi;
 
 install:
   - travis_retry composer install --no-suggest --no-interaction --prefer-dist --no-progress

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Fix the configuration syntax for the sql bindings in breadcrumbs configuration option to be compaitable with Laravel (#207)
+- Fix the configuration syntax for the sql bindings in breadcrumbs configuration option to be compatible with Laravel (#207)
 
 ## 1.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Fix the configuration syntax for the sql bindings in breadcrumbs configuration option to be compaitable with Laravel (#207)
+
 ## 1.0.0
 
 - This version requires `sentry/sentry` `>= 2.0` and also PHP `>= 7.1`
@@ -7,10 +11,6 @@
 - Be advised `app('sentry')` now no longer returns the "old" `Raven_Client` instead it will return `\Sentry\State\Hub`
 
 Please see [Docs](https://docs.sentry.io/platforms/php/laravel/) for detailed usage.
-
-## 0.12.0 (unreleased)
-
-- ...
 
 ## 0.11.0
 

--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,11 @@
       "Sentry\\Laravel\\": "src/"
     }
   },
+  "autoload-dev": {
+    "psr-4": {
+      "Sentry\\Laravel\\Tests\\": "test/Sentry/"
+    }
+  },
   "scripts": {
     "tests": [
       "vendor/bin/phpunit --verbose"

--- a/config/sentry.php
+++ b/config/sentry.php
@@ -7,5 +7,5 @@ return array(
     // 'release' => trim(exec('git --git-dir ' . base_path('.git') . ' log --pretty="%h" -n1 HEAD')),
 
     // Capture bindings on SQL queries
-    'breadcrumbs.sql_bindings' => true,
+    'breadcrumbs' => array('sql_bindings' => true),
 );

--- a/config/sentry.php
+++ b/config/sentry.php
@@ -6,6 +6,10 @@ return array(
     // capture release as git sha
     // 'release' => trim(exec('git --git-dir ' . base_path('.git') . ' log --pretty="%h" -n1 HEAD')),
 
-    // Capture bindings on SQL queries
-    'breadcrumbs' => array('sql_bindings' => true),
+    'breadcrumbs' => [
+
+        // Capture bindings on SQL queries logged in breadcrumbs
+        'sql_bindings' => true,
+
+    ],
 );

--- a/src/Sentry/Laravel/EventHandler.php
+++ b/src/Sentry/Laravel/EventHandler.php
@@ -65,7 +65,7 @@ class EventHandler
      */
     public function __construct(array $config)
     {
-        $this->sqlBindings = isset($config['breadcrumbs.sql_bindings']) ? $config['breadcrumbs.sql_bindings'] === true : true;
+        $this->sqlBindings = isset($config['breadcrumbs']['sql_bindings']) ? $config['breadcrumbs']['sql_bindings'] === true : true;
     }
 
     /**

--- a/src/Sentry/Laravel/EventHandler.php
+++ b/src/Sentry/Laravel/EventHandler.php
@@ -56,7 +56,7 @@ class EventHandler
      *
      * @var bool
      */
-    private $sqlBindings;
+    private $recordSqlBindings;
 
     /**
      * EventHandler constructor.
@@ -65,7 +65,7 @@ class EventHandler
      */
     public function __construct(array $config)
     {
-        $this->sqlBindings = isset($config['breadcrumbs']['sql_bindings']) ? $config['breadcrumbs']['sql_bindings'] === true : true;
+        $this->recordSqlBindings = ($config['breadcrumbs']['sql_bindings'] ?? $config['breadcrumbs.sql_bindings'] ?? false) === true;
     }
 
     /**
@@ -161,7 +161,7 @@ class EventHandler
     {
         $data = array('connectionName' => $connectionName);
 
-        if ($this->sqlBindings) {
+        if ($this->recordSqlBindings) {
             $data['bindings'] = $bindings;
         }
 
@@ -183,7 +183,7 @@ class EventHandler
     {
         $data = array('connectionName' => $query->connectionName);
 
-        if ($this->sqlBindings) {
+        if ($this->recordSqlBindings) {
             $data['bindings'] = $query->bindings;
         }
 

--- a/src/Sentry/Laravel/ServiceProvider.php
+++ b/src/Sentry/Laravel/ServiceProvider.php
@@ -96,7 +96,11 @@ class ServiceProvider extends IlluminateServiceProvider
             $userConfig = $this->app['config'][static::$abstract];
 
             // We do not want this setting to hit our main client because it's Laravel specific
-            unset($userConfig['breadcrumbs.sql_bindings']);
+            unset(
+                $userConfig['breadcrumbs'],
+                // this is kept for backwards compatibilty and can be dropped in a breaking release
+                $userConfig['breadcrumbs.sql_bindings']
+            );
 
             $options = \array_merge(
                 [

--- a/src/Sentry/Laravel/ServiceProvider.php
+++ b/src/Sentry/Laravel/ServiceProvider.php
@@ -130,7 +130,9 @@ class ServiceProvider extends IlluminateServiceProvider
      */
     protected function hasDsnSet(): bool
     {
-        return !empty($this->app['config'][static::$abstract]['dsn'] ?? null);
+        $config = $this->app['config'][static::$abstract];
+
+        return !empty($config['dsn']);
     }
 
     /**

--- a/test/Sentry/EventHandlerTest.php
+++ b/test/Sentry/EventHandlerTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Sentry\Laravel\Tests;
+
 class EventHandlerTest extends \PHPUnit\Framework\TestCase
 {
     /**

--- a/test/Sentry/SentryLaravelTestCase.php
+++ b/test/Sentry/SentryLaravelTestCase.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Sentry\Laravel\Tests;
+
+use Sentry\State\Scope;
+use Sentry\State\HubInterface;
+use Sentry\Laravel\ServiceProvider;
+use Orchestra\Testbench\TestCase as LaravelTestCase;
+
+abstract class SentryLaravelTestCase extends LaravelTestCase
+{
+    protected $setupConfig = [
+        // Set config here before refreshing the app to set it in the container before Sentry is loaded
+        // or use the `$this->resetApplicationWithConfig([ /* config */ ]);` helper method
+    ];
+
+    protected function getEnvironmentSetUp($app)
+    {
+        foreach ($this->setupConfig as $key => $value) {
+            $app['config']->set($key, $value);
+        }
+    }
+
+    protected function getPackageProviders($app)
+    {
+        return [
+            ServiceProvider::class,
+        ];
+    }
+
+    protected function resetApplicationWithConfig(array $config)
+    {
+        $this->setupConfig = $config;
+
+        $this->refreshApplication();
+    }
+
+    protected function getScope(HubInterface $hub): Scope
+    {
+        $method = new \ReflectionMethod($hub, 'getScope');
+
+        $method->setAccessible(true);
+
+        return $method->invoke($hub);
+    }
+}

--- a/test/Sentry/SentryLaravelTestCase.php
+++ b/test/Sentry/SentryLaravelTestCase.php
@@ -35,6 +35,16 @@ abstract class SentryLaravelTestCase extends LaravelTestCase
         $this->refreshApplication();
     }
 
+    protected function dispatchLaravelEvent($event, array $payload = [])
+    {
+        $dispatcher = $this->app['events'];
+
+        // Laravel 5.4+ uses the dispatch method to dispatch/fire events
+        return method_exists($dispatcher, 'dispatch')
+            ? $dispatcher->dispatch($event, $payload)
+            : $dispatcher->fire($event, $payload);
+    }
+
     protected function getScope(HubInterface $hub): Scope
     {
         $method = new \ReflectionMethod($hub, 'getScope');

--- a/test/Sentry/ServiceProviderTest.php
+++ b/test/Sentry/ServiceProviderTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Sentry\Laravel\Tests;
+
 use Sentry\State\Hub;
 use Sentry\Laravel\Facade;
 use Sentry\Laravel\ServiceProvider;

--- a/test/Sentry/ServiceProviderWithoutDsnTest.php
+++ b/test/Sentry/ServiceProviderWithoutDsnTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Sentry\Laravel\Tests;
+
 use Sentry\Laravel\ServiceProvider;
 use Illuminate\Routing\Events\RouteMatched;
 

--- a/test/Sentry/SqlBindingsInBreadcrumbsTest.php
+++ b/test/Sentry/SqlBindingsInBreadcrumbsTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Sentry\Laravel\Tests;
+
+use Sentry\State\Hub;
+use Illuminate\Support\Arr;
+
+class SqlBindingsInBreadcrumbsTest extends SentryLaravelTestCase
+{
+    protected function getEnvironmentSetUp($app)
+    {
+        $app['config']->set('sentry.dsn', 'http://publickey:secretkey@sentry.dev/123');
+
+        parent::getEnvironmentSetUp($app);
+    }
+
+    public function testIsBound()
+    {
+        $this->assertTrue(app()->bound('sentry'));
+        $this->assertInstanceOf(Hub::class, app('sentry'));
+    }
+
+    /**
+     * @depends testIsBound
+     */
+    public function testSqlBindingsAreRecordedWhenEnabled()
+    {
+        $this->resetApplicationWithConfig([
+            'sentry.breadcrumbs.sql_bindings' => true,
+        ]);
+
+        $this->assertTrue($this->app['config']->get('sentry.breadcrumbs.sql_bindings'));
+
+        $this->app['events']->dispatch('illuminate.query', [
+            $query = 'SELECT * FROM breadcrumbs WHERE bindings = ?;',
+            $bindings = ['1'],
+            10,
+            'test',
+        ]);
+
+        /** @var \Sentry\Breadcrumb $lastBreadcrumb */
+        $lastBreadcrumb = Arr::last($this->getScope(Hub::getCurrent())->getBreadcrumbs());
+
+        $this->assertEquals($query, $lastBreadcrumb->getMessage());
+        $this->assertEquals($bindings, $lastBreadcrumb->getMetadata()['bindings']);
+    }
+
+    /**
+     * @depends testIsBound
+     */
+    public function testSqlBindingsAreRecordedWhenDisabled()
+    {
+        $this->resetApplicationWithConfig([
+            'sentry.breadcrumbs.sql_bindings' => false,
+        ]);
+
+        $this->assertFalse($this->app['config']->get('sentry.breadcrumbs.sql_bindings'));
+
+        $this->app['events']->dispatch('illuminate.query', [
+            $query = 'SELECT * FROM breadcrumbs WHERE bindings <> ?;',
+            $bindings = ['1'],
+            10,
+            'test',
+        ]);
+
+        /** @var \Sentry\Breadcrumb $lastBreadcrumb */
+        $lastBreadcrumb = Arr::last($this->getScope(Hub::getCurrent())->getBreadcrumbs());
+
+        $this->assertEquals($query, $lastBreadcrumb->getMessage());
+        $this->assertFalse(isset($lastBreadcrumb->getMetadata()['bindings']));
+    }
+}

--- a/test/Sentry/SqlBindingsInBreadcrumbsTest.php
+++ b/test/Sentry/SqlBindingsInBreadcrumbsTest.php
@@ -3,7 +3,6 @@
 namespace Sentry\Laravel\Tests;
 
 use Sentry\State\Hub;
-use Illuminate\Support\Arr;
 
 class SqlBindingsInBreadcrumbsTest extends SentryLaravelTestCase
 {
@@ -31,15 +30,17 @@ class SqlBindingsInBreadcrumbsTest extends SentryLaravelTestCase
 
         $this->assertTrue($this->app['config']->get('sentry.breadcrumbs.sql_bindings'));
 
-        $this->app['events']->dispatch('illuminate.query', [
+        $this->dispatchLaravelEvent('illuminate.query', [
             $query = 'SELECT * FROM breadcrumbs WHERE bindings = ?;',
             $bindings = ['1'],
             10,
             'test',
         ]);
 
+        $breadcrumbs = $this->getScope(Hub::getCurrent())->getBreadcrumbs();
+
         /** @var \Sentry\Breadcrumb $lastBreadcrumb */
-        $lastBreadcrumb = Arr::last($this->getScope(Hub::getCurrent())->getBreadcrumbs());
+        $lastBreadcrumb = end($breadcrumbs);
 
         $this->assertEquals($query, $lastBreadcrumb->getMessage());
         $this->assertEquals($bindings, $lastBreadcrumb->getMetadata()['bindings']);
@@ -56,15 +57,17 @@ class SqlBindingsInBreadcrumbsTest extends SentryLaravelTestCase
 
         $this->assertFalse($this->app['config']->get('sentry.breadcrumbs.sql_bindings'));
 
-        $this->app['events']->dispatch('illuminate.query', [
+        $this->dispatchLaravelEvent('illuminate.query', [
             $query = 'SELECT * FROM breadcrumbs WHERE bindings <> ?;',
             $bindings = ['1'],
             10,
             'test',
         ]);
 
+        $breadcrumbs = $this->getScope(Hub::getCurrent())->getBreadcrumbs();
+
         /** @var \Sentry\Breadcrumb $lastBreadcrumb */
-        $lastBreadcrumb = Arr::last($this->getScope(Hub::getCurrent())->getBreadcrumbs());
+        $lastBreadcrumb = end($breadcrumbs);
 
         $this->assertEquals($query, $lastBreadcrumb->getMessage());
         $this->assertFalse(isset($lastBreadcrumb->getMetadata()['bindings']));

--- a/test/Sentry/SqlBindingsInBreadcrumbsWithOldConfigKeyTest.php
+++ b/test/Sentry/SqlBindingsInBreadcrumbsWithOldConfigKeyTest.php
@@ -3,7 +3,6 @@
 namespace Sentry\Laravel\Tests;
 
 use Sentry\State\Hub;
-use Illuminate\Support\Arr;
 use Illuminate\Config\Repository;
 
 class SqlBindingsInBreadcrumbsWithOldConfigKeyTest extends SentryLaravelTestCase
@@ -36,15 +35,17 @@ class SqlBindingsInBreadcrumbsWithOldConfigKeyTest extends SentryLaravelTestCase
     {
         $this->assertTrue($this->app['config']->get('sentry')['breadcrumbs.sql_bindings']);
 
-        $this->app['events']->dispatch('illuminate.query', [
+        $this->dispatchLaravelEvent('illuminate.query', [
             $query = 'SELECT * FROM breadcrumbs WHERE bindings = ?;',
             $bindings = ['1'],
             10,
             'test',
         ]);
 
+        $breadcrumbs = $this->getScope(Hub::getCurrent())->getBreadcrumbs();
+
         /** @var \Sentry\Breadcrumb $lastBreadcrumb */
-        $lastBreadcrumb = Arr::last($this->getScope(Hub::getCurrent())->getBreadcrumbs());
+        $lastBreadcrumb = end($breadcrumbs);
 
         $this->assertEquals($query, $lastBreadcrumb->getMessage());
         $this->assertEquals($bindings, $lastBreadcrumb->getMetadata()['bindings']);

--- a/test/Sentry/SqlBindingsInBreadcrumbsWithOldConfigKeyTest.php
+++ b/test/Sentry/SqlBindingsInBreadcrumbsWithOldConfigKeyTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Sentry\Laravel\Tests;
+
+use Sentry\State\Hub;
+use Illuminate\Support\Arr;
+use Illuminate\Config\Repository;
+
+class SqlBindingsInBreadcrumbsWithOldConfigKeyTest extends SentryLaravelTestCase
+{
+    protected function getEnvironmentSetUp($app)
+    {
+        parent::getEnvironmentSetUp($app);
+
+        $app['config']->set('sentry.dsn', 'http://publickey:secretkey@sentry.dev/123');
+
+        $config = $app['config']->all();
+
+        $config['sentry']['breadcrumbs.sql_bindings'] = true;
+
+        unset($config['sentry']['breadcrumbs']);
+
+        $app['config'] = new Repository($config);
+    }
+
+    public function testIsBound()
+    {
+        $this->assertTrue(app()->bound('sentry'));
+        $this->assertInstanceOf(Hub::class, app('sentry'));
+    }
+
+    /**
+     * @depends testIsBound
+     */
+    public function testSqlBindingsAreRecordedWhenEnabledByOldConfigKey()
+    {
+        $this->assertTrue($this->app['config']->get('sentry')['breadcrumbs.sql_bindings']);
+
+        $this->app['events']->dispatch('illuminate.query', [
+            $query = 'SELECT * FROM breadcrumbs WHERE bindings = ?;',
+            $bindings = ['1'],
+            10,
+            'test',
+        ]);
+
+        /** @var \Sentry\Breadcrumb $lastBreadcrumb */
+        $lastBreadcrumb = Arr::last($this->getScope(Hub::getCurrent())->getBreadcrumbs());
+
+        $this->assertEquals($query, $lastBreadcrumb->getMessage());
+        $this->assertEquals($bindings, $lastBreadcrumb->getMetadata()['bindings']);
+    }
+}

--- a/test/bootstrap.php
+++ b/test/bootstrap.php
@@ -3,3 +3,5 @@
 error_reporting(E_ALL | E_STRICT);
 
 session_start();
+
+require_once __DIR__ . '/../vendor/autoload.php';


### PR DESCRIPTION
This wasn't following Laravel syntax making it impossible to overload.

This is the normal way to overload a config param in Laravel
```
config(['sentry.breadcrumbs.sql_bindings' => false]);
```
this uses dot syntax.

The problem is that the config/sentry.php file uses `breadcrumbs.sql_bindings` which won't be overwrite-able with Laravel.

```
dump(config('sentry'));
config(['sentry.breadcrumbs.sql_bindings' => false]);
dd(config('sentry'));
```
will generate
```
array:2 [
  "dsn" => ""
  "breadcrumbs.sql_bindings" => true
]
array:2 [
  "dsn" => null
  "breadcrumbs.sql_bindings" => true
  "breadcrumbs" => array:1 [
    "sql_bindings" => false
  ]
]
```
The config param wasn't overwritten because `config()` can't accept a config param with a `.` in the name, it will map that to a multi-dimensional array.