### PR TITLE
Add `send_default_pii` to published config file

### DIFF
--- a/config/sentry.php
+++ b/config/sentry.php
@@ -21,5 +21,7 @@ return [
         'queue_info' => true,
     ],
 
-    'send_default_pii' => true,
+    // @see: https://docs.sentry.io/error-reporting/configuration/?platform=php#send-default-pii
+    'send_default_pii' => false,
+
 ];

--- a/config/sentry.php
+++ b/config/sentry.php
@@ -21,4 +21,5 @@ return [
         'queue_info' => true,
     ],
 
+    'send_default_pii' => true,
 ];


### PR DESCRIPTION
Hi,

This config change will send logged-in user id along with error.
This should be enabled by default.

If you guys don't want to enable this default, let's just keep this property in config file so that we (developers) can enable it without going into docs anytime.

Thanks.