### PR TITLE
feat: Add publish command

### DIFF
--- a/config/sentry.php
+++ b/config/sentry.php
@@ -30,5 +30,5 @@ return [
     // @see: https://docs.sentry.io/error-reporting/configuration/?platform=php#send-default-pii
     'send_default_pii' => false,
 
-    'traces_sample_rate' => 0,
+    'traces_sample_rate' => \floatval(env('SENTRY_TRACES_SAMPLE_RATE', 0.0)),
 ];

--- a/src/Sentry/Laravel/PublishConfigCommand.php
+++ b/src/Sentry/Laravel/PublishConfigCommand.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Sentry\Laravel;
+
+use Illuminate\Console\Command;
+
+class PublishConfigCommand extends Command
+{
+    /**
+     * Laravel 5.0.x: The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $name = 'sentry:publish';
+
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'sentry:publish';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Publishes the Sentry Config';
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        $this->info('[Sentry] Publishing config ...');
+        $this->call('vendor:publish', [
+            '--provider' => 'Sentry\Laravel\ServiceProvider'
+        ]);
+
+        if ($this->confirm('Enable Performance Monitoring?', true)) {
+            $this->setEnvironmentValue(['SENTRY_TRACES_SAMPLE_RATE' => 1.0]);
+
+            $this->info('[Sentry] Added `SENTRY_TRACES_SAMPLE_RATE=1` to you env file.');
+
+            $testCommandPrompt = 'Want to send a test Event & Transaction?';
+            $args = ['--transaction' => true];
+        } else {
+            $testCommandPrompt = 'Want to send a test Event?';
+            $args = [];
+        }
+
+        if ($this->confirm($testCommandPrompt, true)) {
+            $this->call('sentry:test', $args);
+        }
+    }
+
+    public function setEnvironmentValue(array $values)
+    {
+        $envFile = app()->environmentFilePath();
+        $str = file_get_contents($envFile);
+
+        if (count($values) > 0) {
+            foreach ($values as $envKey => $envValue) {
+
+                $str .= "\n"; // In case the searched variable is in the last line without \n
+                $keyPosition = strpos($str, "{$envKey}=");
+                $endOfLinePosition = strpos($str, "\n", $keyPosition);
+                $oldLine = substr($str, $keyPosition, $endOfLinePosition - $keyPosition);
+
+                // If key does not exist, add it
+                if (!$keyPosition || !$endOfLinePosition || !$oldLine) {
+                    $str .= "{$envKey}={$envValue}\n";
+                } else {
+                    $str = str_replace($oldLine, "{$envKey}={$envValue}", $str);
+                }
+
+            }
+        }
+
+        $str = substr($str, 0, -1);
+        if (!file_put_contents($envFile, $str)) return false;
+        return true;
+    }
+}

--- a/src/Sentry/Laravel/PublishConfigCommand.php
+++ b/src/Sentry/Laravel/PublishConfigCommand.php
@@ -42,7 +42,7 @@ class PublishConfigCommand extends Command
         if ($this->confirm('Enable Performance Monitoring?', true)) {
             $this->setEnvironmentValue(['SENTRY_TRACES_SAMPLE_RATE' => 1.0]);
 
-            $this->info('[Sentry] Added `SENTRY_TRACES_SAMPLE_RATE=1` to you env file.');
+            $this->info('[Sentry] Added `SENTRY_TRACES_SAMPLE_RATE=1` to your .env file.');
 
             $testCommandPrompt = 'Want to send a test Event & Transaction?';
             $args = ['--transaction' => true];

--- a/src/Sentry/Laravel/ServiceProvider.php
+++ b/src/Sentry/Laravel/ServiceProvider.php
@@ -13,6 +13,7 @@ use Laravel\Lumen\Application as Lumen;
 use Sentry\Integration as SdkIntegration;
 use Illuminate\Foundation\Application as Laravel;
 use Illuminate\Support\ServiceProvider as IlluminateServiceProvider;
+use Illuminate\Support\Facades\Storage;
 
 class ServiceProvider extends IlluminateServiceProvider
 {
@@ -92,6 +93,7 @@ class ServiceProvider extends IlluminateServiceProvider
     {
         $this->commands([
             TestCommand::class,
+            PublishConfigCommand::class,
         ]);
     }
 


### PR DESCRIPTION
This will help users with onboarding and enabling Performance monitoring.

They only need to run `php artisan sentry:publish` after installation and they will get this:

![CleanShot 2020-09-10 at 14 49 29](https://user-images.githubusercontent.com/363802/92731099-f0cdda80-f374-11ea-96f1-f5af1c05a8e9.gif)
