### PR TITLE
Default log channel level to DEBUG

### DIFF
--- a/src/Sentry/Laravel/LogChannel.php
+++ b/src/Sentry/Laravel/LogChannel.php
@@ -14,7 +14,7 @@ class LogChannel extends LogManager
      */
     public function __invoke(array $config)
     {
-        $handler = new SentryHandler($this->app->make('sentry'), $config['level'] ?? null, $config['bubble'] ?? true);
+        $handler = new SentryHandler($this->app->make('sentry'), $config['level'] ?? Logger::DEBUG, $config['bubble'] ?? true);
 
         return new Logger($this->parseChannel($config), [$this->prepareHandler($handler, $config)]);
     }


### PR DESCRIPTION
In reference to #285 this fixes an issue where the log channel would not work out of the box because it would default to a `null` level instead of `DEBUG`.