### PR TITLE
Fix 2.2 compatibility

### DIFF
--- a/src/Sentry/Laravel/Integration.php
+++ b/src/Sentry/Laravel/Integration.php
@@ -117,7 +117,7 @@ class Integration implements IntegrationInterface
     public static function getCurrentHub(): HubInterface
     {
         if (class_exists(SentrySdk::class)) {
-            SentrySdk::getCurrentHub();
+            return SentrySdk::getCurrentHub();
         }
 
         return Hub::getCurrent();


### PR DESCRIPTION
I think the author of the original missed a return statement, because right now its just calling the deprecated method AFTER the new one.