### PR TITLE
Fix for default integrations not disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fix for default integrations not disabled (#327)
+
 ## 1.6.1
 
 - Fix queue events with missing handler suffix (#322)

--- a/test/Sentry/IntegrationsOptionTest.php
+++ b/test/Sentry/IntegrationsOptionTest.php
@@ -86,7 +86,7 @@ class IntegrationsOptionTest extends SentryLaravelTestCase
             $this->ensureIsNotDisabledIntegration($integration);
         }
 
-        $this->expectNotToPerformAssertions();
+        $this->assertTrue(true, 'Not all disabled integrations are actually disabled.');
     }
 
     public function testDisabledIntegrationsAreNotPresentWithCustomIntegrations()


### PR DESCRIPTION
This possibly results in duplicated exception/errors being reported in Sentry.

Since `getsentry/sentry-laravel:^1.6` and/or `getsentry/sentry:^2.3`.

As reported by @carestad on #261.