### PR TITLE
Check if user context is array (fix fatal error)

### DIFF
--- a/src/Sentry/Laravel/SentryHandler.php
+++ b/src/Sentry/Laravel/SentryHandler.php
@@ -174,8 +174,8 @@ class SentryHandler extends AbstractProcessingHandler
                     unset($record['context']['fingerprint']);
                 }
 
-                if (is_array($record['context']['user'])) {
-                    $scope->setUser($record['context']['user']);
+                if (!empty($record['context']['user'])) {
+                     $scope->setUser((array)$record['context']['user']);
                     unset($record['context']['user']);
                 }
 

--- a/src/Sentry/Laravel/SentryHandler.php
+++ b/src/Sentry/Laravel/SentryHandler.php
@@ -175,7 +175,7 @@ class SentryHandler extends AbstractProcessingHandler
                 }
 
                 if (!empty($record['context']['user'])) {
-                     $scope->setUser((array)$record['context']['user']);
+                    $scope->setUser((array)$record['context']['user']);
                     unset($record['context']['user']);
                 }
 

--- a/src/Sentry/Laravel/SentryHandler.php
+++ b/src/Sentry/Laravel/SentryHandler.php
@@ -174,7 +174,7 @@ class SentryHandler extends AbstractProcessingHandler
                     unset($record['context']['fingerprint']);
                 }
 
-                if (!empty($record['context']['user'])) {
+                if (is_array($record['context']['user'])) {
                     $scope->setUser($record['context']['user']);
                     unset($record['context']['user']);
                 }


### PR DESCRIPTION
This fixes an issue, if anything but an array is passed to Laravel/Monolog context as key `user`.

Assumption: `sentry` driver is configured as laravel logging driver

Example: Faulty behavior (before):
```php
\Log::error('some error', [
    'user' => 'john_doe',
]);
```
==> Causes fatal error (in symfony/laravel usually wrapped in `FatalThrowableError` exception):
```
Argument 1 passed to Sentry\State\Scope::setUser() must be of the type array, string given, called in .../vendor/sentry/sentry-laravel/src/Sentry/Laravel/SentryHandler.php on line 178
```
(because `user` is directly passed to sentry `setUser` method as it's `!empty`)

Solution (this PR):
Changing the check from `!empty` to `is_array` makes sure this kind of error is prevented