### PR TITLE
Fix missing breadcrumbs from views

### DIFF
--- a/src/Sentry/Laravel/Tracing/ViewEngineDecorator.php
+++ b/src/Sentry/Laravel/Tracing/ViewEngineDecorator.php
@@ -41,14 +41,13 @@ final class ViewEngineDecorator implements Engine
 
         $span = $parentSpan->startChild($context);
 
-        $scope = SentrySdk::getCurrentHub()->pushScope();
-        $scope->setSpan($span);
+        SentrySdk::getCurrentHub()->setSpan($span);
 
         $result = $this->engine->get($path, $data);
 
         $span->finish();
 
-        SentrySdk::getCurrentHub()->popScope();
+        SentrySdk::getCurrentHub()->setSpan($parentSpan);
 
         return $result;
     }


### PR DESCRIPTION
I noticed the breadcrumbs created from views were discarded because of the scope push/pop.

I am not sure this is better but it does work better, I'd appreciate some feedback if this sounds logical but this does seem more "correct".