### PR TITLE
Added alias for Hub to container

### DIFF
--- a/src/Sentry/Laravel/ServiceProvider.php
+++ b/src/Sentry/Laravel/ServiceProvider.php
@@ -3,6 +3,7 @@
 namespace Sentry\Laravel;
 
 use Sentry\State\Hub;
+use Sentry\State\HubInterface;
 use Sentry\ClientBuilder;
 use Illuminate\Log\LogManager;
 use Laravel\Lumen\Application as Lumen;
@@ -25,6 +26,8 @@ class ServiceProvider extends IlluminateServiceProvider
     public function boot(): void
     {
         $this->app->make(self::$abstract);
+
+        $this->app->alias(self::$abstract, HubInterface::class);
 
         if ($this->hasDsnSet()) {
             $this->bindEvents($this->app);

--- a/src/Sentry/Laravel/ServiceProvider.php
+++ b/src/Sentry/Laravel/ServiceProvider.php
@@ -3,8 +3,8 @@
 namespace Sentry\Laravel;
 
 use Sentry\State\Hub;
-use Sentry\State\HubInterface;
 use Sentry\ClientBuilder;
+use Sentry\State\HubInterface;
 use Illuminate\Log\LogManager;
 use Laravel\Lumen\Application as Lumen;
 use Sentry\Integration\IntegrationInterface;
@@ -26,8 +26,6 @@ class ServiceProvider extends IlluminateServiceProvider
     public function boot(): void
     {
         $this->app->make(self::$abstract);
-
-        $this->app->alias(self::$abstract, HubInterface::class);
 
         if ($this->hasDsnSet()) {
             $this->bindEvents($this->app);
@@ -129,6 +127,8 @@ class ServiceProvider extends IlluminateServiceProvider
 
             return Hub::getCurrent();
         });
+
+        $this->app->alias(self::$abstract, HubInterface::class);
     }
 
     /**


### PR DESCRIPTION
Code:
```
        dump(
            $this->sentry, // hinted Hub via constructor
            $this->container->make('sentry'),
            $this->container->make(Hub::class),
       );
```

Before and after:

![sentry-di](https://user-images.githubusercontent.com/671925/60473617-f84e1a00-9cc1-11e9-8678-f362f08dd7c4.png)

Constructor hinting or `make()` of the interface was not working before this fix as well.

/fixes #248