### PR TITLE
Change default breadcrumb type for handled events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Use default breadcrumb type for handled events (#302)
+
 ## 1.5.0
 
 - Fix throwing errors when installed when config cache is active (6214338)

--- a/src/Sentry/Laravel/EventHandler.php
+++ b/src/Sentry/Laravel/EventHandler.php
@@ -256,7 +256,7 @@ class EventHandler
 
         Integration::addBreadcrumb(new Breadcrumb(
             Breadcrumb::LEVEL_INFO,
-            Breadcrumb::TYPE_USER,
+            Breadcrumb::TYPE_DEFAULT,
             'sql.query',
             $query,
             $data
@@ -300,7 +300,7 @@ class EventHandler
 
         Integration::addBreadcrumb(new Breadcrumb(
             $this->logLevelToBreadcrumbLevel($level),
-            Breadcrumb::TYPE_USER,
+            Breadcrumb::TYPE_DEFAULT,
             'log.' . $level,
             $message,
             empty($context) ? [] : ['params' => $context]
@@ -381,7 +381,7 @@ class EventHandler
 
         Integration::addBreadcrumb(new Breadcrumb(
             Breadcrumb::LEVEL_INFO,
-            Breadcrumb::TYPE_USER,
+            Breadcrumb::TYPE_DEFAULT,
             'queue.job',
             'Processing queue job',
             $job
@@ -406,7 +406,7 @@ class EventHandler
 
             Integration::addBreadcrumb(new Breadcrumb(
                 Breadcrumb::LEVEL_INFO,
-                Breadcrumb::TYPE_USER,
+                Breadcrumb::TYPE_DEFAULT,
                 'artisan.command',
                 'Invoked Artisan command: ' . $event->command,
                 method_exists($event->input, '__toString') ? [


### PR DESCRIPTION
Changed breadcrumb type for most handled events from user to default.

Closes #302 