### PR TITLE
Add support for Laravel 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,12 +17,15 @@ env:
     - LARAVEL=5.6.* TESTBENCH=3.6.* PHPUNIT=7.5.*
     - LARAVEL=5.7.* TESTBENCH=3.7.* PHPUNIT=7.5.*
     - LARAVEL=5.8.* TESTBENCH=3.8.* PHPUNIT=7.5.*
+    - LARAVEL=6.0.* TESTBENCH=3.9.* PHPUNIT=8.0.*
 
 matrix:
   fast_finish: true
   allow_failures:
     - php: 7.4snapshot
   exclude:
+    - php: 7.1
+      env: LARAVEL=6.0.* TESTBENCH=3.9.* PHPUNIT=8.0.*
     - php: 7.2
       env: LARAVEL=5.0.* TESTBENCH=3.0.* PHPUNIT=4.8.*
     - php: 7.3

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,8 @@
     "orchestra/testbench": "^3.9",
     "friendsofphp/php-cs-fixer": "2.14.*"
   },
+  "minimum-stability": "dev",
+  "prefer-stable": true,
   "autoload": {
     "psr-0": {
       "Sentry\\Laravel\\": "src/"

--- a/composer.json
+++ b/composer.json
@@ -13,13 +13,13 @@
   ],
   "require": {
     "php": "^7.1",
-    "illuminate/support": "5.0 - 5.8",
+    "illuminate/support": "5.0 - 5.8 | ^6.0",
     "sentry/sdk": "^2.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "7.5.*",
-    "laravel/framework": "5.8.*",
-    "orchestra/testbench": "3.8.*",
+    "phpunit/phpunit": "^8.0",
+    "laravel/framework": "^6.0",
+    "orchestra/testbench": "^3.9",
     "friendsofphp/php-cs-fixer": "2.14.*"
   },
   "autoload": {

--- a/test/Sentry/EventHandlerTest.php
+++ b/test/Sentry/EventHandlerTest.php
@@ -4,11 +4,10 @@ namespace Sentry\Laravel\Tests;
 
 class EventHandlerTest extends \Orchestra\Testbench\TestCase
 {
-    /**
-     * @expectedException \RuntimeException
-     */
     public function test_missing_event_handler_throws_exception()
     {
+        $this->expectException(\RuntimeException::class);
+
         $handler = new \Sentry\Laravel\EventHandler($this->app->events, []);
 
         $handler->thisIsNotAHandlerAndShouldThrowAnException();

--- a/test/Sentry/EventHandlerTest.php
+++ b/test/Sentry/EventHandlerTest.php
@@ -4,10 +4,11 @@ namespace Sentry\Laravel\Tests;
 
 class EventHandlerTest extends \Orchestra\Testbench\TestCase
 {
+    /**
+     * @expectedException \RuntimeException
+     */
     public function test_missing_event_handler_throws_exception()
     {
-        $this->expectException(\RuntimeException::class);
-
         $handler = new \Sentry\Laravel\EventHandler($this->app->events, []);
 
         $handler->thisIsNotAHandlerAndShouldThrowAnException();

--- a/test/Sentry/IntegrationsOptionTest.php
+++ b/test/Sentry/IntegrationsOptionTest.php
@@ -49,11 +49,10 @@ class IntegrationsOptionTest extends SentryLaravelTestCase
         $this->assertNotNull(Hub::getCurrent()->getClient()->getIntegration(IntegrationsOptionTestIntegrationStub::class));
     }
 
-    /**
-     * @expectedException \ReflectionException
-     */
     public function testCustomIntegrationThrowsExceptionIfNotResolvable()
     {
+        $this->expectException(\ReflectionException::class);
+
         $this->resetApplicationWithConfig([
             'sentry.integrations' => [
                 'this-will-not-resolve',
@@ -61,11 +60,10 @@ class IntegrationsOptionTest extends SentryLaravelTestCase
         ]);
     }
 
-    /**
-     * @expectedException \RuntimeException
-     */
     public function testIncorrectIntegrationEntryThrowsException()
     {
+        $this->expectException(\RuntimeException::class);
+
         $this->resetApplicationWithConfig([
             'sentry.integrations' => [
                 static function () {

--- a/test/Sentry/IntegrationsOptionTest.php
+++ b/test/Sentry/IntegrationsOptionTest.php
@@ -51,7 +51,8 @@ class IntegrationsOptionTest extends SentryLaravelTestCase
 
     public function testCustomIntegrationThrowsExceptionIfNotResolvable()
     {
-        $this->expectException(\ReflectionException::class);
+        // Throws \ReflectionException in <=5.8 and \Illuminate\Contracts\Container\BindingResolutionException since 6.0
+        $this->expectException(\Exception::class);
 
         $this->resetApplicationWithConfig([
             'sentry.integrations' => [

--- a/test/Sentry/IntegrationsOptionTest.php
+++ b/test/Sentry/IntegrationsOptionTest.php
@@ -49,11 +49,12 @@ class IntegrationsOptionTest extends SentryLaravelTestCase
         $this->assertNotNull(Hub::getCurrent()->getClient()->getIntegration(IntegrationsOptionTestIntegrationStub::class));
     }
 
+    /**
+     * Throws \ReflectionException in <=5.8 and \Illuminate\Contracts\Container\BindingResolutionException since 6.0
+     * @expectedException \Exception
+     */
     public function testCustomIntegrationThrowsExceptionIfNotResolvable()
     {
-        // Throws \ReflectionException in <=5.8 and \Illuminate\Contracts\Container\BindingResolutionException since 6.0
-        $this->expectException(\Exception::class);
-
         $this->resetApplicationWithConfig([
             'sentry.integrations' => [
                 'this-will-not-resolve',
@@ -61,10 +62,11 @@ class IntegrationsOptionTest extends SentryLaravelTestCase
         ]);
     }
 
+    /**
+     * @expectedException \RuntimeException
+     */
     public function testIncorrectIntegrationEntryThrowsException()
     {
-        $this->expectException(\RuntimeException::class);
-
         $this->resetApplicationWithConfig([
             'sentry.integrations' => [
                 static function () {


### PR DESCRIPTION
Creating this PR in advance of the Laravel 6 release. This PR add an entry to the travis test matrix for the latest release. As of `orchestra/testbench@3.9.x`, they require PHPUnit 8. This brings some _inconveniences_ with supporting older versions of PHPUnit in the same codebase.

- [x] PHPUnit 8 made `@expectedException` annotations deprecated. However, PHPUnit 4 doesn't have the `$this->expectException()` method yet, which is still used for testing with Laravel 5.0. Should we remove Laravel 5.0 form the test matrix, or drop support?
- [x] PHPUnit 8 and Laravel 6 require PHP >=7.2, which results in one more exception in the test matrix. (fixed in ce244f9)
- [x] There also was one breaking change (https://github.com/laravel/framework/pull/27977) that results in a test failing. (fixed in 0254084)
- [ ] Remove the `minimum-stability` and `prefer-stable` flags from the `composer.json` before merging.