### PR TITLE
Fix generated route name not correctly detected when using prefixes

### DIFF
--- a/src/Sentry/Laravel/Integration.php
+++ b/src/Sentry/Laravel/Integration.php
@@ -135,7 +135,7 @@ class Integration implements IntegrationInterface
             // Laravel 7 route caching generates a route names if the user didn't specify one
             // theirselfs to optimize route matching. These route names are useless to the
             // developer so if we encounter a generated route name we discard the value
-            if (Str::startsWith($routeName, 'generated::')) {
+            if (Str::contains($routeName, 'generated::')) {
                 $routeName = null;
             }
 


### PR DESCRIPTION
Use Str::contains instead of Str::startsWith to verify if route name is generated.

Fixes #440