### PR TITLE
Fix custom alias

### DIFF
--- a/src/Sentry/Laravel/ServiceProvider.php
+++ b/src/Sentry/Laravel/ServiceProvider.php
@@ -25,7 +25,7 @@ class ServiceProvider extends IlluminateServiceProvider
      */
     public function boot(): void
     {
-        $this->app->make(self::$abstract);
+        $this->app->make(static::$abstract);
 
         if ($this->hasDsnSet()) {
             $this->bindEvents($this->app);
@@ -128,7 +128,7 @@ class ServiceProvider extends IlluminateServiceProvider
             return Hub::getCurrent();
         });
 
-        $this->app->alias(self::$abstract, HubInterface::class);
+        $this->app->alias(static::$abstract, HubInterface::class);
     }
 
     /**


### PR DESCRIPTION
Hey,
i'm recently found out, when you set a custom alias via an own Service Provider (see [Docs](https://docs.sentry.io/platforms/php/laravel/#resolve-name-conflicts-with-packages-also-called-sentry)), it does not work.

This error will always occur:
> ReflectionException: Class sentry does not exist
> 
> ~/sentry-laravel/vendor/laravel/framework/src/Illuminate/Container/Container.php:788
> ~/sentry-laravel/vendor/laravel/framework/src/Illuminate/Container/Container.php:667
> ~/sentry-laravel/vendor/laravel/framework/src/Illuminate/Container/Container.php:615
> ~/sentry-laravel/vendor/laravel/framework/src/Illuminate/Foundation/Application.php:767
> ~/sentry-laravel/src/Sentry/Laravel/ServiceProvider.php:28
> ~/sentry-laravel/vendor/laravel/framework/src/Illuminate/Container/BoundMethod.php:32
> ~/sentry-laravel/vendor/laravel/framework/src/Illuminate/Container/BoundMethod.php:90
> ~/sentry-laravel/vendor/laravel/framework/src/Illuminate/Container/BoundMethod.php:34
> ~/sentry-laravel/vendor/laravel/framework/src/Illuminate/Container/Container.php:576
> ~/sentry-laravel/vendor/laravel/framework/src/Illuminate/Foundation/Application.php:827
> ~/sentry-laravel/vendor/laravel/framework/src/Illuminate/Foundation/Application.php:810
> ~/sentry-laravel/vendor/laravel/framework/src/Illuminate/Foundation/Application.php:811
> ~/sentry-laravel/vendor/laravel/framework/src/Illuminate/Foundation/Bootstrap/BootProviders.php:17
> ~/sentry-laravel/vendor/orchestra/testbench-core/src/Concerns/CreatesApplication.php:310
> ~/sentry-laravel/vendor/orchestra/testbench-core/src/Concerns/CreatesApplication.php:202
> ~/sentry-laravel/vendor/orchestra/testbench-core/src/TestCase.php:73
> ~/sentry-laravel/vendor/orchestra/testbench-core/src/Concerns/Testing.php:68
> ~/sentry-laravel/vendor/orchestra/testbench-core/src/TestCase.php:41

To fix this, we will simply need to change the "self" keyword to "static" - since we will extend the given Service Provider.