### PR TITLE
Allow for decorating the client builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Allow decorating the `ClientBuilderInterface` from the `register` method of a Service Provider (#290)
+
 ## 1.4.1
 
 - Fix default Monolog logger level being invalid when using the Log channel (#287)

--- a/src/Sentry/Laravel/ServiceProvider.php
+++ b/src/Sentry/Laravel/ServiceProvider.php
@@ -2,11 +2,11 @@
 
 namespace Sentry\Laravel;
 
-use Sentry\Options;
 use Sentry\State\Hub;
 use Sentry\ClientBuilder;
 use Sentry\State\HubInterface;
 use Illuminate\Log\LogManager;
+use Sentry\ClientBuilderInterface;
 use Laravel\Lumen\Application as Lumen;
 use Sentry\Integration as SdkIntegration;
 use Illuminate\Foundation\Application as Laravel;
@@ -96,7 +96,7 @@ class ServiceProvider extends IlluminateServiceProvider
      */
     protected function configureAndRegisterClient(): void
     {
-        $this->app->bind(ClientBuilder::class, function () {
+        $this->app->bind(ClientBuilderInterface::class, function () {
             $basePath = base_path();
             $userConfig = $this->getUserConfig();
 
@@ -130,8 +130,8 @@ class ServiceProvider extends IlluminateServiceProvider
         });
 
         $this->app->singleton(static::$abstract, function () {
-            /** @var \Sentry\ClientBuilder $clientBuilder */
-            $clientBuilder = $this->app->make(ClientBuilder::class);
+            /** @var \Sentry\ClientBuilderInterface $clientBuilder */
+            $clientBuilder = $this->app->make(ClientBuilderInterface::class);
 
             $options = $clientBuilder->getOptions();
 

--- a/src/Sentry/Laravel/ServiceProvider.php
+++ b/src/Sentry/Laravel/ServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace Sentry\Laravel;
 
+use Sentry\Options;
 use Sentry\State\Hub;
 use Sentry\ClientBuilder;
 use Sentry\State\HubInterface;
@@ -95,7 +96,7 @@ class ServiceProvider extends IlluminateServiceProvider
      */
     protected function configureAndRegisterClient(): void
     {
-        $this->app->singleton(static::$abstract, function () {
+        $this->app->bind(ClientBuilder::class, function () {
             $basePath = base_path();
             $userConfig = $this->getUserConfig();
 
@@ -120,8 +121,17 @@ class ServiceProvider extends IlluminateServiceProvider
             );
 
             $clientBuilder = ClientBuilder::create($options);
+
+            // Set the Laravel SDK identifier and version
             $clientBuilder->setSdkIdentifier(Version::SDK_IDENTIFIER);
             $clientBuilder->setSdkVersion(Version::SDK_VERSION);
+
+            return $clientBuilder;
+        });
+
+        $this->app->singleton(static::$abstract, function () {
+            /** @var \Sentry\ClientBuilder $clientBuilder */
+            $clientBuilder = $this->app->make(ClientBuilder::class);
 
             $options = $clientBuilder->getOptions();
 

--- a/test/Sentry/ServiceClientBuilderDecoratorTest.php
+++ b/test/Sentry/ServiceClientBuilderDecoratorTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Sentry\Laravel\Tests;
+
+use Sentry\ClientBuilder;
+use Sentry\Laravel\ServiceProvider;
+
+class ServiceClientBuilderDecoratorTest extends \Orchestra\Testbench\TestCase
+{
+    protected function getEnvironmentSetUp($app)
+    {
+        $app['config']->set('sentry.dsn', 'http://publickey:secretkey@sentry.dev/123');
+
+        $app->extend(ClientBuilder::class, function (ClientBuilder $clientBuilder) {
+            $clientBuilder->getOptions()->setEnvironment('from_service_container');
+
+            return $clientBuilder;
+        });
+    }
+
+    protected function getPackageProviders($app)
+    {
+        return [
+            ServiceProvider::class,
+        ];
+    }
+
+    public function testClientHasCustomSerializer()
+    {
+        /** @var \Sentry\Options $options */
+        $options = $this->app->make('sentry')->getClient()->getOptions();
+
+        $this->assertEquals('from_service_container', $options->getEnvironment());
+    }
+}

--- a/test/Sentry/ServiceClientBuilderDecoratorTest.php
+++ b/test/Sentry/ServiceClientBuilderDecoratorTest.php
@@ -2,7 +2,7 @@
 
 namespace Sentry\Laravel\Tests;
 
-use Sentry\ClientBuilder;
+use Sentry\ClientBuilderInterface;
 use Sentry\Laravel\ServiceProvider;
 
 class ServiceClientBuilderDecoratorTest extends \Orchestra\Testbench\TestCase
@@ -11,7 +11,7 @@ class ServiceClientBuilderDecoratorTest extends \Orchestra\Testbench\TestCase
     {
         $app['config']->set('sentry.dsn', 'http://publickey:secretkey@sentry.dev/123');
 
-        $app->extend(ClientBuilder::class, function (ClientBuilder $clientBuilder) {
+        $app->extend(ClientBuilderInterface::class, function (ClientBuilderInterface $clientBuilder) {
             $clientBuilder->getOptions()->setEnvironment('from_service_container');
 
             return $clientBuilder;


### PR DESCRIPTION
This allows the user to add this snippet to for example their `AppServiceProvider`s `register` method to set a custom serializer or do other tweaks to the `ClientBuilderInterface;` implementation or swap it out for their own builder interely.

In this example we increase `maxDepth` to 5 in for the default serializer.

```php
use Sentry\Serializer\Serializer;
use Sentry\ClientBuilderInterface;

$this->app->extend(ClientBuilderInterface::class, function (ClientBuilderInterface $clientBuilder) {
    $clientBuilder->setSerializer(new Serializer($clientBuilder->getOptions(), 5));
    
    return $clientBuilder;
});
```

Resolves #289.