### PR TITLE
Fix problems when enabling tracing on Laravel Lumen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Fix problems when enabling tracing on Laravel Lumen (#416)
 - PHP 8 Support (#431)
 - Bump Sentry SDK to `3.2.*` (#431)
 

--- a/src/Sentry/Laravel/Tracing/Middleware.php
+++ b/src/Sentry/Laravel/Tracing/Middleware.php
@@ -3,6 +3,7 @@
 namespace Sentry\Laravel\Tracing;
 
 use Closure;
+use Illuminate\Foundation\Application as Laravel;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Routing\Route;
@@ -99,7 +100,7 @@ class Middleware
         // Setting the Transaction on the Hub
         SentrySdk::getCurrentHub()->setSpan($this->transaction);
 
-        if (!$this->addBootTimeSpans()) {
+        if (!$this->addBootTimeSpans() && app() instanceof Laravel) {
             // @TODO: We might want to move this together with the `RouteMatches` listener to some central place and or do this from the `EventHandler`
             app()->booted(function () use ($request, $fallbackTime): void {
                 $spanContextStart = new SpanContext();

--- a/src/Sentry/Laravel/Tracing/ServiceProvider.php
+++ b/src/Sentry/Laravel/Tracing/ServiceProvider.php
@@ -7,6 +7,7 @@ use Illuminate\Contracts\View\Engine;
 use Illuminate\Contracts\View\View;
 use Illuminate\View\Engines\EngineResolver;
 use Illuminate\View\Factory as ViewFactory;
+use Laravel\Lumen\Application as Lumen;
 use Sentry\Laravel\BaseServiceProvider;
 
 class ServiceProvider extends BaseServiceProvider
@@ -18,7 +19,9 @@ class ServiceProvider extends BaseServiceProvider
 
             $this->bindViewEngine();
 
-            if ($this->app->bound(HttpKernelInterface::class)) {
+            if ($this->app instanceof Lumen) {
+                $this->app->middleware(Middleware::class);
+            } elseif ($this->app->bound(HttpKernelInterface::class)) {
                 /** @var \Illuminate\Contracts\Http\Kernel $httpKernel */
                 $httpKernel = $this->app->make(HttpKernelInterface::class);
 
@@ -69,7 +72,7 @@ class ServiceProvider extends BaseServiceProvider
         /** @var ViewFactory $viewFactory */
         $viewFactory = $this->app->make('view');
 
-        $viewFactory->composer('*', static function (View $view) use ($viewFactory) : void {
+        $viewFactory->composer('*', static function (View $view) use ($viewFactory): void {
             $viewFactory->share(ViewEngineDecorator::SHARED_KEY, $view->name());
         });
 


### PR DESCRIPTION
This fixes problems with tracing for Lumen.

Lumen does not have a `booted` event, so we do have to rely on the user adding the `LARAVEL_START`, `SENTRY_AUTOLOAD` and `SENTRY_BOOTSTRAP` defines to their application files for correct bootstrap instrumentation, but that seems like a documentation issue.