### PR TITLE
Updates for sentry/sentry 2.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ package.xml
 .idea
 .php_cs.cache
 docs/_build
+.phpunit.result.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,16 +8,18 @@ php:
 
 env:
   matrix:
-    - LARAVEL=5.0.* TESTBENCH=3.0.* PHPUNIT=4.8.*
-    - LARAVEL=5.1.* TESTBENCH=3.1.* PHPUNIT=5.7.*
-    - LARAVEL=5.2.* TESTBENCH=3.2.* PHPUNIT=5.7.*
-    - LARAVEL=5.3.* TESTBENCH=3.3.* PHPUNIT=5.7.*
-    - LARAVEL=5.4.* TESTBENCH=3.4.* PHPUNIT=5.7.*
-    - LARAVEL=5.5.* TESTBENCH=3.5.* PHPUNIT=6.5.*
-    - LARAVEL=5.6.* TESTBENCH=3.6.* PHPUNIT=7.5.*
-    - LARAVEL=5.7.* TESTBENCH=3.7.* PHPUNIT=7.5.*
-    - LARAVEL=5.8.* TESTBENCH=3.8.* PHPUNIT=7.5.*
-    - LARAVEL=6.0.* TESTBENCH=3.9.* PHPUNIT=8.0.*
+    - LARAVEL=5.0.* TESTBENCH=3.0.* PHPUNIT=4.8.* SENTRY=^2.0
+    - LARAVEL=5.1.* TESTBENCH=3.1.* PHPUNIT=5.7.* SENTRY=^2.0
+    - LARAVEL=5.2.* TESTBENCH=3.2.* PHPUNIT=5.7.* SENTRY=^2.0
+    - LARAVEL=5.3.* TESTBENCH=3.3.* PHPUNIT=5.7.* SENTRY=^2.0
+    - LARAVEL=5.4.* TESTBENCH=3.4.* PHPUNIT=5.7.* SENTRY=^2.0
+    - LARAVEL=5.5.* TESTBENCH=3.5.* PHPUNIT=6.5.* SENTRY=^2.0
+    - LARAVEL=5.6.* TESTBENCH=3.6.* PHPUNIT=7.5.* SENTRY=^2.0
+    - LARAVEL=5.7.* TESTBENCH=3.7.* PHPUNIT=7.5.* SENTRY=^2.0
+    - LARAVEL=5.8.* TESTBENCH=3.8.* PHPUNIT=7.5.* SENTRY=^2.0
+    - LARAVEL=6.0.* TESTBENCH=3.9.* PHPUNIT=8.0.* SENTRY=^2.0
+    # We add one more test using the bleading edge of the sentry/sentry package
+    - LARAVEL=6.0.* TESTBENCH=3.9.* PHPUNIT=8.0.* SENTRY=dev-develop@dev
 
 matrix:
   fast_finish: true
@@ -25,13 +27,15 @@ matrix:
     - php: 7.4snapshot
   exclude:
     - php: 7.1
-      env: LARAVEL=6.0.* TESTBENCH=3.9.* PHPUNIT=8.0.*
+      env: LARAVEL=6.0.* TESTBENCH=3.9.* PHPUNIT=8.0.* SENTRY=^2.0
+    - php: 7.1
+      env: LARAVEL=6.0.* TESTBENCH=3.9.* PHPUNIT=8.0.* SENTRY=dev-develop@dev
     - php: 7.2
-      env: LARAVEL=5.0.* TESTBENCH=3.0.* PHPUNIT=4.8.*
+      env: LARAVEL=5.0.* TESTBENCH=3.0.* PHPUNIT=4.8.* SENTRY=^2.0
     - php: 7.3
-      env: LARAVEL=5.0.* TESTBENCH=3.0.* PHPUNIT=4.8.*
+      env: LARAVEL=5.0.* TESTBENCH=3.0.* PHPUNIT=4.8.* SENTRY=^2.0
     - php: 7.4snapshot
-      env: LARAVEL=5.0.* TESTBENCH=3.0.* PHPUNIT=4.8.*
+      env: LARAVEL=5.0.* TESTBENCH=3.0.* PHPUNIT=4.8.* SENTRY=^2.0
 
 cache:
   directories:
@@ -51,7 +55,7 @@ jobs:
 
 before_install:
   - if [ "$USE_COMPOSER_JSON" != "1" ]; then composer remove friendsofphp/php-cs-fixer --dev --no-update; fi;
-  - if [ "$USE_COMPOSER_JSON" != "1" ]; then composer require laravel/framework:$LARAVEL illuminate/support:$LARAVEL orchestra/testbench:$TESTBENCH phpunit/phpunit:$PHPUNIT --no-update --no-interaction --dev; fi;
+  - if [ "$USE_COMPOSER_JSON" != "1" ]; then composer require laravel/framework:$LARAVEL illuminate/support:$LARAVEL orchestra/testbench:$TESTBENCH phpunit/phpunit:$PHPUNIT sentry/sentry:$SENTRY --no-update --no-interaction --dev; fi;
 
 install:
   - travis_retry composer install --no-suggest --no-interaction --prefer-dist --no-progress

--- a/src/Sentry/Laravel/EventHandler.php
+++ b/src/Sentry/Laravel/EventHandler.php
@@ -16,7 +16,6 @@ use Illuminate\Routing\Route;
 use RuntimeException;
 use Sentry\State\Scope;
 use Sentry\Breadcrumb;
-use Sentry\State\Hub;
 
 class EventHandler
 {
@@ -115,7 +114,7 @@ class EventHandler
             Integration::flushEvents();
 
             // We have added a scope when a job starts processing
-            Hub::getCurrent()->popScope();
+            Integration::getCurrentHub()->popScope();
         });
 
         foreach (static::$queueEventHandlerMap as $eventName => $handler) {
@@ -283,7 +282,7 @@ class EventHandler
     protected function queueJobProcessingHandler(JobProcessing $event)
     {
         // When a job starts, we want to push a new scope
-        Hub::getCurrent()->pushScope();
+        Integration::getCurrentHub()->pushScope();
 
         $job = [
             'job' => $event->job->getName(),

--- a/src/Sentry/Laravel/Integration.php
+++ b/src/Sentry/Laravel/Integration.php
@@ -2,15 +2,16 @@
 
 namespace Sentry\Laravel;
 
+use Sentry\FlushableClientInterface;
+use Sentry\SentrySdk;
+use Sentry\State\Hub;
+use Sentry\State\HubInterface;
 use function Sentry\addBreadcrumb;
 use function Sentry\configureScope;
 use Sentry\Breadcrumb;
 use Sentry\Event;
-use Sentry\Client;
 use Sentry\Integration\IntegrationInterface;
-use Sentry\State\Hub;
 use Sentry\State\Scope;
-use Sentry\Transport\HttpTransport;
 
 class Integration implements IntegrationInterface
 {
@@ -25,7 +26,7 @@ class Integration implements IntegrationInterface
     public function setupOnce(): void
     {
         Scope::addGlobalEventProcessor(function (Event $event): Event {
-            $self = Hub::getCurrent()->getIntegration(self::class);
+            $self = static::getCurrentHub()->getIntegration(self::class);
 
             if (!$self instanceof self) {
                 return $event;
@@ -44,7 +45,7 @@ class Integration implements IntegrationInterface
      */
     public static function addBreadcrumb(Breadcrumb $breadcrumb): void
     {
-        $self = Hub::getCurrent()->getIntegration(self::class);
+        $self = static::getCurrentHub()->getIntegration(self::class);
 
         if (!$self instanceof self) {
             return;
@@ -60,7 +61,7 @@ class Integration implements IntegrationInterface
      */
     public static function configureScope(callable $callback): void
     {
-        $self = Hub::getCurrent()->getIntegration(self::class);
+        $self = static::getCurrentHub()->getIntegration(self::class);
 
         if (!$self instanceof self) {
             return;
@@ -93,21 +94,57 @@ class Integration implements IntegrationInterface
      */
     public static function flushEvents(): void
     {
-        $client = Hub::getCurrent()->getClient();
+        $client = static::getCurrentHub()->getClient();
 
-        if ($client instanceof Client) {
-            $transportProperty = new \ReflectionProperty(Client::class, 'transport');
-            $transportProperty->setAccessible(true);
-
-            $transport = $transportProperty->getValue($client);
-
-            if ($transport instanceof HttpTransport) {
-                $closure = \Closure::bind(function () {
-                    $this->cleanupPendingRequests();
-                }, $transport, $transport);
-
-                $closure();
-            }
+        if ($client instanceof FlushableClientInterface) {
+            $client->flush();
         }
+    }
+
+    /**
+     * Gets the current hub. If it's not initialized then creates a new instance
+     * and sets it as current hub.
+     *
+     * The is here for legacy reasons where we used the Hub directly as a singleton.
+     *
+     * @TODO: This method should be removed and replaced with calls to `SentrySdk::getCurrentHub()` directly once
+     *   `sentry/sentry` 3.0 is released and pinned as an dependency.
+     *
+     * @internal This is not part of the public API and is here temporarily.
+     *
+     * @return \Sentry\State\HubInterface
+     */
+    public static function getCurrentHub(): HubInterface
+    {
+        if (class_exists(SentrySdk::class)) {
+            SentrySdk::getCurrentHub();
+        }
+
+        return Hub::getCurrent();
+    }
+
+    /**
+     * Sets the current hub.
+     *
+     * The is here for legacy reasons where we used the Hub directly as a singleton.
+     *
+     * @TODO: This method should be removed and replaced with calls to `SentrySdk::getCurrentHub()` directly once
+     *   `sentry/sentry` 3.0 is released and pinned as an dependency.
+     *
+     * @internal This is not part of the public API and is here temporarily.
+     *
+     * @param \Sentry\State\HubInterface $hub
+     *
+     * @return void
+     */
+    public static function setCurrentHub(HubInterface $hub): void
+    {
+        if (class_exists(SentrySdk::class)) {
+            SentrySdk::setCurrentHub($hub);
+
+            return;
+        }
+
+        Hub::setCurrent($hub);
     }
 }

--- a/src/Sentry/Laravel/SentryHandler.php
+++ b/src/Sentry/Laravel/SentryHandler.php
@@ -123,21 +123,17 @@ class SentryHandler extends AbstractProcessingHandler
         switch ($logLevel) {
             case Logger::DEBUG:
                 return Severity::debug();
-            case Logger::INFO:
-                return Severity::info();
             case Logger::NOTICE:
+            case Logger::INFO:
                 return Severity::info();
             case Logger::WARNING:
                 return Severity::warning();
             case Logger::ERROR:
                 return Severity::error();
+            case Logger::ALERT:
+            case Logger::EMERGENCY:
             case Logger::CRITICAL:
                 return Severity::fatal();
-            case Logger::ALERT:
-                return Severity::fatal();
-            case Logger::EMERGENCY:
-                return Severity::fatal();
-
         }
     }
 

--- a/src/Sentry/Laravel/ServiceProvider.php
+++ b/src/Sentry/Laravel/ServiceProvider.php
@@ -123,9 +123,11 @@ class ServiceProvider extends IlluminateServiceProvider
             $clientBuilder->setSdkIdentifier(Version::SDK_IDENTIFIER);
             $clientBuilder->setSdkVersion(Version::SDK_VERSION);
 
-            Hub::setCurrent(new Hub($clientBuilder->getClient()));
+            $hub = new Hub($clientBuilder->getClient());
 
-            return Hub::getCurrent();
+            Integration::setCurrentHub($hub);
+
+            return $hub;
         });
 
         $this->app->alias(static::$abstract, HubInterface::class);

--- a/test/Sentry/IntegrationsOptionTest.php
+++ b/test/Sentry/IntegrationsOptionTest.php
@@ -2,7 +2,6 @@
 
 namespace Sentry\Laravel\Tests;
 
-use Sentry\State\Hub;
 use Sentry\Integration\IntegrationInterface;
 
 class IntegrationsOptionTest extends SentryLaravelTestCase
@@ -24,7 +23,7 @@ class IntegrationsOptionTest extends SentryLaravelTestCase
             ],
         ]);
 
-        $this->assertNotNull(Hub::getCurrent()->getClient()->getIntegration(IntegrationsOptionTestIntegrationStub::class));
+        $this->assertNotNull($this->getHubFromContainer()->getClient()->getIntegration(IntegrationsOptionTestIntegrationStub::class));
     }
 
     public function testCustomIntegrationIsResolvedFromContainerByClass()
@@ -35,7 +34,7 @@ class IntegrationsOptionTest extends SentryLaravelTestCase
             ],
         ]);
 
-        $this->assertNotNull(Hub::getCurrent()->getClient()->getIntegration(IntegrationsOptionTestIntegrationStub::class));
+        $this->assertNotNull($this->getHubFromContainer()->getClient()->getIntegration(IntegrationsOptionTestIntegrationStub::class));
     }
 
     public function testCustomIntegrationByInstance()
@@ -46,7 +45,7 @@ class IntegrationsOptionTest extends SentryLaravelTestCase
             ],
         ]);
 
-        $this->assertNotNull(Hub::getCurrent()->getClient()->getIntegration(IntegrationsOptionTestIntegrationStub::class));
+        $this->assertNotNull($this->getHubFromContainer()->getClient()->getIntegration(IntegrationsOptionTestIntegrationStub::class));
     }
 
     /**

--- a/test/Sentry/SqlBindingsInBreadcrumbsTest.php
+++ b/test/Sentry/SqlBindingsInBreadcrumbsTest.php
@@ -2,8 +2,6 @@
 
 namespace Sentry\Laravel\Tests;
 
-use Sentry\State\Hub;
-
 class SqlBindingsInBreadcrumbsTest extends SentryLaravelTestCase
 {
     public function testSqlBindingsAreRecordedWhenEnabled()
@@ -21,7 +19,7 @@ class SqlBindingsInBreadcrumbsTest extends SentryLaravelTestCase
             'test',
         ]);
 
-        $breadcrumbs = $this->getScope(Hub::getCurrent())->getBreadcrumbs();
+        $breadcrumbs = $this->getCurrentBreadcrumbs();
 
         /** @var \Sentry\Breadcrumb $lastBreadcrumb */
         $lastBreadcrumb = end($breadcrumbs);
@@ -45,7 +43,7 @@ class SqlBindingsInBreadcrumbsTest extends SentryLaravelTestCase
             'test',
         ]);
 
-        $breadcrumbs = $this->getScope(Hub::getCurrent())->getBreadcrumbs();
+        $breadcrumbs = $this->getCurrentBreadcrumbs();
 
         /** @var \Sentry\Breadcrumb $lastBreadcrumb */
         $lastBreadcrumb = end($breadcrumbs);

--- a/test/Sentry/SqlBindingsInBreadcrumbsWithOldConfigKeyDisabledTest.php
+++ b/test/Sentry/SqlBindingsInBreadcrumbsWithOldConfigKeyDisabledTest.php
@@ -2,7 +2,6 @@
 
 namespace Sentry\Laravel\Tests;
 
-use Sentry\State\Hub;
 use Illuminate\Config\Repository;
 
 class SqlBindingsInBreadcrumbsWithOldConfigKeyDisabledTest extends SentryLaravelTestCase
@@ -29,7 +28,7 @@ class SqlBindingsInBreadcrumbsWithOldConfigKeyDisabledTest extends SentryLaravel
             'test',
         ]);
 
-        $breadcrumbs = $this->getScope(Hub::getCurrent())->getBreadcrumbs();
+        $breadcrumbs = $this->getCurrentBreadcrumbs();
 
         /** @var \Sentry\Breadcrumb $lastBreadcrumb */
         $lastBreadcrumb = end($breadcrumbs);

--- a/test/Sentry/SqlBindingsInBreadcrumbsWithOldConfigKeyEnabledTest.php
+++ b/test/Sentry/SqlBindingsInBreadcrumbsWithOldConfigKeyEnabledTest.php
@@ -2,7 +2,6 @@
 
 namespace Sentry\Laravel\Tests;
 
-use Sentry\State\Hub;
 use Illuminate\Config\Repository;
 
 class SqlBindingsInBreadcrumbsWithOldConfigKeyEnabledTest extends SentryLaravelTestCase
@@ -29,7 +28,7 @@ class SqlBindingsInBreadcrumbsWithOldConfigKeyEnabledTest extends SentryLaravelT
             'test',
         ]);
 
-        $breadcrumbs = $this->getScope(Hub::getCurrent())->getBreadcrumbs();
+        $breadcrumbs = $this->getCurrentBreadcrumbs();
 
         /** @var \Sentry\Breadcrumb $lastBreadcrumb */
         $lastBreadcrumb = end($breadcrumbs);


### PR DESCRIPTION
This PR is a preperation for `sentry/sentry` version 2.2 which deprecates the use of the `Hub` as a singleton.