### PR TITLE
PHP 8 Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,22 +24,22 @@ env:
     - LARAVEL=^8.0  TESTBENCH=^6.0 PHPUNIT=9.3.*
 
     # We add one more test using the bleeding edge version of Laravel
-    - LARAVEL=8.x-dev@dev TESTBENCH=^6.0 PHPUNIT=8.4.* COMPOSER_STABILITY=dev
+    - LARAVEL=8.x-dev@dev TESTBENCH=^6.0 PHPUNIT=9.3.* COMPOSER_STABILITY=dev
 
 matrix:
   fast_finish: true
   allow_failures:
     - php: 7.3
-      env: LARAVEL=8.x-dev@dev TESTBENCH=^6.0 PHPUNIT=8.4.* COMPOSER_STABILITY=dev
+      env: LARAVEL=8.x-dev@dev TESTBENCH=^6.0 PHPUNIT=9.3.* COMPOSER_STABILITY=dev
     - php: 7.4
-      env: LARAVEL=8.x-dev@dev TESTBENCH=^6.0 PHPUNIT=8.4.* COMPOSER_STABILITY=dev
+      env: LARAVEL=8.x-dev@dev TESTBENCH=^6.0 PHPUNIT=9.3.* COMPOSER_STABILITY=dev
     - php: 8.0
-      env: LARAVEL=8.x-dev@dev TESTBENCH=^6.0 PHPUNIT=8.4.* COMPOSER_STABILITY=dev
+      env: LARAVEL=8.x-dev@dev TESTBENCH=^6.0 PHPUNIT=9.3.* COMPOSER_STABILITY=dev
   exclude:
     - php: 7.2
       env: LARAVEL=^8.0  TESTBENCH=^6.0 PHPUNIT=9.3.*
     - php: 7.2
-      env: LARAVEL=8.x-dev@dev TESTBENCH=^6.0 PHPUNIT=8.4.* COMPOSER_STABILITY=dev
+      env: LARAVEL=8.x-dev@dev TESTBENCH=^6.0 PHPUNIT=9.3.* COMPOSER_STABILITY=dev
     - php: 8.0
       env: LARAVEL=5.1.* TESTBENCH=3.1.* PHPUNIT=5.7.*
     - php: 8.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,9 +19,9 @@ env:
     - LARAVEL=5.8.* TESTBENCH=3.8.* PHPUNIT=7.5.*
     - LARAVEL=^6.0  TESTBENCH=4.7.* PHPUNIT=8.4.*
     - LARAVEL=^7.0  TESTBENCH=5.1.* PHPUNIT=8.4.*
-    
+
     # All versions below only support PHP ^7.3 (Laravel requirement)
-    - LARAVEL=^8.0  TESTBENCH=^6.0 PHPUNIT=8.4.*
+    - LARAVEL=^8.0  TESTBENCH=^6.0 PHPUNIT=9.3.*
 
     # We add one more test using the bleeding edge version of Laravel
     - LARAVEL=8.x-dev@dev TESTBENCH=^6.0 PHPUNIT=8.4.* COMPOSER_STABILITY=dev
@@ -37,9 +37,29 @@ matrix:
       env: LARAVEL=8.x-dev@dev TESTBENCH=^6.0 PHPUNIT=8.4.* COMPOSER_STABILITY=dev
   exclude:
     - php: 7.2
-      env: LARAVEL=^8.0  TESTBENCH=^6.0 PHPUNIT=8.4.*
+      env: LARAVEL=^8.0  TESTBENCH=^6.0 PHPUNIT=9.3.*
     - php: 7.2
       env: LARAVEL=8.x-dev@dev TESTBENCH=^6.0 PHPUNIT=8.4.* COMPOSER_STABILITY=dev
+    - php: 8.0
+      env: LARAVEL=5.1.* TESTBENCH=3.1.* PHPUNIT=5.7.*
+    - php: 8.0
+      env: LARAVEL=5.2.* TESTBENCH=3.2.* PHPUNIT=5.7.*
+    - php: 8.0
+      env: LARAVEL=5.3.* TESTBENCH=3.3.* PHPUNIT=5.7.*
+    - php: 8.0
+      env: LARAVEL=5.4.* TESTBENCH=3.4.* PHPUNIT=5.7.*
+    - php: 8.0
+      env: LARAVEL=5.5.* TESTBENCH=3.5.* PHPUNIT=6.5.*
+    - php: 8.0
+      env: LARAVEL=5.6.* TESTBENCH=3.6.* PHPUNIT=7.5.*
+    - php: 8.0
+      env: LARAVEL=5.7.* TESTBENCH=3.7.* PHPUNIT=7.5.*
+    - php: 8.0
+      env: LARAVEL=5.8.* TESTBENCH=3.8.* PHPUNIT=7.5.*
+    - php: 8.0
+      env: LARAVEL=^6.0  TESTBENCH=4.7.* PHPUNIT=8.4.*
+    - php: 8.0
+      env: LARAVEL=^7.0  TESTBENCH=5.1.* PHPUNIT=8.4.*
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ php:
   - 7.2
   - 7.3
   - 7.4
+  - 8.0
 
 env:
   matrix:
@@ -31,6 +32,8 @@ matrix:
     - php: 7.3
       env: LARAVEL=8.x-dev@dev TESTBENCH=^6.0 PHPUNIT=8.4.* COMPOSER_STABILITY=dev
     - php: 7.4
+      env: LARAVEL=8.x-dev@dev TESTBENCH=^6.0 PHPUNIT=8.4.* COMPOSER_STABILITY=dev
+    - php: 8.0
       env: LARAVEL=8.x-dev@dev TESTBENCH=^6.0 PHPUNIT=8.4.* COMPOSER_STABILITY=dev
   exclude:
     - php: 7.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,32 +8,35 @@ php:
 env:
   matrix:
     # All versions below should be test on PHP ^7.1 (Sentry SDK requirement)
-    - LARAVEL=5.1.* TESTBENCH=3.1.* PHPUNIT=5.7.* SENTRY=^3.0
-    - LARAVEL=5.2.* TESTBENCH=3.2.* PHPUNIT=5.7.* SENTRY=^3.0
-    - LARAVEL=5.3.* TESTBENCH=3.3.* PHPUNIT=5.7.* SENTRY=^3.0
-    - LARAVEL=5.4.* TESTBENCH=3.4.* PHPUNIT=5.7.* SENTRY=^3.0
-    - LARAVEL=5.5.* TESTBENCH=3.5.* PHPUNIT=6.5.* SENTRY=^3.0
-    - LARAVEL=5.6.* TESTBENCH=3.6.* PHPUNIT=7.5.* SENTRY=^3.0
-    - LARAVEL=5.7.* TESTBENCH=3.7.* PHPUNIT=7.5.* SENTRY=^3.0
-    - LARAVEL=5.8.* TESTBENCH=3.8.* PHPUNIT=7.5.* SENTRY=^3.0
+    - LARAVEL=5.1.* TESTBENCH=3.1.* PHPUNIT=5.7.*
+    - LARAVEL=5.2.* TESTBENCH=3.2.* PHPUNIT=5.7.*
+    - LARAVEL=5.3.* TESTBENCH=3.3.* PHPUNIT=5.7.*
+    - LARAVEL=5.4.* TESTBENCH=3.4.* PHPUNIT=5.7.*
+    - LARAVEL=5.5.* TESTBENCH=3.5.* PHPUNIT=6.5.*
+    - LARAVEL=5.6.* TESTBENCH=3.6.* PHPUNIT=7.5.*
+    - LARAVEL=5.7.* TESTBENCH=3.7.* PHPUNIT=7.5.*
+    - LARAVEL=5.8.* TESTBENCH=3.8.* PHPUNIT=7.5.*
+    - LARAVEL=^6.0  TESTBENCH=4.7.* PHPUNIT=8.4.*
+    - LARAVEL=^7.0  TESTBENCH=5.1.* PHPUNIT=8.4.*
+    
+    # All versions below only support PHP ^7.3 (Laravel requirement)
+    - LARAVEL=^8.0  TESTBENCH=^6.0 PHPUNIT=8.4.*
 
-    # All versions below only support PHP ^7.2 (Laravel requirement)
-    - LARAVEL=^6.0 TESTBENCH=4.7.* PHPUNIT=8.4.* SENTRY=^3.0
-    - LARAVEL=^7.0 TESTBENCH=5.1.* PHPUNIT=8.4.* SENTRY=^3.0
-
-    # We add one more test using the next version of Laravel which only support PHP ^7.3 (Laravel requirement)
-    - LARAVEL=8.x-dev@dev TESTBENCH=^6.0 PHPUNIT=8.4.* SENTRY=^3.0 COMPOSER_STABILITY=dev
+    # We add one more test using the bleeding edge version of Laravel
+    - LARAVEL=8.x-dev@dev TESTBENCH=^6.0 PHPUNIT=8.4.* COMPOSER_STABILITY=dev
 
 matrix:
   fast_finish: true
   allow_failures:
     - php: 7.3
-      env: LARAVEL=8.x-dev@dev TESTBENCH=^6.0 PHPUNIT=8.4.* SENTRY=^3.0 COMPOSER_STABILITY=dev
+      env: LARAVEL=8.x-dev@dev TESTBENCH=^6.0 PHPUNIT=8.4.* COMPOSER_STABILITY=dev
     - php: 7.4
-      env: LARAVEL=8.x-dev@dev TESTBENCH=^6.0 PHPUNIT=8.4.* SENTRY=^3.0 COMPOSER_STABILITY=dev
+      env: LARAVEL=8.x-dev@dev TESTBENCH=^6.0 PHPUNIT=8.4.* COMPOSER_STABILITY=dev
   exclude:
     - php: 7.2
-      env: LARAVEL=8.x-dev@dev TESTBENCH=^6.0 PHPUNIT=8.4.* SENTRY=^3.0 COMPOSER_STABILITY=dev
+      env: LARAVEL=^8.0  TESTBENCH=^6.0 PHPUNIT=8.4.*
+    - php: 7.2
+      env: LARAVEL=8.x-dev@dev TESTBENCH=^6.0 PHPUNIT=8.4.* COMPOSER_STABILITY=dev
 
 cache:
   directories:
@@ -54,7 +57,7 @@ jobs:
 before_install:
   - if [ "$USE_COMPOSER_JSON" != "1" ]; then composer remove friendsofphp/php-cs-fixer --dev --no-update; fi;
   - if [ "$USE_COMPOSER_JSON" != "1" ]; then composer config minimum-stability ${COMPOSER_STABILITY:=stable}; fi;
-  - if [ "$USE_COMPOSER_JSON" != "1" ]; then composer require laravel/framework:$LARAVEL illuminate/support:$LARAVEL orchestra/testbench:$TESTBENCH phpunit/phpunit:$PHPUNIT sentry/sentry:$SENTRY --no-update --no-interaction --dev; fi;
+  - if [ "$USE_COMPOSER_JSON" != "1" ]; then composer require laravel/framework:$LARAVEL illuminate/support:$LARAVEL orchestra/testbench:$TESTBENCH phpunit/phpunit:$PHPUNIT --no-update --no-interaction --dev; fi;
 
 install:
   - travis_retry composer install --no-suggest --no-interaction --prefer-dist --no-progress

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- PHP 8 Support (#431)
+- Bump Sentry SDK to `3.2.*` (#431)
+
 ## 2.3.0
 
 - Bump Sentry SDK to `3.1.*` (#420)

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     }
   ],
   "require": {
-    "php": "^7.2",
+    "php": "^7.2 | ^8.0",
     "illuminate/support": "5.0 - 5.8 | ^6.0 | ^7.0 | ^8.0",
     "sentry/sentry": "3.1.*",
     "sentry/sdk": "^3.1"

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
   "require": {
     "php": "^7.2 | ^8.0",
     "illuminate/support": "5.0 - 5.8 | ^6.0 | ^7.0 | ^8.0",
-    "sentry/sentry": "3.1.*",
+    "sentry/sentry": "dev-master@dev",
     "sentry/sdk": "^3.1"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -27,9 +27,9 @@
     "sentry/sdk": "^3.1"
   },
   "require-dev": {
-    "phpunit/phpunit": "^8.0",
-    "laravel/framework": "^7.0",
-    "orchestra/testbench": "^5.0",
+    "phpunit/phpunit": "^9.3",
+    "laravel/framework": "^8.0",
+    "orchestra/testbench": "^6.0",
     "friendsofphp/php-cs-fixer": "2.16.*",
     "mockery/mockery": "1.3.*"
   },

--- a/composer.json
+++ b/composer.json
@@ -48,10 +48,10 @@
       "vendor/bin/phpunit --verbose"
     ],
     "tests-travis": [
-      "vendor/bin/phpunit --verbose --configuration phpunit.xml --coverage-clover test/clover.xml"
+      "XDEBUG_MODE=coverage vendor/bin/phpunit --verbose --configuration phpunit.xml --coverage-clover test/clover.xml"
     ],
     "tests-report": [
-      "vendor/bin/phpunit --verbose --configuration phpunit.xml --coverage-html test/html-report"
+      "XDEBUG_MODE=coverage vendor/bin/phpunit --verbose --configuration phpunit.xml --coverage-html test/html-report"
     ],
     "phpcs": [
       "vendor/bin/php-cs-fixer fix --config=.php_cs --verbose --diff --dry-run"

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
   "require": {
     "php": "^7.2 | ^8.0",
     "illuminate/support": "5.0 - 5.8 | ^6.0 | ^7.0 | ^8.0",
-    "sentry/sentry": "dev-master@dev",
+    "sentry/sentry": "3.1.*",
     "sentry/sdk": "^3.1"
   },
   "require-dev": {

--- a/test/Sentry/EventHandlerTest.php
+++ b/test/Sentry/EventHandlerTest.php
@@ -3,16 +3,18 @@
 namespace Sentry\Laravel\Tests;
 
 use ReflectionClass;
+use RuntimeException;
 use Sentry\Laravel\EventHandler;
 use Orchestra\Testbench\TestCase;
 
 class EventHandlerTest extends TestCase
 {
-    /**
-     * @expectedException \RuntimeException
-     */
+    use ExpectsException;
+
     public function test_missing_event_handler_throws_exception()
     {
+        $this->safeExpectException(RuntimeException::class);
+
         $handler = new EventHandler($this->app->events, []);
 
         $handler->thisIsNotAHandlerAndShouldThrowAnException();

--- a/test/Sentry/ExpectsException.php
+++ b/test/Sentry/ExpectsException.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Sentry\Laravel\Tests;
+
+use RuntimeException;
+
+trait ExpectsException
+{
+    protected function safeExpectException(string $class): void
+    {
+        if (method_exists($this, 'expectException')) {
+            $this->expectException($class);
+
+            return;
+        }
+
+        if (method_exists($this, 'setExpectedException')) {
+            $this->setExpectedException($class);
+
+            return;
+        }
+
+        throw new RuntimeException('Could not expect an exception.');
+    }
+}

--- a/test/Sentry/IntegrationsOptionTest.php
+++ b/test/Sentry/IntegrationsOptionTest.php
@@ -2,6 +2,8 @@
 
 namespace Sentry\Laravel\Tests;
 
+use Exception;
+use RuntimeException;
 use Sentry\Integration\IntegrationInterface;
 use Sentry\Integration\ErrorListenerIntegration;
 use Sentry\Integration\ExceptionListenerIntegration;
@@ -9,6 +11,8 @@ use Sentry\Integration\FatalErrorListenerIntegration;
 
 class IntegrationsOptionTest extends SentryLaravelTestCase
 {
+    use ExpectsException;
+
     protected function getEnvironmentSetUp($app)
     {
         parent::getEnvironmentSetUp($app);
@@ -53,11 +57,11 @@ class IntegrationsOptionTest extends SentryLaravelTestCase
 
     /**
      * Throws \ReflectionException in <=5.8 and \Illuminate\Contracts\Container\BindingResolutionException since 6.0
-     *
-     * @expectedException \Exception
      */
     public function testCustomIntegrationThrowsExceptionIfNotResolvable()
     {
+        $this->safeExpectException(Exception::class);
+
         $this->resetApplicationWithConfig([
             'sentry.integrations' => [
                 'this-will-not-resolve',
@@ -65,11 +69,10 @@ class IntegrationsOptionTest extends SentryLaravelTestCase
         ]);
     }
 
-    /**
-     * @expectedException \RuntimeException
-     */
     public function testIncorrectIntegrationEntryThrowsException()
     {
+        $this->safeExpectException(RuntimeException::class);
+
         $this->resetApplicationWithConfig([
             'sentry.integrations' => [
                 static function () {

--- a/test/Sentry/Tracing/EventHandlerTest.php
+++ b/test/Sentry/Tracing/EventHandlerTest.php
@@ -5,17 +5,20 @@ namespace Sentry\Laravel\Tests\Tracing;
 use Mockery;
 use ReflectionClass;
 use Orchestra\Testbench\TestCase;
+use RuntimeException;
+use Sentry\Laravel\Tests\ExpectsException;
 use Sentry\Laravel\Tracing\EventHandler;
 use Sentry\SentrySdk;
 use Sentry\Tracing\TransactionContext;
 
 class EventHandlerTest extends TestCase
 {
-    /**
-     * @expectedException \RuntimeException
-     */
+    use ExpectsException;
+
     public function test_missing_event_handler_throws_exception()
     {
+        $this->safeExpectException(RuntimeException::class);
+
         $handler = new EventHandler($this->app->events);
 
         $handler->thisIsNotAHandlerAndShouldThrowAnException();


### PR DESCRIPTION
Pending sentry-php release.

Revert e115eea ~~and bump to `3.2.*` version before merge~~!

Fixes #424.