### PR TITLE
Track Artisan command invocation in breadcrumb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Track Artisan command invocation in breadcrumb (#232)
 - Fixed `sql_bindings` configuration fallback (#231)
 - Fixed events generated in queue worker not sending until worker exits (#228)
 - Add phpDoc methods to the facade for better autocompletion (#226)

--- a/src/Sentry/Laravel/EventHandler.php
+++ b/src/Sentry/Laravel/EventHandler.php
@@ -313,11 +313,21 @@ class EventHandler
      */
     protected function commandStartingHandler(CommandStarting $event)
     {
-        Integration::configureScope(function (Scope $scope) use ($event): void {
-            if ($event->command) {
+        if ($event->command) {
+            Integration::configureScope(function (Scope $scope) use ($event): void {
                 $scope->setTag('command', $event->command);
-            }
-        });
+            });
+
+            Integration::addBreadcrumb(new Breadcrumb(
+                Breadcrumb::LEVEL_INFO,
+                Breadcrumb::TYPE_USER,
+                'artisan.command',
+                'Invoked Artisan command: ' . $event->command,
+                method_exists($event->input, '__toString') ? [
+                    'input' => (string)$event->input,
+                ] : []
+            ));
+        }
     }
 
     /**


### PR DESCRIPTION
This will add a breadcrumb with the full command input.

This might look something like this:

![image](https://user-images.githubusercontent.com/1090754/56578192-49100b00-65cd-11e9-807c-c484d0b85d06.png)

/fixes #223