### PR TITLE
Allow any log level to create breadcrumbs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Allow any log level to create breadcrumbs (#297)
+
 ## 1.4.1
 
 - Fix default Monolog logger level being invalid when using the Log channel (#287)

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
   "require": {
     "php": "^7.1",
     "illuminate/support": "5.0 - 5.8 | ^6.0",
-    "sentry/sdk": "^2.0.4"
+    "sentry/sdk": "^2.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^8.0",

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
   "require": {
     "php": "^7.1",
     "illuminate/support": "5.0 - 5.8 | ^6.0",
-    "sentry/sdk": "^2.0"
+    "sentry/sdk": "^2.0.4"
   },
   "require-dev": {
     "phpunit/phpunit": "^8.0",

--- a/src/Sentry/Laravel/EventHandler.php
+++ b/src/Sentry/Laravel/EventHandler.php
@@ -3,19 +3,19 @@
 namespace Sentry\Laravel;
 
 use Exception;
-use Illuminate\Log\Events\MessageLogged;
 use Illuminate\Auth\Events\Authenticated;
+use Illuminate\Console\Events\CommandFinished;
+use Illuminate\Console\Events\CommandStarting;
+use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Database\Events\QueryExecuted;
+use Illuminate\Log\Events\MessageLogged;
 use Illuminate\Queue\Events\JobProcessing;
 use Illuminate\Queue\QueueManager;
 use Illuminate\Routing\Events\RouteMatched;
-use Illuminate\Contracts\Events\Dispatcher;
-use Illuminate\Database\Events\QueryExecuted;
-use Illuminate\Console\Events\CommandStarting;
-use Illuminate\Console\Events\CommandFinished;
 use Illuminate\Routing\Route;
 use RuntimeException;
-use Sentry\State\Scope;
 use Sentry\Breadcrumb;
+use Sentry\State\Scope;
 
 class EventHandler
 {
@@ -240,13 +240,7 @@ class EventHandler
      */
     protected function logHandler($level, $message, $context)
     {
-        Integration::addBreadcrumb(new Breadcrumb(
-            $level,
-            Breadcrumb::TYPE_USER,
-            'log.' . $level,
-            $message,
-            empty($context) ? [] : ['params' => $context]
-        ));
+        $this->addLogBreadcrumb($level, $message, is_array($context) ? $context : []);
     }
 
     /**
@@ -256,13 +250,53 @@ class EventHandler
      */
     protected function messageLoggedHandler(MessageLogged $logEntry)
     {
+        $this->addLogBreadcrumb($logEntry->level, $logEntry->message, $logEntry->context);
+    }
+
+    /**
+     * Helper to add an log breadcrumb.
+     *
+     * @param  string $level   Log level. May be any standard.
+     * @param  string $message Log messsage.
+     * @param  array  $context Log context.
+     * @return void
+     */
+    private function addLogBreadcrumb(string $level, string $message, array $context = []): void
+    {
         Integration::addBreadcrumb(new Breadcrumb(
-            $logEntry->level,
+            $this->logLvlToBreadcrumbLvl($level),
             Breadcrumb::TYPE_USER,
-            'log.' . $logEntry->level,
-            $logEntry->message,
-            empty($logEntry->context) ? [] : ['params' => $logEntry->context]
+            'log.' . $level,
+            $message,
+            empty($context) ? [] : ['params' => $context]
         ));
+    }
+
+    /**
+     * Translates common log levels to Sentry breadcrumb levels.
+     *
+     * @param string $level Log level. Maybe any standard.
+     * @return string Breadcrumb level.
+     */
+    protected function logLvlToBreadcrumbLvl(string $level): string
+    {
+        switch (strtolower($level)) {
+            case 'debug':
+                return Breadcrumb::LEVEL_DEBUG;
+            case 'info':
+            case 'notice':
+                return Breadcrumb::LEVEL_INFO;
+            case 'warning':
+                return Breadcrumb::LEVEL_WARNING;
+            case 'error':
+                return Breadcrumb::LEVEL_ERROR;
+            case 'critical':
+            case 'alert':
+            case 'emergency':
+                return Breadcrumb::LEVEL_FATAL;
+            default:
+                return Breadcrumb::LEVEL_INFO;
+        }
     }
 
     /**

--- a/src/Sentry/Laravel/EventHandler.php
+++ b/src/Sentry/Laravel/EventHandler.php
@@ -259,12 +259,11 @@ class EventHandler
      * @param  string $level   Log level. May be any standard.
      * @param  string $message Log messsage.
      * @param  array  $context Log context.
-     * @return void
      */
     private function addLogBreadcrumb(string $level, string $message, array $context = []): void
     {
         Integration::addBreadcrumb(new Breadcrumb(
-            $this->logLvlToBreadcrumbLvl($level),
+            $this->logLevelToBreadcrumbLevel($level),
             Breadcrumb::TYPE_USER,
             'log.' . $level,
             $message,
@@ -275,17 +274,15 @@ class EventHandler
     /**
      * Translates common log levels to Sentry breadcrumb levels.
      *
-     * @param string $level Log level. Maybe any standard.
+     * @param  string $level Log level. Maybe any standard.
+     *
      * @return string Breadcrumb level.
      */
-    protected function logLvlToBreadcrumbLvl(string $level): string
+    protected function logLevelToBreadcrumbLevel(string $level): string
     {
         switch (strtolower($level)) {
             case 'debug':
                 return Breadcrumb::LEVEL_DEBUG;
-            case 'info':
-            case 'notice':
-                return Breadcrumb::LEVEL_INFO;
             case 'warning':
                 return Breadcrumb::LEVEL_WARNING;
             case 'error':
@@ -294,6 +291,8 @@ class EventHandler
             case 'alert':
             case 'emergency':
                 return Breadcrumb::LEVEL_FATAL;
+            case 'info':
+            case 'notice':
             default:
                 return Breadcrumb::LEVEL_INFO;
         }

--- a/src/Sentry/Laravel/EventHandler.php
+++ b/src/Sentry/Laravel/EventHandler.php
@@ -316,6 +316,11 @@ class EventHandler
      */
     protected function logLevelToBreadcrumbLevel(string $level): string
     {
+        // @TODO: Once we depend on `sentry-php` 3.0 we can use `Breadcrumb::LEVEL_FATAL` directly.
+        $fatal = defined(Breadcrumb::class . '::LEVEL_FATAL')
+            ? constant(Breadcrumb::class . '::LEVEL_FATAL')
+            : constant(Breadcrumb::class . '::LEVEL_CRITICAL');
+
         switch (strtolower($level)) {
             case 'debug':
                 return Breadcrumb::LEVEL_DEBUG;
@@ -326,7 +331,7 @@ class EventHandler
             case 'critical':
             case 'alert':
             case 'emergency':
-                return Breadcrumb::LEVEL_FATAL;
+                return $fatal;
             case 'info':
             case 'notice':
             default:


### PR DESCRIPTION
Creating a breadcrumb with an invalid log level would cause an exception, resulting in the log being missing in the breadcrumbs. This pull request adds a log level adapter method, which translates common log levels to suitable breadcrumb levels, defaulting to the info level.

Fixes #297 