### PR TITLE
Skip performance tracing in unit tests

### DIFF
--- a/src/Sentry/Laravel/Tracing/Middleware.php
+++ b/src/Sentry/Laravel/Tracing/Middleware.php
@@ -36,7 +36,7 @@ class Middleware
      */
     public function handle($request, Closure $next)
     {
-        if (app()->bound('sentry')) {
+        if (app()->bound('sentry') && !app()->runningUnitTests()) {
             $this->startTransaction($request, app('sentry'));
         }
 


### PR DESCRIPTION
Since [startTransaction](https://github.com/getsentry/sentry-laravel/blob/master/src/Sentry/Laravel/Tracing/Middleware.php#L73) is using typehint and class `Sentry\State\Hub` is declared as final, we are not able to mock `app('sentry')` in unit tests, I don't think we should trace performance during unit tests.