### PR TITLE
Flush events when Application terminates

### DIFF
--- a/src/Sentry/Laravel/ServiceProvider.php
+++ b/src/Sentry/Laravel/ServiceProvider.php
@@ -60,6 +60,12 @@ class ServiceProvider extends IlluminateServiceProvider
                 return (new LogChannel($app))($config);
             });
         }
+
+        if ($this->app instanceof Laravel) {
+            $this->app->terminating(function () {
+                Integration::flushEvents();
+            });
+        }
     }
 
     /**


### PR DESCRIPTION
Environment:
- Laravel 6.0
- PHP 7.3
- Using stack driver with Sentry and Single handlers

Exceptions thrown during artisan commands have not been reaching Sentry. Even `php artisan sentry:test` has been failing for me. Upon investigating, it looks like `exit($status)` in artisan prevents the `__destruct()` magic method in HttpTransport from cleaning up pending requests? Could be wrong here, but commenting out exit() did seem to fix the issue.

https://github.com/laravel/laravel/blob/master/artisan#L53
https://github.com/getsentry/sentry-php/blob/master/src/Transport/HttpTransport.php#L66

My proposed change is to hook into the Laravel application `terminating()` callback. This utilises the fix introduced here: https://github.com/getsentry/sentry-laravel/pull/228 to ensure all pending promises resolve.

Unfortunately, it doesn't look like Lumen offers equivalent functionality.