### PR TITLE
Ensure that captured messages are fingerprinted based on the message

### DIFF
--- a/src/Sentry/Laravel/SentryHandler.php
+++ b/src/Sentry/Laravel/SentryHandler.php
@@ -11,6 +11,7 @@ use Sentry\Event;
 use Sentry\Severity;
 use Sentry\State\Hub;
 use Sentry\State\Scope;
+use function Sentry\configureScope;
 
 class SentryHandler extends AbstractProcessingHandler
 {
@@ -203,6 +204,9 @@ class SentryHandler extends AbstractProcessingHandler
                 if (isset($record['context']['exception']) && $record['context']['exception'] instanceof \Throwable) {
                     $this->hub->captureException($record['context']['exception']);
                 } else {
+                    configureScope(function (Scope &$scope) use ($record) {
+                        $scope = $scope->setFingerprint([md5($record['message'])]);
+                    });
                     $this->hub->captureMessage($record['formatted'], $this->getLogLevel($record['level']));
                 }
             }


### PR DESCRIPTION
Feature request: Captured messages should have the option to be fingerprinted based on the PSR-3 (https://www.php-fig.org/psr/psr-3/) message.

Hi. Maybe someone can point me in the right direction, but the edited code I have here is an example of an implementation of the feature request, which solves my issue.

We enjoy being able to log messages (*not* exceptions, necessarily) to sentry. However, since every monolog record is unique (based on the time and context e.g. https://github.com/Seldaek/monolog/blob/master/src/Monolog/Handler/ErrorLogHandler.php#L67), sentry only reports 1 event *per* log message. Needless to say, it's pretty hard to accurately gauge the frequency of each log statement. Fingerprinting seems like the exact feature to avoid this issue, but I don't see an easy way to do that.

What are people's thoughts on adding a feature like this?