### PR TITLE
Adds support for Laravel ^6.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
   },
   "require-dev": {
     "phpunit/phpunit": "7.5.*",
-    "laravel/framework": "5.8.*",
+    "laravel/framework": "5.8.* || ^6.0",
     "orchestra/testbench": "3.8.*",
     "friendsofphp/php-cs-fixer": "2.14.*"
   },


### PR DESCRIPTION
Laravel 6.0 is released on September 3rd. This adds support for that release. I'm not sure how you want to handle versioning. There's normally different releases for the various versions, however, version 6 does not have any breaking changes that will affect Sentry's reporting, only that versioning is changing to semantic versioning starting at 6.0.x.