### PR TITLE
Performance beta improvements

### DIFF
--- a/src/Sentry/Laravel/EventHandler.php
+++ b/src/Sentry/Laravel/EventHandler.php
@@ -16,7 +16,6 @@ use Illuminate\Queue\Events\WorkerStopping;
 use Illuminate\Queue\QueueManager;
 use Illuminate\Routing\Events\RouteMatched;
 use Illuminate\Routing\Route;
-use Illuminate\Support\Str;
 use RuntimeException;
 use Sentry\Breadcrumb;
 use Sentry\SentrySdk;
@@ -195,33 +194,11 @@ class EventHandler
      */
     protected function routerMatchedHandler(Route $route)
     {
-        $routeName = null;
-
-        if ($route->getName()) {
-            // someaction (route name/alias)
-            $routeName = $route->getName();
-
-            // Laravel 7 route caching generates a route names if the user didn't specify one
-            // theirselfs to optimize route matching. These route names are useless to the
-            // developer so if we encounter a generated route name we discard the value
-            if (Str::startsWith($routeName, 'generated::')) {
-                $routeName = null;
-            }
-        }
-
-        if (empty($routeName) && $route->getActionName()) {
-            // SomeController@someAction (controller action)
-            $routeName = $route->getActionName();
-        } elseif (empty($routeName) || $routeName === 'Closure') {
-            // /someaction // Fallback to the url
-            $routeName = $route->uri();
-        }
-
         Integration::addBreadcrumb(new Breadcrumb(
             Breadcrumb::LEVEL_INFO,
             Breadcrumb::TYPE_NAVIGATION,
             'route',
-            $routeName
+            $routeName = Integration::extractNameForRoute($route)
         ));
 
         Integration::setTransaction($routeName);

--- a/src/Sentry/Laravel/Integration.php
+++ b/src/Sentry/Laravel/Integration.php
@@ -2,6 +2,8 @@
 
 namespace Sentry\Laravel;
 
+use Illuminate\Routing\Route;
+use Illuminate\Support\Str;
 use Sentry\FlushableClientInterface;
 use Sentry\SentrySdk;
 use function Sentry\addBreadcrumb;
@@ -33,7 +35,7 @@ class Integration implements IntegrationInterface
             if (null === $event->getTransaction()) {
                 $event->setTransaction($self->getTransaction());
             }
-            
+
             return $event;
         });
     }
@@ -99,5 +101,41 @@ class Integration implements IntegrationInterface
         if ($client instanceof FlushableClientInterface) {
             $client->flush();
         }
+    }
+
+    /**
+     * Extract the name for the route.
+     *
+     * @param \Illuminate\Routing\Route $route
+     *
+     * @return string|null
+     */
+    public static function extractNameForRoute(Route $route)
+    {
+        $routeName = null;
+
+        if ($route->getName()) {
+            // someaction (route name/alias)
+            $routeName = $route->getName();
+
+            // Laravel 7 route caching generates a route names if the user didn't specify one
+            // theirselfs to optimize route matching. These route names are useless to the
+            // developer so if we encounter a generated route name we discard the value
+            if (Str::startsWith($routeName, 'generated::')) {
+                $routeName = null;
+            }
+        }
+
+        if (empty($routeName) && $route->getActionName()) {
+            // SomeController@someAction (controller action)
+            $routeName = $route->getActionName();
+        }
+
+        if (empty($routeName) || $routeName === 'Closure') {
+            // /someaction // Fallback to the url
+            $routeName = $route->uri();
+        }
+
+        return $routeName;
     }
 }

--- a/src/Sentry/Laravel/ServiceProvider.php
+++ b/src/Sentry/Laravel/ServiceProvider.php
@@ -30,6 +30,8 @@ class ServiceProvider extends IlluminateServiceProvider
 
     /**
      * Boot the service provider.
+     *
+     * @param \Illuminate\Contracts\Foundation\Application $application
      */
     public function boot(Application $application): void
     {

--- a/src/Sentry/Laravel/TracingMiddleware.php
+++ b/src/Sentry/Laravel/TracingMiddleware.php
@@ -80,18 +80,28 @@ class TracingMiddleware
 
     private function addBootTimeSpans(Transaction $transaction): void
     {
-        if (LARAVEL_START && SENTRY_AUTOLOAD && SENTRY_BOOTSTRAP) {
-            $spanContextStart = new SpanContext();
-            $spanContextStart->op = 'autoload';
-            $spanContextStart->startTimestamp = LARAVEL_START;
-            $spanContextStart->endTimestamp = SENTRY_AUTOLOAD;
-            $transaction->startChild($spanContextStart);
-
-            $spanContextStart = new SpanContext();
-            $spanContextStart->op = 'bootstrap';
-            $spanContextStart->startTimestamp = SENTRY_AUTOLOAD;
-            $spanContextStart->endTimestamp = SENTRY_BOOTSTRAP;
-            $transaction->startChild($spanContextStart);
+        if (!defined('LARAVEL_START') || !LARAVEL_START) {
+            return;
         }
+
+        if (!defined('SENTRY_AUTOLOAD') || !SENTRY_AUTOLOAD) {
+            return;
+        }
+
+        if (!defined('SENTRY_BOOTSTRAP') || !SENTRY_BOOTSTRAP) {
+            return;
+        }
+
+        $spanContextStart = new SpanContext();
+        $spanContextStart->op = 'autoload';
+        $spanContextStart->endTimestamp = SENTRY_AUTOLOAD;
+        $spanContextStart->startTimestamp = LARAVEL_START;
+        $transaction->startChild($spanContextStart);
+
+        $spanContextStart = new SpanContext();
+        $spanContextStart->op = 'bootstrap';
+        $spanContextStart->endTimestamp = SENTRY_BOOTSTRAP;
+        $spanContextStart->startTimestamp = SENTRY_AUTOLOAD;
+        $transaction->startChild($spanContextStart);
     }
 }

--- a/src/Sentry/Laravel/TracingViewEngineDecorator.php
+++ b/src/Sentry/Laravel/TracingViewEngineDecorator.php
@@ -10,7 +10,7 @@ use Sentry\SentrySdk;
 use Sentry\State\Scope;
 use Sentry\Tracing\SpanContext;
 
-final class ViewEngineDecorator implements Engine
+final class TracingViewEngineDecorator implements Engine
 {
     public const SHARED_KEY = '__sentry_tracing_view_name';
 


### PR DESCRIPTION
Fixes:

- Route name like `users/1` instead of `/users/{id}`
- Fixes routes reports as `GET //` instead of `GET /`
- Crashes when missing `SENTRY_AUTOLOAD` and/or `SENTRY_BOOTSTRAP` defines