### PR TITLE
Support for `SENTRY_ENVIRONMENT` environment variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Respect the `SENTRY_ENVIRONMENT` environment variable to override the Laravel environment (#354)
+
 ## 1.8.0
 
 - Add `send_default_pii` option by default to published config file (#340)

--- a/config/sentry.php
+++ b/config/sentry.php
@@ -7,7 +7,7 @@ return [
     // capture release as git sha
     // 'release' => trim(exec('git --git-dir ' . base_path('.git') . ' log --pretty="%h" -n1 HEAD')),
 
-    // By default the environment will be inferred from your Laravel application
+    // When left empty or `null` the Laravel environment will be used
     'environment' => env('SENTRY_ENVIRONMENT'),
 
     'breadcrumbs' => [

--- a/config/sentry.php
+++ b/config/sentry.php
@@ -7,6 +7,9 @@ return [
     // capture release as git sha
     // 'release' => trim(exec('git --git-dir ' . base_path('.git') . ' log --pretty="%h" -n1 HEAD')),
 
+    // By default the environment will be inferred from your Laravel application
+    'environment' => env('SENTRY_ENVIRONMENT'),
+
     'breadcrumbs' => [
         // Capture Laravel logs in breadcrumbs
         'logs' => true,

--- a/src/Sentry/Laravel/ServiceProvider.php
+++ b/src/Sentry/Laravel/ServiceProvider.php
@@ -114,12 +114,13 @@ class ServiceProvider extends IlluminateServiceProvider
 
             $options = \array_merge(
                 [
-                    'environment' => \env('SENTRY_ENVIRONMENT') ?? $this->app->environment(),
                     'prefixes' => [$basePath],
                     'in_app_exclude' => ["{$basePath}/vendor"],
                 ],
                 $userConfig
             );
+
+            $options['environment'] = $userConfig['environment'] ?? $this->app->environment();
 
             $clientBuilder = ClientBuilder::create($options);
 

--- a/src/Sentry/Laravel/ServiceProvider.php
+++ b/src/Sentry/Laravel/ServiceProvider.php
@@ -120,7 +120,10 @@ class ServiceProvider extends IlluminateServiceProvider
                 $userConfig
             );
 
-            $options['environment'] = $userConfig['environment'] ?? $this->app->environment();
+            // When we get no environment from the (user) configuration we default to the Laravel environment
+            if (empty($options['environment'])) {
+                $options['environment'] = $this->app->environment();
+            }
 
             $clientBuilder = ClientBuilder::create($options);
 

--- a/src/Sentry/Laravel/ServiceProvider.php
+++ b/src/Sentry/Laravel/ServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace Sentry\Laravel;
 
+use Illuminate\Support\Env;
 use Sentry\SentrySdk;
 use Sentry\State\Hub;
 use Sentry\ClientBuilder;
@@ -114,7 +115,7 @@ class ServiceProvider extends IlluminateServiceProvider
 
             $options = \array_merge(
                 [
-                    'environment' => $this->app->environment(),
+                    'environment' => Env::get('SENTRY_ENVIRONMENT') ?? $this->app->environment(),
                     'prefixes' => [$basePath],
                     'in_app_exclude' => ["{$basePath}/vendor"],
                 ],

--- a/src/Sentry/Laravel/ServiceProvider.php
+++ b/src/Sentry/Laravel/ServiceProvider.php
@@ -2,7 +2,6 @@
 
 namespace Sentry\Laravel;
 
-use Illuminate\Support\Env;
 use Sentry\SentrySdk;
 use Sentry\State\Hub;
 use Sentry\ClientBuilder;
@@ -115,7 +114,7 @@ class ServiceProvider extends IlluminateServiceProvider
 
             $options = \array_merge(
                 [
-                    'environment' => Env::get('SENTRY_ENVIRONMENT') ?? $this->app->environment(),
+                    'environment' => \env('SENTRY_ENVIRONMENT') ?? $this->app->environment(),
                     'prefixes' => [$basePath],
                     'in_app_exclude' => ["{$basePath}/vendor"],
                 ],

--- a/test/Sentry/ServiceProviderWithEnvironmentFromConfigTest.php
+++ b/test/Sentry/ServiceProviderWithEnvironmentFromConfigTest.php
@@ -5,11 +5,11 @@ namespace Sentry;
 use Sentry\Laravel\Facade;
 use Sentry\Laravel\ServiceProvider;
 
-class ServiceProviderWithEnvironmentFromEnvironmentTest extends \Orchestra\Testbench\TestCase
+class ServiceProviderWithEnvironmentFromConfigTest extends \Orchestra\Testbench\TestCase
 {
     protected function getEnvironmentSetUp($app)
     {
-        putenv('SENTRY_ENVIRONMENT=not_testing');
+        $app['config']->set('sentry.environment', 'not_testing');
     }
 
     protected function getPackageProviders($app)
@@ -26,7 +26,7 @@ class ServiceProviderWithEnvironmentFromEnvironmentTest extends \Orchestra\Testb
         ];
     }
 
-    public function testSentryEnvironmentDefaultGetsOverriddenByEnvironmentVariable()
+    public function testSentryEnvironmentDefaultGetsOverriddenByConfig()
     {
         $this->assertEquals('not_testing', app('sentry')->getClient()->getOptions()->getEnvironment());
     }

--- a/test/Sentry/ServiceProviderWithEnvironmentFromConfigTest.php
+++ b/test/Sentry/ServiceProviderWithEnvironmentFromConfigTest.php
@@ -2,32 +2,36 @@
 
 namespace Sentry;
 
-use Sentry\Laravel\Facade;
-use Sentry\Laravel\ServiceProvider;
+use Sentry\Laravel\Tests\SentryLaravelTestCase;
 
-class ServiceProviderWithEnvironmentFromConfigTest extends \Orchestra\Testbench\TestCase
+class ServiceProviderWithEnvironmentFromConfigTest extends SentryLaravelTestCase
 {
-    protected function getEnvironmentSetUp($app)
+    public function testSentryEnvironmentDefaultsToLaravelEnvironment()
     {
-        $app['config']->set('sentry.environment', 'not_testing');
+        $this->assertEquals('testing', app()->environment());
     }
 
-    protected function getPackageProviders($app)
+    public function testEmptySentryEnvironmentDefaultsToLaravelEnvironment()
     {
-        return [
-            ServiceProvider::class,
-        ];
-    }
+        $this->resetApplicationWithConfig([
+            'sentry.environment' => '',
+        ]);
 
-    protected function getPackageAliases($app)
-    {
-        return [
-            'Sentry' => Facade::class,
-        ];
+        $this->assertEquals('testing', $this->getHubFromContainer()->getClient()->getOptions()->getEnvironment());
+
+        $this->resetApplicationWithConfig([
+            'sentry.environment' => null,
+        ]);
+
+        $this->assertEquals('testing', $this->getHubFromContainer()->getClient()->getOptions()->getEnvironment());
     }
 
     public function testSentryEnvironmentDefaultGetsOverriddenByConfig()
     {
-        $this->assertEquals('not_testing', app('sentry')->getClient()->getOptions()->getEnvironment());
+        $this->resetApplicationWithConfig([
+            'sentry.environment' => 'not_testing',
+        ]);
+
+        $this->assertEquals('not_testing', $this->getHubFromContainer()->getClient()->getOptions()->getEnvironment());
     }
 }

--- a/test/Sentry/ServiceProviderWithEnvironmentFromEnvironmentTest.php
+++ b/test/Sentry/ServiceProviderWithEnvironmentFromEnvironmentTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Sentry;
+
+use Sentry\Laravel\Facade;
+use Sentry\Laravel\ServiceProvider;
+
+class ServiceProviderWithEnvironmentFromEnvironmentTest extends \Orchestra\Testbench\TestCase
+{
+    protected function getEnvironmentSetUp($app)
+    {
+        putenv('SENTRY_ENVIRONMENT=not_testing');
+    }
+
+    protected function getPackageProviders($app)
+    {
+        return [
+            ServiceProvider::class,
+        ];
+    }
+
+    protected function getPackageAliases($app)
+    {
+        return [
+            'Sentry' => Facade::class,
+        ];
+    }
+
+    public function testSentryEnvironmentDefaultGetsOverriddenByEnvironmentVariable()
+    {
+        $this->assertEquals('not_testing', app('sentry')->getClient()->getOptions()->getEnvironment());
+    }
+}


### PR DESCRIPTION
# Motivation

By default the PHP-SDK [uses the value of the `SENTRY_ENVIRONMENT` environment variable](https://docs.sentry.io/error-reporting/configuration/?platform=php#environment). In the Laravel-SDK this behaviour is overridden, as Laravel implements its own logic to set the environment. 

This makes a lot of sense, but there are certain scenarios where one might wants to have different values for the Sentry environment and the Application environment. For example the [`@production`-directive](https://laravel.com/docs/7.x/blade#if-statements) for Blade can only be properly used, [if you set the Laravel environment to `'production'`](https://github.com/laravel/framework/blob/7.x/src/Illuminate/View/Compilers/Concerns/CompilesConditionals.php#L78).

As an example, we often have the scenario at work, that we deploy a software release in multiple environments, but each environment runs in "production"-mode. We adjust the environment for Sentry to `'customer-abc'`, `'customer-xyz'` for each deployment individually, while the Laravel environment is set to`'production'` for all deployments.

We do this each time, by adding

```
'environment' => env('SENTRY_ENVIRONMENT'),
```

to our `config/sentry.php`-file every time, but I feel like this could be also useful for other users.

# Contents

This PR adjusts the defaults to respect the value of the `SENTRY_ENVIRONMENT` environment variable while still using the Laravel environment as a fallback. No breaking changes are introduced and this way this SDK behaves more like the underlying PHP-SDK.
