### PR TITLE
Fix stripping the base namespace for route name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fix incorrectly stripped base controller action from transaction name (#406)
+
 ## 2.1.1
 
 - Fix for potential `Undefined index: controllers_base_namespace.` notice

--- a/src/Sentry/Laravel/Integration.php
+++ b/src/Sentry/Laravel/Integration.php
@@ -149,7 +149,14 @@ class Integration implements IntegrationInterface
 
         if (empty($routeName) && $route->getActionName()) {
             // SomeController@someAction (controller action)
-            $routeName = ltrim($route->getActionName(), (self::$baseControllerNamespace ?? '') . '\\');
+            $routeName = $route->getActionName();
+
+            $baseNamespace = self::$baseControllerNamespace ?? '';
+
+            // Strip away the base namespace from the action name
+            if (!empty($baseNamespace)) {
+                $routeName = Str::after($routeName, $baseNamespace . '\\');
+            }
         }
 
         if (empty($routeName) || $routeName === 'Closure') {


### PR DESCRIPTION
So I might a mistake in the stripping of the base namespace and used `ltrim` but that takes a character list and not a string so you could end up with some crazy route names that make no sense at all!

Fixed by using a Laravel string helper that does do what we want.