### PR TITLE
Switch the order of null coalescing for the sql_bindings config option

### DIFF
--- a/src/Sentry/Laravel/EventHandler.php
+++ b/src/Sentry/Laravel/EventHandler.php
@@ -65,7 +65,7 @@ class EventHandler
      */
     public function __construct(array $config)
     {
-        $this->recordSqlBindings = ($config['breadcrumbs']['sql_bindings'] ?? $config['breadcrumbs.sql_bindings'] ?? false) === true;
+        $this->recordSqlBindings = ($config['breadcrumbs.sql_bindings'] ?? $config['breadcrumbs']['sql_bindings'] ?? false) === true;
     }
 
     /**

--- a/test/Sentry/SqlBindingsInBreadcrumbsWithOldConfigKeyDisabledTest.php
+++ b/test/Sentry/SqlBindingsInBreadcrumbsWithOldConfigKeyDisabledTest.php
@@ -5,7 +5,7 @@ namespace Sentry\Laravel\Tests;
 use Sentry\State\Hub;
 use Illuminate\Config\Repository;
 
-class SqlBindingsInBreadcrumbsWithOldConfigKeyTest extends SentryLaravelTestCase
+class SqlBindingsInBreadcrumbsWithOldConfigKeyDisabledTest extends SentryLaravelTestCase
 {
     protected function getEnvironmentSetUp($app)
     {
@@ -15,9 +15,7 @@ class SqlBindingsInBreadcrumbsWithOldConfigKeyTest extends SentryLaravelTestCase
 
         $config = $app['config']->all();
 
-        $config['sentry']['breadcrumbs.sql_bindings'] = true;
-
-        unset($config['sentry']['breadcrumbs']);
+        $config['sentry']['breadcrumbs.sql_bindings'] = false;
 
         $app['config'] = new Repository($config);
     }
@@ -31,9 +29,9 @@ class SqlBindingsInBreadcrumbsWithOldConfigKeyTest extends SentryLaravelTestCase
     /**
      * @depends testIsBound
      */
-    public function testSqlBindingsAreRecordedWhenEnabledByOldConfigKey()
+    public function testSqlBindingsAreRecordedWhenDisabledByOldConfigKey()
     {
-        $this->assertTrue($this->app['config']->get('sentry')['breadcrumbs.sql_bindings']);
+        $this->assertFalse($this->app['config']->get('sentry')['breadcrumbs.sql_bindings']);
 
         $this->dispatchLaravelEvent('illuminate.query', [
             $query = 'SELECT * FROM breadcrumbs WHERE bindings = ?;',
@@ -48,6 +46,6 @@ class SqlBindingsInBreadcrumbsWithOldConfigKeyTest extends SentryLaravelTestCase
         $lastBreadcrumb = end($breadcrumbs);
 
         $this->assertEquals($query, $lastBreadcrumb->getMessage());
-        $this->assertEquals($bindings, $lastBreadcrumb->getMetadata()['bindings']);
+        $this->assertFalse(isset($lastBreadcrumb->getMetadata()['bindings']));
     }
 }

--- a/test/Sentry/SqlBindingsInBreadcrumbsWithOldConfigKeyEnabledTest.php
+++ b/test/Sentry/SqlBindingsInBreadcrumbsWithOldConfigKeyEnabledTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Sentry\Laravel\Tests;
+
+use Sentry\State\Hub;
+use Illuminate\Config\Repository;
+
+class SqlBindingsInBreadcrumbsWithOldConfigKeyEnabledTest extends SentryLaravelTestCase
+{
+    protected function getEnvironmentSetUp($app)
+    {
+        parent::getEnvironmentSetUp($app);
+
+        $app['config']->set('sentry.dsn', 'http://publickey:secretkey@sentry.dev/123');
+
+        $config = $app['config']->all();
+
+        $config['sentry']['breadcrumbs.sql_bindings'] = true;
+
+        $app['config'] = new Repository($config);
+    }
+
+    public function testIsBound()
+    {
+        $this->assertTrue(app()->bound('sentry'));
+        $this->assertInstanceOf(Hub::class, app('sentry'));
+    }
+
+    /**
+     * @depends testIsBound
+     */
+    public function testSqlBindingsAreRecordedWhenEnabledByOldConfigKey()
+    {
+        $this->assertTrue($this->app['config']->get('sentry')['breadcrumbs.sql_bindings']);
+
+        $this->dispatchLaravelEvent('illuminate.query', [
+            $query = 'SELECT * FROM breadcrumbs WHERE bindings = ?;',
+            $bindings = ['1'],
+            10,
+            'test',
+        ]);
+
+        $breadcrumbs = $this->getScope(Hub::getCurrent())->getBreadcrumbs();
+
+        /** @var \Sentry\Breadcrumb $lastBreadcrumb */
+        $lastBreadcrumb = end($breadcrumbs);
+
+        $this->assertEquals($query, $lastBreadcrumb->getMessage());
+        $this->assertEquals($bindings, $lastBreadcrumb->getMetadata()['bindings']);
+    }
+}


### PR DESCRIPTION
Hello,

A breaking change was introduced in https://github.com/getsentry/sentry-laravel/pull/207.

The user and package config files are merged by the service provider, and so the order of the null coalescing means that the default of "true" is used, regardless of what the user set the legacy config setting to.