### PR TITLE
Add event processor that adds exception context to event

### DIFF
--- a/src/Sentry/Laravel/Integration/ExceptionContextIntegration.php
+++ b/src/Sentry/Laravel/Integration/ExceptionContextIntegration.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Sentry\Laravel\Integration;
+
+use Sentry\Event;
+use Sentry\EventHint;
+use Sentry\State\Scope;
+use Sentry\Integration\IntegrationInterface;
+
+class ExceptionContextIntegration implements IntegrationInterface
+{
+    public function setupOnce(): void
+    {
+        Scope::addGlobalEventProcessor(static function (Event $event, ?EventHint $hint = null): Event {
+            if ($hint === null || $hint->exception === null) {
+                return $event;
+            }
+
+            if (!method_exists($hint->exception, 'context')) {
+                return $event;
+            }
+
+            $context = $hint->exception->context();
+
+            if (is_array($context)) {
+                $event->setExtra(['exception_context' => $context]);
+            }
+
+            return $event;
+        });
+    }
+}

--- a/src/Sentry/Laravel/ServiceProvider.php
+++ b/src/Sentry/Laravel/ServiceProvider.php
@@ -194,7 +194,11 @@ class ServiceProvider extends BaseServiceProvider
      */
     private function resolveIntegrationsFromUserConfig(): array
     {
-        $integrations = [new Integration];
+        // Default Sentry Laravel SDK integrations
+        $integrations = [
+            new Integration,
+            new Integration\ExceptionContextIntegration,
+        ];
 
         $userIntegrations = $this->getUserConfig()['integrations'] ?? [];
 

--- a/test/Sentry/Integration/ExceptionContextIntegrationTest.php
+++ b/test/Sentry/Integration/ExceptionContextIntegrationTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Sentry\Laravel\Tests\Integration;
+
+use Exception;
+use PHPUnit\Framework\TestCase;
+use Sentry\Event;
+use Sentry\EventHint;
+use Sentry\Laravel\Integration\ExceptionContextIntegration;
+use Sentry\State\Scope;
+use function Sentry\withScope;
+
+class ExceptionContextIntegrationTest extends TestCase
+{
+    /**
+     * @dataProvider invokeDataProvider
+     */
+    public function testInvoke(Exception $exception, ?array $expectedContext): void
+    {
+        $integration = new ExceptionContextIntegration;
+        $integration->setupOnce();
+
+        withScope(function (Scope $scope) use ($exception, $expectedContext): void {
+            $event = Event::createEvent();
+
+            $event = $scope->applyToEvent($event, EventHint::fromArray(compact('exception')));
+
+            $this->assertNotNull($event);
+
+            $exceptionContext = $event->getExtra()['exception_context'] ?? null;
+
+            $this->assertSame($expectedContext, $exceptionContext);
+        });
+    }
+
+    public function invokeDataProvider(): iterable
+    {
+        yield 'Exception without context method -> no exception context' => [
+            new Exception('Exception without context.'),
+            null,
+        ];
+
+        $context = ['some' => 'context'];
+
+        yield 'Exception with context method returning array of context' => [
+            $this->generateExceptionWithContext($context),
+            $context,
+        ];
+
+        yield 'Exception with context method returning string of context' => [
+            $this->generateExceptionWithContext('Invalid context, expects array'),
+            null,
+        ];
+    }
+
+    private function generateExceptionWithContext($context)
+    {
+        return new class($context) extends Exception {
+            private $context;
+
+            public function __construct($context)
+            {
+                $this->context = $context;
+
+                parent::__construct('Exception with context.');
+            }
+
+            public function context()
+            {
+                return $this->context;
+            }
+        };
+    }
+}


### PR DESCRIPTION
Since (very) recently Laravel added the implicit contract the the public `context` method on an exception class returns some extra context information that is added to the logs.

We like to also relay this information to Sentry.

Example (from the Laravel docs):

```php
<?php

namespace App\Exceptions;

use Exception;

class InvalidOrderException extends Exception
{
    // ...

    /**
     * Get the exception's context information.
     *
     * @return array
     */
    public function context()
    {
        return ['order_id' => $this->orderId];
    }
}
```

> https://laravel.com/docs/8.x/errors#exception-log-context

Laravel adds this information to the logs and Sentry adds this information to the `exception_context` key in the extra data.

This looks like this in the Sentry interface:

![image](https://user-images.githubusercontent.com/1090754/109816974-a47f9b00-7c31-11eb-8dad-774a0956e022.png)