### PR TITLE
feat: Improve publish command

### DIFF
--- a/src/Sentry/Laravel/PublishConfigCommand.php
+++ b/src/Sentry/Laravel/PublishConfigCommand.php
@@ -19,7 +19,7 @@ class PublishConfigCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'sentry:publish';
+    protected $signature = 'sentry:publish {--dsn=}';
 
     /**
      * The console command description.
@@ -42,10 +42,10 @@ class PublishConfigCommand extends Command
 
         $args = [];
 
-        $dsn = '';
+        $dsn = $this->option('dsn');
 
         if (!$this->isKeySet('SENTRY_LARAVEL_DSN')) {
-            do {
+            while (empty($dsn)) {
                 $this->info('');
                 $this->question('[Sentry] Please paste the DSN here');
                 $dsn = $this->ask('DSN');
@@ -59,9 +59,10 @@ class PublishConfigCommand extends Command
                     $dsn = '';
                     continue;
                 }
-                $this->setEnvironmentValue(['SENTRY_LARAVEL_DSN' => $dsn]);
-                $args = array_merge($args, ['--dsn' => $dsn]);
-            } while (empty($dsn));
+            };
+
+            $this->setEnvironmentValue(['SENTRY_LARAVEL_DSN' => $dsn]);
+            $args = array_merge($args, ['--dsn' => $dsn]);
         }
 
         if ($this->confirm('Enable Performance Monitoring?', true)) {

--- a/src/Sentry/Laravel/TestCommand.php
+++ b/src/Sentry/Laravel/TestCommand.php
@@ -21,7 +21,7 @@ class TestCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'sentry:test {--transaction}';
+    protected $signature = 'sentry:test {--transaction} {--dsn}';
 
     /**
      * The console command description.
@@ -43,6 +43,10 @@ class TestCommand extends Command
         try {
             /** @var \Sentry\State\Hub $hub */
             $hub = app('sentry');
+
+            if ($this->option('dsn')) {
+                $hub->getClient()->getOptions()->setDsn($this->option('dsn'));
+            }
 
             if ($hub->getClient()->getOptions()->getDsn()) {
                 $this->info('[Sentry] DSN discovered!');

--- a/src/Sentry/Laravel/TestCommand.php
+++ b/src/Sentry/Laravel/TestCommand.php
@@ -4,6 +4,8 @@ namespace Sentry\Laravel;
 
 use Exception;
 use Illuminate\Console\Command;
+use Sentry\ClientBuilder;
+use Sentry\State\Hub;
 use Sentry\Tracing\SpanContext;
 use Sentry\Tracing\TransactionContext;
 
@@ -21,7 +23,7 @@ class TestCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'sentry:test {--transaction} {--dsn}';
+    protected $signature = 'sentry:test {--transaction} {--dsn=}';
 
     /**
      * The console command description.
@@ -45,7 +47,7 @@ class TestCommand extends Command
             $hub = app('sentry');
 
             if ($this->option('dsn')) {
-                $hub->getClient()->getOptions()->setDsn($this->option('dsn'));
+                $hub = new Hub(ClientBuilder::create(['dsn' => $this->option('dsn')])->getClient());
             }
 
             if ($hub->getClient()->getOptions()->getDsn()) {
@@ -74,23 +76,22 @@ class TestCommand extends Command
 
             $ex = $this->generateTestException('command name', ['foo' => 'bar']);
 
-            $hub->captureException($ex);
+            $eventId = $hub->captureException($ex);
 
             $this->info('[Sentry] Sending test Event');
 
             $span1->finish();
             $result = $transaction->finish();
             if ($result) {
-                $this->info('[Sentry] Sending test Transaction');
+                $this->info("[Sentry] Transaction sent: {$result}");
             }
 
-            $lastEventId = $hub->getLastEventId();
 
-            if (!$lastEventId) {
+            if (!$eventId) {
                 $this->error('[Sentry] There was an error sending the test event.');
                 $this->error('[Sentry] Please check if you DSN is set properly in your config or `.env` as `SENTRY_LARAVEL_DSN`.');
             } else {
-                $this->info("[Sentry] Event sent with ID: {$lastEventId}");
+                $this->info("[Sentry] Event sent with ID: {$eventId}");
             }
         } catch (Exception $e) {
             $this->error("[Sentry] {$e->getMessage()}");


### PR DESCRIPTION
https://github.com/getsentry/sentry-docs/pull/2405

The command now accepts `--dsn=` so it can be run like `php artisan sentry:publish --dsn=___PUBLIC_DSN___`

If no DSN is provided as an argument it will ask for it.

The format can be the plain DSN or with `SENTRY_LARAVEL_DSN=https://05b28b635e8d415ca5ea4415b785d271@o1.ingest.sentry.io/155735` if people copy it like this from our docs.

![CleanShot 2020-10-01 at 10 52 30](https://user-images.githubusercontent.com/363802/94788770-5ccfbb80-03d4-11eb-8ad1-e51ae0bb7619.gif)