### PR TITLE
Improve tracing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Improve performance tracing by nesting `view.render` spans and adding a `app.handle` span showing how long the actual application code runs after Laravel bootstrapping (#387)
+
 ## 2.0.0
 
 **Breaking Change**: This version uses the [envelope endpoint](https://develop.sentry.dev/sdk/envelopes/). If you are

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,8 @@
     "phpunit/phpunit": "^8.0",
     "laravel/framework": "^7.0",
     "orchestra/testbench": "^5.0",
-    "friendsofphp/php-cs-fixer": "2.16.*"
+    "friendsofphp/php-cs-fixer": "2.16.*",
+    "mockery/mockery": "1.3.*"
   },
   "autoload": {
     "psr-0": {

--- a/src/Sentry/Laravel/BaseServiceProvider.php
+++ b/src/Sentry/Laravel/BaseServiceProvider.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Sentry\Laravel;
+
+use Illuminate\Support\ServiceProvider;
+
+abstract class BaseServiceProvider extends ServiceProvider
+{
+    /**
+     * Abstract type to bind Sentry as in the Service Container.
+     *
+     * @var string
+     */
+    public static $abstract = 'sentry';
+
+    /**
+     * Check if a DSN was set in the config.
+     *
+     * @return bool
+     */
+    protected function hasDsnSet(): bool
+    {
+        $config = $this->getUserConfig();
+
+        return !empty($config['dsn']);
+    }
+
+    /**
+     * Retrieve the user configuration.
+     *
+     * @return array
+     */
+    protected function getUserConfig(): array
+    {
+        $config = $this->app['config'][static::$abstract];
+
+        return empty($config) ? [] : $config;
+    }
+}

--- a/src/Sentry/Laravel/EventHandler.php
+++ b/src/Sentry/Laravel/EventHandler.php
@@ -278,14 +278,16 @@ class EventHandler
             $data['bindings'] = $bindings;
         }
 
-        $transaction = SentrySdk::getCurrentHub()->getTransaction();
-        if (null !== $transaction) {
+        $parentSpan = Integration::currentTracingSpan();
+
+        if (null !== $parentSpan) {
             $context = new SpanContext();
             $context->setOp('sql.query');
             $context->setDescription($query);
             $context->setStartTimestamp(microtime(true) - $time / 1000);
             $context->setEndTimestamp($context->getStartTimestamp() + $time / 1000);
-            $transaction->startChild($context);
+
+            $parentSpan->startChild($context);
         }
 
         Integration::addBreadcrumb(new Breadcrumb(

--- a/src/Sentry/Laravel/EventHandler.php
+++ b/src/Sentry/Laravel/EventHandler.php
@@ -20,8 +20,6 @@ use RuntimeException;
 use Sentry\Breadcrumb;
 use Sentry\SentrySdk;
 use Sentry\State\Scope;
-use Sentry\Tracing\SpanContext;
-use Sentry\Tracing\Transaction;
 
 class EventHandler
 {
@@ -197,16 +195,6 @@ class EventHandler
     {
         $routeName = Integration::extractNameForRoute($route) ?? '<unlabeled transaction>';
 
-        $transaction = SentrySdk::getCurrentHub()->getTransaction();
-
-        if ($transaction instanceof Transaction) {
-            $transaction->setName($routeName);
-            $transaction->setData([
-                'action' => $route->getActionName(),
-                'name' => $route->getName()
-            ]);
-        }
-
         Integration::addBreadcrumb(new Breadcrumb(
             Breadcrumb::LEVEL_INFO,
             Breadcrumb::TYPE_NAVIGATION,
@@ -276,18 +264,6 @@ class EventHandler
 
         if ($this->recordSqlBindings) {
             $data['bindings'] = $bindings;
-        }
-
-        $parentSpan = Integration::currentTracingSpan();
-
-        if (null !== $parentSpan) {
-            $context = new SpanContext();
-            $context->setOp('sql.query');
-            $context->setDescription($query);
-            $context->setStartTimestamp(microtime(true) - $time / 1000);
-            $context->setEndTimestamp($context->getStartTimestamp() + $time / 1000);
-
-            $parentSpan->startChild($context);
         }
 
         Integration::addBreadcrumb(new Breadcrumb(

--- a/src/Sentry/Laravel/PublishConfigCommand.php
+++ b/src/Sentry/Laravel/PublishConfigCommand.php
@@ -63,7 +63,6 @@ class PublishConfigCommand extends Command
 
         if (count($values) > 0) {
             foreach ($values as $envKey => $envValue) {
-
                 $str .= "\n"; // In case the searched variable is in the last line without \n
                 $keyPosition = strpos($str, "{$envKey}=");
                 $endOfLinePosition = strpos($str, "\n", $keyPosition);
@@ -75,12 +74,13 @@ class PublishConfigCommand extends Command
                 } else {
                     $str = str_replace($oldLine, "{$envKey}={$envValue}", $str);
                 }
-
             }
         }
 
         $str = substr($str, 0, -1);
-        if (!file_put_contents($envFile, $str)) return false;
+        if (!file_put_contents($envFile, $str)) {
+            return false;
+        }
         return true;
     }
 }

--- a/src/Sentry/Laravel/ServiceProvider.php
+++ b/src/Sentry/Laravel/ServiceProvider.php
@@ -2,7 +2,6 @@
 
 namespace Sentry\Laravel;
 
-use Illuminate\Contracts\Http\Kernel as HttpKernelInterface;
 use Sentry\SentrySdk;
 use Sentry\State\Hub;
 use Sentry\ClientBuilder;
@@ -12,18 +11,9 @@ use Sentry\ClientBuilderInterface;
 use Laravel\Lumen\Application as Lumen;
 use Sentry\Integration as SdkIntegration;
 use Illuminate\Foundation\Application as Laravel;
-use Illuminate\Support\ServiceProvider as IlluminateServiceProvider;
-use Illuminate\Support\Facades\Storage;
 
-class ServiceProvider extends IlluminateServiceProvider
+class ServiceProvider extends BaseServiceProvider
 {
-    /**
-     * Abstract type to bind Sentry as in the Service Container.
-     *
-     * @var string
-     */
-    public static $abstract = 'sentry';
-
     /**
      * Boot the service provider.
      */
@@ -183,18 +173,6 @@ class ServiceProvider extends IlluminateServiceProvider
     }
 
     /**
-     * Check if a DSN was set in the config.
-     *
-     * @return bool
-     */
-    protected function hasDsnSet(): bool
-    {
-        $config = $this->getUserConfig();
-
-        return !empty($config['dsn']);
-    }
-
-    /**
      * Resolve the integrations from the user configuration with the container.
      *
      * @return array
@@ -222,18 +200,6 @@ class ServiceProvider extends IlluminateServiceProvider
         }
 
         return $integrations;
-    }
-
-    /**
-     * Retrieve the user configuration.
-     *
-     * @return array
-     */
-    private function getUserConfig(): array
-    {
-        $config = $this->app['config'][static::$abstract];
-
-        return empty($config) ? [] : $config;
     }
 
     /**

--- a/src/Sentry/Laravel/Tracing/EventHandler.php
+++ b/src/Sentry/Laravel/Tracing/EventHandler.php
@@ -71,7 +71,7 @@ class EventHandler
 
         $parentSpan = Integration::currentTracingSpan();
 
-        // If there is no tracing span active there is no need to handle the even
+        // If there is no tracing span active there is no need to handle the event
         if ($parentSpan === null) {
             return;
         }

--- a/src/Sentry/Laravel/Tracing/EventHandler.php
+++ b/src/Sentry/Laravel/Tracing/EventHandler.php
@@ -1,0 +1,157 @@
+<?php
+
+namespace Sentry\Laravel\Tracing;
+
+use Exception;
+use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Database\Events\QueryExecuted;
+use Illuminate\Routing\Events\RouteMatched;
+use Illuminate\Routing\Route;
+use RuntimeException;
+use Sentry\Laravel\Integration;
+use Sentry\SentrySdk;
+use Sentry\Tracing\SpanContext;
+use Sentry\Tracing\Transaction;
+
+class EventHandler
+{
+    /**
+     * Map event handlers to events.
+     *
+     * @var array
+     */
+    protected static $eventHandlerMap = [
+        'router.matched'    => 'routerMatched',  // Until Laravel 5.1
+        RouteMatched::class => 'routeMatched',   // Since Laravel 5.2
+
+        'illuminate.query'   => 'query',         // Until Laravel 5.1
+        QueryExecuted::class => 'queryExecuted', // Since Laravel 5.2
+    ];
+
+    /**
+     * The Laravel event dispatcher.
+     *
+     * @var \Illuminate\Contracts\Events\Dispatcher
+     */
+    private $events;
+
+    /**
+     * EventHandler constructor.
+     *
+     * @param \Illuminate\Contracts\Events\Dispatcher $events
+     */
+    public function __construct(Dispatcher $events)
+    {
+        $this->events = $events;
+    }
+
+    /**
+     * Attach all event handlers.
+     */
+    public function subscribe(): void
+    {
+        foreach (static::$eventHandlerMap as $eventName => $handler) {
+            $this->events->listen($eventName, [$this, $handler]);
+        }
+    }
+
+    /**
+     * Pass through the event and capture any errors.
+     *
+     * @param string $method
+     * @param array  $arguments
+     */
+    public function __call($method, $arguments)
+    {
+        $handlerMethod = $handlerMethod = "{$method}Handler";
+
+        if (!method_exists($this, $handlerMethod)) {
+            throw new RuntimeException("Missing tracing event handler: {$handlerMethod}");
+        }
+
+        $parentSpan = Integration::currentTracingSpan();
+
+        // If there is no tracing span active there is no need to handle the even
+        if ($parentSpan === null) {
+            return;
+        }
+
+        try {
+            call_user_func_array([$this, $handlerMethod], $arguments);
+        } catch (Exception $exception) {
+            // Ignore
+        }
+    }
+
+    /**
+     * Until Laravel 5.1
+     *
+     * @param \Illuminate\Routing\Route $route
+     */
+    protected function routerMatchedHandler(Route $route): void
+    {
+        $transaction = SentrySdk::getCurrentHub()->getTransaction();
+
+        if ($transaction instanceof Transaction) {
+            $routeName = Integration::extractNameForRoute($route) ?? '<unlabeled transaction>';
+
+            $transaction->setName($routeName);
+            $transaction->setData([
+                'action' => $route->getActionName(),
+                'name'   => $route->getName(),
+            ]);
+        }
+    }
+
+    /**
+     * Since Laravel 5.2
+     *
+     * @param \Illuminate\Routing\Events\RouteMatched $match
+     */
+    protected function routeMatchedHandler(RouteMatched $match): void
+    {
+        $this->routerMatchedHandler($match->route);
+    }
+
+    /**
+     * Until Laravel 5.1
+     *
+     * @param string $query
+     * @param array  $bindings
+     * @param int    $time
+     * @param string $connectionName
+     */
+    protected function queryHandler($query, $bindings, $time, $connectionName): void
+    {
+        $this->recordQuerySpan($query, $time);
+    }
+
+    /**
+     * Since Laravel 5.2
+     *
+     * @param \Illuminate\Database\Events\QueryExecuted $query
+     */
+    protected function queryExecutedHandler(QueryExecuted $query): void
+    {
+        $this->recordQuerySpan($query->sql, $query->time);
+    }
+
+    /**
+     * Helper to add an query breadcrumb.
+     *
+     * @param string     $query
+     * @param float|null $time
+     */
+    private function recordQuerySpan($query, $time): void
+    {
+        $parentSpan = Integration::currentTracingSpan();
+
+        $context = new SpanContext();
+        $context->setOp('sql.query');
+        $context->setDescription($query);
+        $context->setStartTimestamp(microtime(true) - $time / 1000);
+        $context->setEndTimestamp($context->getStartTimestamp() + $time / 1000);
+
+        $parentSpan->startChild($context);
+    }
+}

--- a/src/Sentry/Laravel/Tracing/Middleware.php
+++ b/src/Sentry/Laravel/Tracing/Middleware.php
@@ -4,6 +4,7 @@ namespace Sentry\Laravel\Tracing;
 
 use Closure;
 use Illuminate\Http\Request;
+use Illuminate\Http\Response;
 use Sentry\SentrySdk;
 use Sentry\State\Hub;
 use Sentry\Tracing\SpanContext;
@@ -59,6 +60,10 @@ class Middleware
 
             // Make sure we set the span in the Sentry SDK to the transaction
             SentrySdk::getCurrentHub()->setSpan($this->transaction);
+
+            if ($response instanceof Response) {
+                $this->transaction->setHttpStatus($response->status());
+            }
 
             $this->transaction->finish();
         }

--- a/src/Sentry/Laravel/Tracing/Middleware.php
+++ b/src/Sentry/Laravel/Tracing/Middleware.php
@@ -58,7 +58,8 @@ class Middleware
                 $this->appSpan->finish();
             }
 
-            // Make sure we set the span in the Sentry SDK to the transaction
+            // Make sure we set the transaction and not have a child span in the Sentry SDK
+            // If the transaction is not on the scope during finish, the trace.context is wrong
             SentrySdk::getCurrentHub()->setSpan($this->transaction);
 
             if ($response instanceof Response) {

--- a/src/Sentry/Laravel/Tracing/ServiceProvider.php
+++ b/src/Sentry/Laravel/Tracing/ServiceProvider.php
@@ -53,7 +53,6 @@ class ServiceProvider extends IlluminateServiceProvider
         /** @var ViewFactory $viewFactory */
         $viewFactory = $this->app->make('view');
 
-        /** @noinspection UnusedFunctionResultInspection */
         $viewFactory->composer('*', static function (View $view) use ($viewFactory) : void {
             $viewFactory->share(ViewEngineDecorator::SHARED_KEY, $view->name());
         });

--- a/src/Sentry/Laravel/Tracing/ServiceProvider.php
+++ b/src/Sentry/Laravel/Tracing/ServiceProvider.php
@@ -5,26 +5,42 @@ namespace Sentry\Laravel\Tracing;
 use Illuminate\Contracts\Http\Kernel as HttpKernelInterface;
 use Illuminate\Contracts\View\Engine;
 use Illuminate\Contracts\View\View;
-use Illuminate\Support\ServiceProvider as IlluminateServiceProvider;
 use Illuminate\View\Engines\EngineResolver;
 use Illuminate\View\Factory as ViewFactory;
+use Sentry\Laravel\BaseServiceProvider;
 
-class ServiceProvider extends IlluminateServiceProvider
+class ServiceProvider extends BaseServiceProvider
 {
     public function boot(): void
     {
-        if ($this->app->bound(HttpKernelInterface::class)) {
-            /** @var \Illuminate\Contracts\Http\Kernel $httpKernel */
-            $httpKernel = $this->app->make(HttpKernelInterface::class);
+        if ($this->hasDsnSet()) {
+            $this->bindEvents($this->app);
 
-            $httpKernel->prependMiddleware(Middleware::class);
+            $this->bindViewEngine();
+
+            if ($this->app->bound(HttpKernelInterface::class)) {
+                /** @var \Illuminate\Contracts\Http\Kernel $httpKernel */
+                $httpKernel = $this->app->make(HttpKernelInterface::class);
+
+                $httpKernel->prependMiddleware(Middleware::class);
+            }
         }
     }
 
     public function register(): void
     {
         $this->app->singleton(Middleware::class);
+    }
 
+    private function bindEvents(): void
+    {
+        $handler = new EventHandler($this->app->events);
+
+        $handler->subscribe();
+    }
+
+    private function bindViewEngine(): void
+    {
         $viewEngineWrapper = function (EngineResolver $engineResolver): void {
             foreach (['file', 'php', 'blade'] as $engineName) {
                 try {

--- a/src/Sentry/Laravel/Tracing/ViewEngineDecorator.php
+++ b/src/Sentry/Laravel/Tracing/ViewEngineDecorator.php
@@ -1,12 +1,12 @@
 <?php
 
-
 namespace Sentry\Laravel\Tracing;
 
 use Illuminate\Contracts\View\Engine;
 use Illuminate\View\Compilers\CompilerInterface;
 use Illuminate\View\Factory;
 use Sentry\Laravel\Integration;
+use Sentry\SentrySdk;
 use Sentry\Tracing\SpanContext;
 
 final class ViewEngineDecorator implements Engine
@@ -42,15 +42,22 @@ final class ViewEngineDecorator implements Engine
 
         $span = $parentSpan->startChild($context);
 
+        $scope = SentrySdk::getCurrentHub()->pushScope();
+        $scope->setSpan($span);
+
         $result = $this->engine->get($path, $data);
 
         $span->finish();
+
+        SentrySdk::getCurrentHub()->popScope();
 
         return $result;
     }
 
     /**
-     * Laravel uses this function internally
+     * Laravel uses this function internally.
+     *
+     * @internal
      */
     public function getCompiler(): CompilerInterface
     {

--- a/test/Sentry/Tracing/EventHandlerTest.php
+++ b/test/Sentry/Tracing/EventHandlerTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Sentry\Laravel\Tests\Tracing;
+
+use ReflectionClass;
+use Orchestra\Testbench\TestCase;
+use Sentry\Laravel\Tracing\EventHandler;
+use Sentry\SentrySdk;
+use Sentry\Tracing\TransactionContext;
+
+class EventHandlerTest extends TestCase
+{
+    /**
+     * @expectedException \RuntimeException
+     */
+    public function test_missing_event_handler_throws_exception()
+    {
+        $handler = new EventHandler($this->app->events);
+
+        $handler->thisIsNotAHandlerAndShouldThrowAnException();
+    }
+
+    public function test_all_mapped_event_handlers_exist()
+    {
+        $this->tryAllEventHandlerMethods(
+            $this->getStaticPropertyValueFromClass(EventHandler::class, 'eventHandlerMap')
+        );
+    }
+
+    public function test_handlers_are_not_called_when_no_transaction()
+    {
+        SentrySdk::getCurrentHub()->setSpan(null);
+
+        $eventHandlerMock = $this->mock(EventHandler::class)->makePartial();
+
+        $eventHandlerMock->shouldReceive('__call')->withArgs(['queryHandler', []]);
+
+        $eventHandlerMock->query();
+    }
+
+    public function test_handlers_are_called_when_transaction_is_present()
+    {
+        $transaction = SentrySdk::getCurrentHub()->startTransaction(new TransactionContext());
+        SentrySdk::getCurrentHub()->setSpan($transaction);
+
+        $eventHandlerMock = $this->mock(EventHandler::class)->makePartial()->shouldAllowMockingProtectedMethods();
+
+        $eventHandlerMock->shouldReceive('queryHandler')->withArgs(['', [], 0, ''])->once();
+
+        $eventHandlerMock->query('', [], 0, '');
+    }
+
+    private function tryAllEventHandlerMethods(array $methods): void
+    {
+        $handler = new EventHandler($this->app->events, []);
+
+        $methods = array_map(static function ($method) {
+            return "{$method}Handler";
+        }, array_unique(array_values($methods)));
+
+        foreach ($methods as $handlerMethod) {
+            $this->assertTrue(method_exists($handler, $handlerMethod));
+        }
+    }
+
+    private function getStaticPropertyValueFromClass($className, $attributeName)
+    {
+        $class = new ReflectionClass($className);
+
+        $attributes = $class->getStaticProperties();
+
+        return $attributes[$attributeName];
+    }
+}

--- a/test/Sentry/Tracing/EventHandlerTest.php
+++ b/test/Sentry/Tracing/EventHandlerTest.php
@@ -2,6 +2,7 @@
 
 namespace Sentry\Laravel\Tests\Tracing;
 
+use Mockery;
 use ReflectionClass;
 use Orchestra\Testbench\TestCase;
 use Sentry\Laravel\Tracing\EventHandler;
@@ -31,7 +32,7 @@ class EventHandlerTest extends TestCase
     {
         SentrySdk::getCurrentHub()->setSpan(null);
 
-        $eventHandlerMock = $this->mock(EventHandler::class)->makePartial();
+        $eventHandlerMock = Mockery::mock(EventHandler::class)->makePartial();
 
         $eventHandlerMock->shouldReceive('__call')->withArgs(['queryHandler', []]);
 
@@ -43,7 +44,7 @@ class EventHandlerTest extends TestCase
         $transaction = SentrySdk::getCurrentHub()->startTransaction(new TransactionContext());
         SentrySdk::getCurrentHub()->setSpan($transaction);
 
-        $eventHandlerMock = $this->mock(EventHandler::class)->makePartial()->shouldAllowMockingProtectedMethods();
+        $eventHandlerMock = Mockery::mock(EventHandler::class)->makePartial()->shouldAllowMockingProtectedMethods();
 
         $eventHandlerMock->shouldReceive('queryHandler')->withArgs(['', [], 0, ''])->once();
 


### PR DESCRIPTION
- [x] Nest `view.render` spans
- [x] Nest `sql.query` spans
- [x] Add 2 child spans to `http.server`
  - [x] `app.bootstrap` the Laravel bootstrap process
  - [x] `app.handle` (please suggest a better name) which will have all other spans that are generated by the user application as childs
- [x] Only boot the tracing provider if there was a hint of a DSN (like the Sentry SDK itself)
- [x] Move all tracing related events to it's own event handler

Current state:

![image](https://user-images.githubusercontent.com/1090754/94535048-62e16300-0241-11eb-8a31-6870e02749d3.png)