### PR TITLE
Fix overwriting the transaction name if it's set by the user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fix overwriting the transaction name if it's set by the user (#442)
+
 ## 2.3.1
 
 - Fix problems when enabling tracing on Laravel Lumen (#416)


### PR DESCRIPTION
This hopefully fixes #439.

We wait until the last moment with setting the transaction name so the user can set it in their application flow, we only set the transaction name in the terminating state of the middleware (after the user request) and check first if the transaction name is the default before setting it to prevent overwriting the user value.