### PR TITLE
Resolve integrations from container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Resolve `integrations` option from the container (#239)
+
 ## 1.0.2
 
 - Track Artisan command invocation in breadcrumb (#232)

--- a/src/Sentry/Laravel/ServiceProvider.php
+++ b/src/Sentry/Laravel/ServiceProvider.php
@@ -52,7 +52,7 @@ class ServiceProvider extends IlluminateServiceProvider
 
         $this->mergeConfigFrom(__DIR__ . '/../../../config/sentry.php', static::$abstract);
 
-        $this->configureAndRegisterClient($this->app['config'][static::$abstract]);
+        $this->configureAndRegisterClient($this->getUserConfig());
 
         if (($logManager = $this->app->make('log')) instanceof LogManager) {
             $logManager->extend('sentry', function ($app, array $config) {
@@ -66,7 +66,7 @@ class ServiceProvider extends IlluminateServiceProvider
      */
     protected function bindEvents(): void
     {
-        $userConfig = $this->app['config'][static::$abstract];
+        $userConfig = $this->getUserConfig();
 
         $handler = new EventHandler($this->app->events, $userConfig);
 
@@ -96,7 +96,7 @@ class ServiceProvider extends IlluminateServiceProvider
     {
         $this->app->singleton(static::$abstract, function () {
             $basePath = base_path();
-            $userConfig = $this->app['config'][static::$abstract];
+            $userConfig = $this->getUserConfig();
 
             // We do not want this setting to hit our main client because it's Laravel specific
             unset(
@@ -135,7 +135,7 @@ class ServiceProvider extends IlluminateServiceProvider
      */
     protected function hasDsnSet(): bool
     {
-        $config = $this->app['config'][static::$abstract];
+        $config = $this->getUserConfig();
 
         return !empty($config['dsn']);
     }
@@ -149,7 +149,7 @@ class ServiceProvider extends IlluminateServiceProvider
     {
         $integrations = [new Integration];
 
-        $userIntegrations = $this->app['config'][static::$abstract]['integrations'] ?? [];
+        $userIntegrations = $this->getUserConfig()['integrations'] ?? [];
 
         foreach ($userIntegrations as $userIntegration) {
             if ($userIntegration instanceof IntegrationInterface) {
@@ -162,6 +162,16 @@ class ServiceProvider extends IlluminateServiceProvider
         }
 
         return $integrations;
+    }
+
+    /**
+     * Retrieve the user configuration.
+     *
+     * @return array
+     */
+    private function getUserConfig(): array
+    {
+        return $this->app['config'][static::$abstract];
     }
 
     /**

--- a/src/Sentry/Laravel/ServiceProvider.php
+++ b/src/Sentry/Laravel/ServiceProvider.php
@@ -155,7 +155,7 @@ class ServiceProvider extends IlluminateServiceProvider
             if ($userIntegration instanceof IntegrationInterface) {
                 $integrations[] = $userIntegration;
             } elseif (\is_string($userIntegration)) {
-                $integrations[] = $this->app->get($userIntegration);
+                $integrations[] = $this->app->make($userIntegration);
             } else {
                 throw new \RuntimeException('Sentry integrations should either be a container reference or a instance of `\Sentry\Integration\IntegrationInterface`.');
             }

--- a/test/Sentry/IntegrationsOptionTest.php
+++ b/test/Sentry/IntegrationsOptionTest.php
@@ -40,6 +40,17 @@ class IntegrationsOptionTest extends SentryLaravelTestCase
         $this->assertNotNull(Hub::getCurrent()->getClient()->getIntegration(IntegrationsOptionTestIntegrationStub::class));
     }
 
+    public function testCustomIntegrationByInstance()
+    {
+        $this->resetApplicationWithConfig([
+            'sentry.integrations' => [
+                new IntegrationsOptionTestIntegrationStub,
+            ],
+        ]);
+
+        $this->assertNotNull(Hub::getCurrent()->getClient()->getIntegration(IntegrationsOptionTestIntegrationStub::class));
+    }
+
     public function testCustomIntegrationThrowsExceptionIfNotResolvable()
     {
         $this->expectException(EntryNotFoundException::class);

--- a/test/Sentry/IntegrationsOptionTest.php
+++ b/test/Sentry/IntegrationsOptionTest.php
@@ -50,7 +50,7 @@ class IntegrationsOptionTest extends SentryLaravelTestCase
     }
 
     /**
-     * @expectedException \Illuminate\Container\EntryNotFoundException
+     * @expectedException \ReflectionException
      */
     public function testCustomIntegrationThrowsExceptionIfNotResolvable()
     {

--- a/test/Sentry/IntegrationsOptionTest.php
+++ b/test/Sentry/IntegrationsOptionTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Sentry\Laravel\Tests;
+
+use RuntimeException;
+use Sentry\State\Hub;
+use Sentry\Integration\IntegrationInterface;
+use Illuminate\Container\EntryNotFoundException;
+
+class IntegrationsOptionTest extends SentryLaravelTestCase
+{
+    protected function getEnvironmentSetUp($app)
+    {
+        parent::getEnvironmentSetUp($app);
+
+        $app->singleton('custom-sentry-integration', static function () {
+            return new IntegrationsOptionTestIntegrationStub;
+        });
+    }
+
+    public function testCustomIntegrationIsResolvedFromContainerByAlias()
+    {
+        $this->resetApplicationWithConfig([
+            'sentry.integrations' => [
+                'custom-sentry-integration',
+            ],
+        ]);
+
+        $this->assertNotNull(Hub::getCurrent()->getClient()->getIntegration(IntegrationsOptionTestIntegrationStub::class));
+    }
+
+    public function testCustomIntegrationIsResolvedFromContainerByClass()
+    {
+        $this->resetApplicationWithConfig([
+            'sentry.integrations' => [
+                IntegrationsOptionTestIntegrationStub::class,
+            ],
+        ]);
+
+        $this->assertNotNull(Hub::getCurrent()->getClient()->getIntegration(IntegrationsOptionTestIntegrationStub::class));
+    }
+
+    public function testCustomIntegrationThrowsExceptionIfNotResolvable()
+    {
+        $this->expectException(EntryNotFoundException::class);
+
+        $this->resetApplicationWithConfig([
+            'sentry.integrations' => [
+                'this-will-not-resolve',
+            ],
+        ]);
+    }
+
+    public function testIncorrectIntegrationEntryThrowsException()
+    {
+        $this->expectException(RuntimeException::class);
+
+        $this->resetApplicationWithConfig([
+            'sentry.integrations' => [
+                static function () {
+                },
+            ],
+        ]);
+    }
+}
+
+class IntegrationsOptionTestIntegrationStub implements IntegrationInterface
+{
+    public function setupOnce(): void
+    {
+    }
+}

--- a/test/Sentry/IntegrationsOptionTest.php
+++ b/test/Sentry/IntegrationsOptionTest.php
@@ -2,10 +2,8 @@
 
 namespace Sentry\Laravel\Tests;
 
-use RuntimeException;
 use Sentry\State\Hub;
 use Sentry\Integration\IntegrationInterface;
-use Illuminate\Container\EntryNotFoundException;
 
 class IntegrationsOptionTest extends SentryLaravelTestCase
 {
@@ -51,10 +49,11 @@ class IntegrationsOptionTest extends SentryLaravelTestCase
         $this->assertNotNull(Hub::getCurrent()->getClient()->getIntegration(IntegrationsOptionTestIntegrationStub::class));
     }
 
+    /**
+     * @expectedException \Illuminate\Container\EntryNotFoundException
+     */
     public function testCustomIntegrationThrowsExceptionIfNotResolvable()
     {
-        $this->expectException(EntryNotFoundException::class);
-
         $this->resetApplicationWithConfig([
             'sentry.integrations' => [
                 'this-will-not-resolve',
@@ -62,10 +61,11 @@ class IntegrationsOptionTest extends SentryLaravelTestCase
         ]);
     }
 
+    /**
+     * @expectedException \RuntimeException
+     */
     public function testIncorrectIntegrationEntryThrowsException()
     {
-        $this->expectException(RuntimeException::class);
-
         $this->resetApplicationWithConfig([
             'sentry.integrations' => [
                 static function () {

--- a/test/Sentry/SentryLaravelTestCase.php
+++ b/test/Sentry/SentryLaravelTestCase.php
@@ -16,6 +16,8 @@ abstract class SentryLaravelTestCase extends LaravelTestCase
 
     protected function getEnvironmentSetUp($app)
     {
+        $app['config']->set('sentry.dsn', 'http://publickey:secretkey@sentry.dev/123');
+
         foreach ($this->setupConfig as $key => $value) {
             $app['config']->set($key, $value);
         }

--- a/test/Sentry/SqlBindingsInBreadcrumbsTest.php
+++ b/test/Sentry/SqlBindingsInBreadcrumbsTest.php
@@ -6,22 +6,6 @@ use Sentry\State\Hub;
 
 class SqlBindingsInBreadcrumbsTest extends SentryLaravelTestCase
 {
-    protected function getEnvironmentSetUp($app)
-    {
-        $app['config']->set('sentry.dsn', 'http://publickey:secretkey@sentry.dev/123');
-
-        parent::getEnvironmentSetUp($app);
-    }
-
-    public function testIsBound()
-    {
-        $this->assertTrue(app()->bound('sentry'));
-        $this->assertInstanceOf(Hub::class, app('sentry'));
-    }
-
-    /**
-     * @depends testIsBound
-     */
     public function testSqlBindingsAreRecordedWhenEnabled()
     {
         $this->resetApplicationWithConfig([
@@ -46,9 +30,6 @@ class SqlBindingsInBreadcrumbsTest extends SentryLaravelTestCase
         $this->assertEquals($bindings, $lastBreadcrumb->getMetadata()['bindings']);
     }
 
-    /**
-     * @depends testIsBound
-     */
     public function testSqlBindingsAreRecordedWhenDisabled()
     {
         $this->resetApplicationWithConfig([

--- a/test/Sentry/SqlBindingsInBreadcrumbsWithOldConfigKeyDisabledTest.php
+++ b/test/Sentry/SqlBindingsInBreadcrumbsWithOldConfigKeyDisabledTest.php
@@ -11,8 +11,6 @@ class SqlBindingsInBreadcrumbsWithOldConfigKeyDisabledTest extends SentryLaravel
     {
         parent::getEnvironmentSetUp($app);
 
-        $app['config']->set('sentry.dsn', 'http://publickey:secretkey@sentry.dev/123');
-
         $config = $app['config']->all();
 
         $config['sentry']['breadcrumbs.sql_bindings'] = false;
@@ -20,15 +18,6 @@ class SqlBindingsInBreadcrumbsWithOldConfigKeyDisabledTest extends SentryLaravel
         $app['config'] = new Repository($config);
     }
 
-    public function testIsBound()
-    {
-        $this->assertTrue(app()->bound('sentry'));
-        $this->assertInstanceOf(Hub::class, app('sentry'));
-    }
-
-    /**
-     * @depends testIsBound
-     */
     public function testSqlBindingsAreRecordedWhenDisabledByOldConfigKey()
     {
         $this->assertFalse($this->app['config']->get('sentry')['breadcrumbs.sql_bindings']);

--- a/test/Sentry/SqlBindingsInBreadcrumbsWithOldConfigKeyEnabledTest.php
+++ b/test/Sentry/SqlBindingsInBreadcrumbsWithOldConfigKeyEnabledTest.php
@@ -11,8 +11,6 @@ class SqlBindingsInBreadcrumbsWithOldConfigKeyEnabledTest extends SentryLaravelT
     {
         parent::getEnvironmentSetUp($app);
 
-        $app['config']->set('sentry.dsn', 'http://publickey:secretkey@sentry.dev/123');
-
         $config = $app['config']->all();
 
         $config['sentry']['breadcrumbs.sql_bindings'] = true;
@@ -20,15 +18,6 @@ class SqlBindingsInBreadcrumbsWithOldConfigKeyEnabledTest extends SentryLaravelT
         $app['config'] = new Repository($config);
     }
 
-    public function testIsBound()
-    {
-        $this->assertTrue(app()->bound('sentry'));
-        $this->assertInstanceOf(Hub::class, app('sentry'));
-    }
-
-    /**
-     * @depends testIsBound
-     */
     public function testSqlBindingsAreRecordedWhenEnabledByOldConfigKey()
     {
         $this->assertTrue($this->app['config']->get('sentry')['breadcrumbs.sql_bindings']);


### PR DESCRIPTION
This will resolve the `integrations` option with the Laravel container (if needed).

I do not check if the instance retrieved from the container is an object that implements `IntegrationInterface` since the Sentry client will validate that itself.

This also makes the `Sentry\Laravel\Integration` not overwritable by the user which seems like a good side effect to me since there should be no reason to not register that integration.

/fixes #238