### PR TITLE
Strip away the controllers base namespace

### DIFF
--- a/config/sentry.php
+++ b/config/sentry.php
@@ -31,4 +31,7 @@ return [
     'send_default_pii' => false,
 
     'traces_sample_rate' => (float)(env('SENTRY_TRACES_SAMPLE_RATE', 0.0)),
+
+    'controllers_base_namespace' => env('SENTRY_CONTROLLERS_BASE_NAMESPACE', 'App\\Http\\Controllers'),
+
 ];

--- a/src/Sentry/Laravel/Integration.php
+++ b/src/Sentry/Laravel/Integration.php
@@ -22,6 +22,11 @@ class Integration implements IntegrationInterface
     private static $transaction;
 
     /**
+     * @var null|string
+     */
+    private static $baseControllerNamespace;
+
+    /**
      * {@inheritdoc}
      */
     public function setupOnce(): void
@@ -84,9 +89,17 @@ class Integration implements IntegrationInterface
     /**
      * @param null|string $transaction
      */
-    public static function setTransaction($transaction): void
+    public static function setTransaction(?string $transaction): void
     {
         self::$transaction = $transaction;
+    }
+
+    /**
+     * @param null|string $namespace
+     */
+    public static function setControllersBaseNamespace(?string $namespace): void
+    {
+        self::$baseControllerNamespace = $namespace !== null ? trim($namespace, '\\') : null;
     }
 
     /**
@@ -136,7 +149,7 @@ class Integration implements IntegrationInterface
 
         if (empty($routeName) && $route->getActionName()) {
             // SomeController@someAction (controller action)
-            $routeName = ltrim($route->getActionName(), '\\');
+            $routeName = ltrim($route->getActionName(), (self::$baseControllerNamespace ?? '') . '\\');
         }
 
         if (empty($routeName) || $routeName === 'Closure') {


### PR DESCRIPTION
This would rename a transaction called `App\Http\Controllers\Todo\Create` to `Todo\Create`.

This makes it more readable inside the Sentry interface.

When users have another base namespace they can override the config option to set their own.