### PR TITLE
Move request info tracking to the middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Fix incorrectly stripped base controller action from transaction name (#406)
+- Move tracing request/response data hydration to the tracing middleware (#408)
 
 ## 2.1.1
 

--- a/src/Sentry/Laravel/Integration.php
+++ b/src/Sentry/Laravel/Integration.php
@@ -148,8 +148,8 @@ class Integration implements IntegrationInterface
         }
 
         if (empty($routeName) && $route->getActionName()) {
-            // SomeController@someAction (controller action)
-            $routeName = $route->getActionName();
+            // Some\Controller@someAction (controller action)
+            $routeName = ltrim($route->getActionName(), '\\');
 
             $baseNamespace = self::$baseControllerNamespace ?? '';
 

--- a/src/Sentry/Laravel/Tracing/EventHandler.php
+++ b/src/Sentry/Laravel/Tracing/EventHandler.php
@@ -5,13 +5,9 @@ namespace Sentry\Laravel\Tracing;
 use Exception;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Database\Events\QueryExecuted;
-use Illuminate\Routing\Events\RouteMatched;
-use Illuminate\Routing\Route;
 use RuntimeException;
 use Sentry\Laravel\Integration;
-use Sentry\SentrySdk;
 use Sentry\Tracing\SpanContext;
-use Sentry\Tracing\Transaction;
 
 class EventHandler
 {
@@ -21,9 +17,6 @@ class EventHandler
      * @var array
      */
     protected static $eventHandlerMap = [
-        'router.matched'    => 'routerMatched',  // Until Laravel 5.1
-        RouteMatched::class => 'routeMatched',   // Since Laravel 5.2
-
         'illuminate.query'   => 'query',         // Until Laravel 5.1
         QueryExecuted::class => 'queryExecuted', // Since Laravel 5.2
     ];
@@ -81,36 +74,6 @@ class EventHandler
         } catch (Exception $exception) {
             // Ignore
         }
-    }
-
-    /**
-     * Until Laravel 5.1
-     *
-     * @param \Illuminate\Routing\Route $route
-     */
-    protected function routerMatchedHandler(Route $route): void
-    {
-        $transaction = SentrySdk::getCurrentHub()->getTransaction();
-
-        if ($transaction instanceof Transaction) {
-            $routeName = Integration::extractNameForRoute($route) ?? '<unlabeled transaction>';
-
-            $transaction->setName($routeName);
-            $transaction->setData([
-                'action' => $route->getActionName(),
-                'name'   => $route->getName(),
-            ]);
-        }
-    }
-
-    /**
-     * Since Laravel 5.2
-     *
-     * @param \Illuminate\Routing\Events\RouteMatched $match
-     */
-    protected function routeMatchedHandler(RouteMatched $match): void
-    {
-        $this->routerMatchedHandler($match->route);
     }
 
     /**


### PR DESCRIPTION
Reason for this is that the route matched event is not always fired (Apiato is a good example) and sometimes the data is also not correctly attached to the transaction but a span which makes it useless.

So we hydrate request and response information just before finishing the transaction in the middleware.