### PR TITLE
Fix link for send-default-pii in config

### DIFF
--- a/config/sentry.php
+++ b/config/sentry.php
@@ -27,7 +27,7 @@ return [
         'command_info' => true,
     ],
 
-    // @see: https://docs.sentry.io/error-reporting/configuration/?platform=php#send-default-pii
+    // @see: https://docs.sentry.io/platforms/php/configuration/options/#send-default-pii
     'send_default_pii' => false,
 
     'traces_sample_rate' => (float)(env('SENTRY_TRACES_SAMPLE_RATE', 0.0)),


### PR DESCRIPTION
The old one just redirects to https://docs.sentry.io/platforms/php and does not link to the explanation for send-default-pii