### PR TITLE
Discard Laravel 7 route cache generated route names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Discard Laravel 7 route cache generated route names (#337)
+
 ## 1.7.0
 
 - Support for Laravel 7 (#330)


### PR DESCRIPTION
This "fixes" Laravel 7 installations with optimized routes to report the transaction as `generated::5jWyeo1tUHxEoWwE` instead of `SomeController@action` or the `uri` as fallback.

We pretend the route name was not set if it starts with `generated::`.