### PR TITLE
Disable tracing on empty `traces_sample_rate`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Improve performance tracing by nesting `view.render` spans and adding a `app.handle` span showing how long the actual application code runs after Laravel bootstrapping (#387)
+- Disable tracing on empty `traces_sample_rate` (#390)
 
 ## 2.0.0
 

--- a/src/Sentry/Laravel/BaseServiceProvider.php
+++ b/src/Sentry/Laravel/BaseServiceProvider.php
@@ -36,4 +36,17 @@ abstract class BaseServiceProvider extends ServiceProvider
 
         return empty($config) ? [] : $config;
     }
+
+    /**
+     * Check if tracing was enabled in the config.
+     *
+     * @return bool
+     */
+    protected function hasTracingEnabled(): bool
+    {
+        $config = $this->getUserConfig();
+
+        // We would expect a `0.0` which is considered `empty` when tracing should be disabled
+        return !empty($config['traces_sample_rate']);
+    }
 }

--- a/src/Sentry/Laravel/Tracing/ServiceProvider.php
+++ b/src/Sentry/Laravel/Tracing/ServiceProvider.php
@@ -13,7 +13,7 @@ class ServiceProvider extends BaseServiceProvider
 {
     public function boot(): void
     {
-        if ($this->hasDsnSet()) {
+        if ($this->hasDsnSet() && $this->hasTracingEnabled()) {
             $this->bindEvents($this->app);
 
             $this->bindViewEngine();


### PR DESCRIPTION
Noticed we can probably disable the tracing completely if the `traces_sample_rate` is `0.0` since there would be no chance to send a trace to Sentry which would negate any performance impact the tracing code could have on an application.

Looking at this code do we want to collect the trace data anyway even if we already know the sample rate is 0 and thus the trace will not be sent or is the `traces_sampler` option supposed to be able to override that later? Because then this PR might not be good...

Bottom line, if the `traces_sample_rate === 0.0` should we even collect tracing data?
Yes = Merge, No = Close 😉 