### PR TITLE
Actually forward any other view engine calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Improve performance tracing by nesting `view.render` spans and adding a `app.handle` span showing how long the actual application code runs after Laravel bootstrapping (#387)
 - Improve UX of `sentry:publish` command
+- Fix incompatibility with other packages that also decorate the view engine, like Livewire (#395)
 
 ## 2.0.0
 

--- a/src/Sentry/Laravel/Tracing/ViewEngineDecorator.php
+++ b/src/Sentry/Laravel/Tracing/ViewEngineDecorator.php
@@ -3,7 +3,6 @@
 namespace Sentry\Laravel\Tracing;
 
 use Illuminate\Contracts\View\Engine;
-use Illuminate\View\Compilers\CompilerInterface;
 use Illuminate\View\Factory;
 use Sentry\Laravel\Integration;
 use Sentry\SentrySdk;
@@ -54,13 +53,8 @@ final class ViewEngineDecorator implements Engine
         return $result;
     }
 
-    /**
-     * Laravel uses this function internally.
-     *
-     * @internal
-     */
-    public function getCompiler(): CompilerInterface
+    public function __call($name, $arguments)
     {
-        return $this->engine->getCompiler();
+        return call_user_func_array([$this->engine, $name], $arguments);
     }
 }


### PR DESCRIPTION
We "decorate" the view engine but we are not actually decorating it in the sense we forward unchanged behaviour to the original proxy (still called a decorator?).

This change will do that so any underlying engines will still work even if they implement custom methods (for example Livewire and even Laravel core does this).

Fixes #394.