### PR TITLE
Improve Laravel request handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Unreleased
 
-- Read the request IP from the request to make it more accurate when behind a reverse proxy (requires [trusted proxies](https://laravel.com/docs/8.x/requests#configuring-trusted-proxies) to be setup correctly) (#419)
+- Read the request IP from the Laravel request to make it more accurate when behind a reverse proxy (requires [trusted proxies](https://laravel.com/docs/8.x/requests#configuring-trusted-proxies) to be setup correctly) (#419)
+- Get request information (like the URL) from the Laravel request instead of constructing it from the global state (#419)
 
 ## 2.3.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Read the request IP from the request to make it more accurate when behind a reverse proxy (requires [trusted proxies](https://laravel.com/docs/8.x/requests#configuring-trusted-proxies) to be setup correctly) (#419)
+
 ## 2.3.1
 
 - Fix problems when enabling tracing on Laravel Lumen (#416)

--- a/composer.json
+++ b/composer.json
@@ -1,75 +1,77 @@
 {
-  "name": "sentry/sentry-laravel",
-  "type": "library",
-  "description": "Laravel SDK for Sentry (https://sentry.io)",
-  "keywords": [
-    "sentry",
-    "laravel",
-    "log",
-    "logging",
-    "error-monitoring",
-    "error-handler",
-    "crash-reporting",
-    "crash-reports"
-  ],
-  "homepage": "https://sentry.io",
-  "license": "Apache-2.0",
-  "authors": [
-    {
-      "name": "Sentry",
-      "email": "accounts@sentry.io"
-    }
-  ],
-  "require": {
-    "php": "^7.2 | ^8.0",
-    "illuminate/support": "5.0 - 5.8 | ^6.0 | ^7.0 | ^8.0",
-    "sentry/sentry": "3.1.*",
-    "sentry/sdk": "^3.1"
-  },
-  "require-dev": {
-    "phpunit/phpunit": "^9.3",
-    "laravel/framework": "^8.0",
-    "orchestra/testbench": "^6.0",
-    "friendsofphp/php-cs-fixer": "2.16.*",
-    "mockery/mockery": "1.3.*"
-  },
-  "autoload": {
-    "psr-0": {
-      "Sentry\\Laravel\\": "src/"
-    }
-  },
-  "autoload-dev": {
-    "psr-4": {
-      "Sentry\\Laravel\\Tests\\": "test/Sentry/"
-    }
-  },
-  "scripts": {
-    "tests": [
-      "vendor/bin/phpunit --verbose"
+    "name": "sentry/sentry-laravel",
+    "type": "library",
+    "description": "Laravel SDK for Sentry (https://sentry.io)",
+    "keywords": [
+        "sentry",
+        "laravel",
+        "log",
+        "logging",
+        "error-monitoring",
+        "error-handler",
+        "crash-reporting",
+        "crash-reports"
     ],
-    "tests-travis": [
-      "XDEBUG_MODE=coverage vendor/bin/phpunit --verbose --configuration phpunit.xml --coverage-clover test/clover.xml"
+    "homepage": "https://sentry.io",
+    "license": "Apache-2.0",
+    "authors": [
+        {
+            "name": "Sentry",
+            "email": "accounts@sentry.io"
+        }
     ],
-    "tests-report": [
-      "XDEBUG_MODE=coverage vendor/bin/phpunit --verbose --configuration phpunit.xml --coverage-html test/html-report"
-    ],
-    "phpcs": [
-      "vendor/bin/php-cs-fixer fix --config=.php_cs --verbose --diff --dry-run"
-    ]
-  },
-  "extra": {
-    "branch-alias": {
-      "dev-master": "2.x-dev",
-      "dev-0.x": "0.x-dev"
+    "require": {
+        "php": "^7.2 | ^8.0",
+        "illuminate/support": "5.0 - 5.8 | ^6.0 | ^7.0 | ^8.0",
+        "sentry/sentry": "3.1.*",
+        "sentry/sdk": "^3.1",
+        "symfony/psr-http-message-bridge": "^1.0 | ^2.0",
+        "nyholm/psr7": "^1.0"
     },
-    "laravel": {
-      "providers": [
-        "Sentry\\Laravel\\ServiceProvider",
-        "Sentry\\Laravel\\Tracing\\ServiceProvider"
-      ],
-      "aliases": {
-        "Sentry": "Sentry\\Laravel\\Facade"
-      }
+    "require-dev": {
+        "phpunit/phpunit": "^9.3",
+        "laravel/framework": "^8.0",
+        "orchestra/testbench": "^6.0",
+        "friendsofphp/php-cs-fixer": "2.16.*",
+        "mockery/mockery": "1.3.*"
+    },
+    "autoload": {
+        "psr-0": {
+            "Sentry\\Laravel\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Sentry\\Laravel\\Tests\\": "test/Sentry/"
+        }
+    },
+    "scripts": {
+        "tests": [
+            "vendor/bin/phpunit --verbose"
+        ],
+        "tests-travis": [
+            "XDEBUG_MODE=coverage vendor/bin/phpunit --verbose --configuration phpunit.xml --coverage-clover test/clover.xml"
+        ],
+        "tests-report": [
+            "XDEBUG_MODE=coverage vendor/bin/phpunit --verbose --configuration phpunit.xml --coverage-html test/html-report"
+        ],
+        "phpcs": [
+            "vendor/bin/php-cs-fixer fix --config=.php_cs --verbose --diff --dry-run"
+        ]
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "2.x-dev",
+            "dev-0.x": "0.x-dev"
+        },
+        "laravel": {
+            "providers": [
+                "Sentry\\Laravel\\ServiceProvider",
+                "Sentry\\Laravel\\Tracing\\ServiceProvider"
+            ],
+            "aliases": {
+                "Sentry": "Sentry\\Laravel\\Facade"
+            }
+        }
     }
-  }
 }

--- a/src/Sentry/Laravel/EventHandler.php
+++ b/src/Sentry/Laravel/EventHandler.php
@@ -6,9 +6,9 @@ use Exception;
 use Illuminate\Auth\Events\Authenticated;
 use Illuminate\Console\Events\CommandFinished;
 use Illuminate\Console\Events\CommandStarting;
-use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Database\Events\QueryExecuted;
+use Illuminate\Http\Request;
 use Illuminate\Log\Events\MessageLogged;
 use Illuminate\Queue\Events\JobExceptionOccurred;
 use Illuminate\Queue\Events\JobProcessed;
@@ -370,10 +370,12 @@ class EventHandler
             /** @var \Illuminate\Http\Request $request */
             $request = $this->app->make('request');
 
-            $ipAddress = $request->ip();
+            if ($request instanceof Request) {
+                $ipAddress = $request->ip();
 
-            if ($ipAddress !== null) {
-                $userData['ip_address'] = $ipAddress;
+                if ($ipAddress !== null) {
+                    $userData['ip_address'] = $ipAddress;
+                }
             }
         }
 

--- a/src/Sentry/Laravel/EventHandler.php
+++ b/src/Sentry/Laravel/EventHandler.php
@@ -419,7 +419,7 @@ class EventHandler
     /**
      * Since Laravel 5.2
      *
-     * @param \Illuminate\Queue\Events\JobProcessing $event
+     * @param \Illuminate\Queue\Events\JobExceptionOccurred $event
      */
     protected function queueJobExceptionOccurredHandler(JobExceptionOccurred $event)
     {
@@ -429,7 +429,7 @@ class EventHandler
     /**
      * Since Laravel 5.2
      *
-     * @param \Illuminate\Queue\Events\JobProcessing $event
+     * @param \Illuminate\Queue\Events\JobProcessed $event
      */
     protected function queueJobProcessedHandler(JobProcessed $event)
     {
@@ -439,7 +439,7 @@ class EventHandler
     /**
      * Since Laravel 5.2
      *
-     * @param \Illuminate\Queue\Events\JobProcessing $event
+     * @param \Illuminate\Queue\Events\WorkerStopping $event
      */
     protected function queueWorkerStoppingHandler(WorkerStopping $event)
     {

--- a/src/Sentry/Laravel/Http/LaravelRequestFetcher.php
+++ b/src/Sentry/Laravel/Http/LaravelRequestFetcher.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Sentry\Laravel\Http;
+
+use Illuminate\Contracts\Container\BindingResolutionException;
+use Illuminate\Contracts\Foundation\Application;
+use Psr\Http\Message\ServerRequestInterface;
+use Sentry\Integration\RequestFetcher;
+use Sentry\Integration\RequestFetcherInterface;
+
+class LaravelRequestFetcher implements RequestFetcherInterface
+{
+    /**
+     * The Laravel application container.
+     *
+     * @var \Illuminate\Contracts\Foundation\Application
+     */
+    private $app;
+
+    public function __construct(Application $app)
+    {
+        $this->app = $app;
+    }
+
+    public function fetchRequest(): ?ServerRequestInterface
+    {
+        if (!$this->app->bound('request') || $this->app->runningInConsole()) {
+            return null;
+        }
+
+        try {
+            return $this->app->make(ServerRequestInterface::class);
+        } catch (BindingResolutionException $e) {
+            return (new RequestFetcher)->fetchRequest();
+        }
+    }
+}

--- a/src/Sentry/Laravel/Http/SetRequestIpMiddleware.php
+++ b/src/Sentry/Laravel/Http/SetRequestIpMiddleware.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Sentry\Laravel\Http;
+
+use Closure;
+use Illuminate\Http\Request;
+use Sentry\State\Scope;
+
+class SetRequestIpMiddleware
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param \Illuminate\Http\Request $request
+     * @param \Closure                 $next
+     *
+     * @return mixed
+     */
+    public function handle(Request $request, Closure $next)
+    {
+        if (app()->bound('sentry')) {
+            app('sentry')->configureScope(static function (Scope $scope) use ($request): void {
+                $scope->setUser([
+                    'ip_address' => $request->ip(),
+                ]);
+            });
+        }
+
+        return $next($request);
+    }
+}

--- a/src/Sentry/Laravel/ServiceProvider.php
+++ b/src/Sentry/Laravel/ServiceProvider.php
@@ -77,7 +77,7 @@ class ServiceProvider extends BaseServiceProvider
     {
         $userConfig = $this->getUserConfig();
 
-        $handler = new EventHandler($this->app->events, $userConfig);
+        $handler = new EventHandler($this->app, $userConfig);
 
         $handler->subscribe();
 

--- a/src/Sentry/Laravel/Tracing/ServiceProvider.php
+++ b/src/Sentry/Laravel/Tracing/ServiceProvider.php
@@ -5,6 +5,7 @@ namespace Sentry\Laravel\Tracing;
 use Illuminate\Contracts\Http\Kernel as HttpKernelInterface;
 use Illuminate\Contracts\View\Engine;
 use Illuminate\Contracts\View\View;
+use Illuminate\Foundation\Http\Kernel as HttpKernel;
 use Illuminate\View\Engines\EngineResolver;
 use Illuminate\View\Factory as ViewFactory;
 use Laravel\Lumen\Application as Lumen;
@@ -22,10 +23,12 @@ class ServiceProvider extends BaseServiceProvider
             if ($this->app instanceof Lumen) {
                 $this->app->middleware(Middleware::class);
             } elseif ($this->app->bound(HttpKernelInterface::class)) {
-                /** @var \Illuminate\Contracts\Http\Kernel $httpKernel */
+                /** @var \Illuminate\Foundation\Http\Kernel $httpKernel */
                 $httpKernel = $this->app->make(HttpKernelInterface::class);
 
-                $httpKernel->prependMiddleware(Middleware::class);
+                if ($httpKernel instanceof HttpKernel) {
+                    $httpKernel->prependMiddleware(Middleware::class);
+                }
             }
         }
     }

--- a/test/Sentry/EventHandlerTest.php
+++ b/test/Sentry/EventHandlerTest.php
@@ -13,7 +13,7 @@ class EventHandlerTest extends TestCase
      */
     public function test_missing_event_handler_throws_exception()
     {
-        $handler = new EventHandler($this->app->events, []);
+        $handler = new EventHandler($this->app, []);
 
         $handler->thisIsNotAHandlerAndShouldThrowAnException();
     }
@@ -41,7 +41,7 @@ class EventHandlerTest extends TestCase
 
     private function tryAllEventHandlerMethods(array $methods): void
     {
-        $handler = new EventHandler($this->app->events, []);
+        $handler = new EventHandler($this->app, []);
 
         $methods = array_map(static function ($method) {
             return "{$method}Handler";


### PR DESCRIPTION
This PR improves and does a few things:

- Get the user IP from the Laravel request (fixes IP reported wrong when using a reverse proxy)
- Get the request from Laravel instead of recreating it (fixes `https://app.com:80/` being reported as url)