### PR TITLE
Make sure the transaction is set even if the event transaction has an empty string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Fix generated route name not correctly ignored when using prefix (#441)
 - Fix overwriting the transaction name if it's set by the user (#442)
 - Add result from optional `context(): array` method on captured exception to the event sent to Sentry (#457)
+- Fix not overwriting the event transaction name if it was an empty string (#460)
 
 ## 2.3.1
 

--- a/src/Sentry/Laravel/EventHandler.php
+++ b/src/Sentry/Laravel/EventHandler.php
@@ -135,8 +135,11 @@ class EventHandler
      */
     public function subscribe()
     {
+        /** @var \Illuminate\Events\Dispatcher $dispatcher */
+        $dispatcher = $this->app['events'];
+
         foreach (static::$eventHandlerMap as $eventName => $handler) {
-            $this->app->events->listen($eventName, [$this, $handler]);
+            $dispatcher->listen($eventName, [$this, $handler]);
         }
     }
 
@@ -145,8 +148,11 @@ class EventHandler
      */
     public function subscribeAuthEvents()
     {
+        /** @var \Illuminate\Events\Dispatcher $dispatcher */
+        $dispatcher = $this->app['events'];
+
         foreach (static::$authEventHandlerMap as $eventName => $handler) {
-            $this->app->events->listen($eventName, [$this, $handler]);
+            $dispatcher->listen($eventName, [$this, $handler]);
         }
     }
 
@@ -162,8 +168,11 @@ class EventHandler
             $this->afterQueuedJob();
         });
 
+        /** @var \Illuminate\Events\Dispatcher $dispatcher */
+        $dispatcher = $this->app['events'];
+
         foreach (static::$queueEventHandlerMap as $eventName => $handler) {
-            $this->app->events->listen($eventName, [$this, $handler]);
+            $dispatcher->listen($eventName, [$this, $handler]);
         }
     }
 

--- a/src/Sentry/Laravel/Integration.php
+++ b/src/Sentry/Laravel/Integration.php
@@ -38,7 +38,7 @@ class Integration implements IntegrationInterface
                 return $event;
             }
 
-            if (null === $event->getTransaction()) {
+            if (empty($event->getTransaction())) {
                 $event->setTransaction($self->getTransaction());
             }
 

--- a/src/Sentry/Laravel/Integration.php
+++ b/src/Sentry/Laravel/Integration.php
@@ -155,7 +155,8 @@ class Integration implements IntegrationInterface
 
             // Strip away the base namespace from the action name
             if (!empty($baseNamespace)) {
-                $routeName = Str::after($routeName, $baseNamespace . '\\');
+                // @see: Str::after, but this is not available before Laravel 5.4 so we use a inlined version
+                $routeName = array_reverse(explode($baseNamespace . '\\', $routeName, 2))[0];
             }
         }
 

--- a/test/Sentry/IntegrationTest.php
+++ b/test/Sentry/IntegrationTest.php
@@ -22,7 +22,9 @@ class IntegrationTest extends SentryLaravelTestCase
         Integration::setTransaction(null);
 
         $event = new RouteMatched(
-            new Route('GET', $routeUrl = '/sentry-route-matched-event', null),
+            new Route('GET', $routeUrl = '/sentry-route-matched-event', static function () {
+                // do nothing...
+            }),
             Mockery::mock(Request::class)->makePartial()
         );
 
@@ -36,7 +38,9 @@ class IntegrationTest extends SentryLaravelTestCase
         Integration::setTransaction(null);
 
         $this->dispatchLaravelEvent('router.matched', [
-            new Route('GET', $routeUrl = '/sentry-router-matched-event', null),
+            new Route('GET', $routeUrl = '/sentry-router-matched-event', static function () {
+                // do nothing...
+            }),
         ]);
 
         $this->assertSame($routeUrl, Integration::getTransaction());

--- a/test/Sentry/IntegrationTest.php
+++ b/test/Sentry/IntegrationTest.php
@@ -21,7 +21,7 @@ class IntegrationTest extends SentryLaravelTestCase
         Integration::setTransaction(null);
 
         $event = new RouteMatched(
-            new Route('GET', $routeUrl = '/sentry-route-matched-event', 'SentryTest@testRouteMatchedEvent'),
+            new Route('GET', $routeUrl = '/sentry-route-matched-event', null),
             $this->mock(Request::class)
         );
 
@@ -35,7 +35,7 @@ class IntegrationTest extends SentryLaravelTestCase
         Integration::setTransaction(null);
 
         $this->dispatchLaravelEvent('router.matched', [
-            new Route('GET', $routeUrl = '/sentry-router-matched-event', 'SentryTest@testRouterMatchedEvent'),
+            new Route('GET', $routeUrl = '/sentry-router-matched-event', null),
         ]);
 
         $this->assertSame($routeUrl, Integration::getTransaction());

--- a/test/Sentry/IntegrationTest.php
+++ b/test/Sentry/IntegrationTest.php
@@ -5,6 +5,7 @@ namespace Sentry\Laravel\Tests;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Events\RouteMatched;
 use Illuminate\Routing\Route;
+use Mockery;
 use Sentry\Event;
 use Sentry\Laravel\Integration;
 use Sentry\State\Scope;
@@ -22,7 +23,7 @@ class IntegrationTest extends SentryLaravelTestCase
 
         $event = new RouteMatched(
             new Route('GET', $routeUrl = '/sentry-route-matched-event', null),
-            $this->mock(Request::class)
+            Mockery::mock(Request::class)->makePartial()
         );
 
         $this->dispatchLaravelEvent($event);

--- a/test/Sentry/IntegrationTest.php
+++ b/test/Sentry/IntegrationTest.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace Sentry\Laravel\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Sentry\ClientInterface;
+use Sentry\Event;
+use Sentry\Laravel\Integration;
+use Sentry\SentrySdk;
+use Sentry\State\Scope;
+use function Sentry\withScope;
+
+class IntegrationTest extends TestCase
+{
+    private static $integration;
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+
+        self::$integration = new Integration;
+        self::$integration->setupOnce();
+    }
+
+    public function testTransactionIsAppliedToEventWithoutTransaction(): void
+    {
+        /** @var ClientInterface&MockObject $client */
+        $client = $this->createMock(ClientInterface::class);
+        $client->expects($this->once())
+            ->method('getIntegration')
+            ->willReturn(self::$integration);
+
+        SentrySdk::getCurrentHub()->bindClient($client);
+
+        Integration::setTransaction($transaction = 'some-transaction-name');
+
+        withScope(function (Scope $scope) use ($transaction): void {
+            $event = Event::createEvent();
+
+            $this->assertNull($event->getTransaction());
+
+            $event = $scope->applyToEvent($event);
+
+            $this->assertNotNull($event);
+
+            $this->assertSame($transaction, $event->getTransaction());
+        });
+    }
+
+    public function testTransactionIsAppliedToEventWithEmptyTransaction(): void
+    {
+        /** @var ClientInterface&MockObject $client */
+        $client = $this->createMock(ClientInterface::class);
+        $client->expects($this->once())
+            ->method('getIntegration')
+            ->willReturn(self::$integration);
+
+        SentrySdk::getCurrentHub()->bindClient($client);
+
+        Integration::setTransaction($transaction = 'some-transaction-name');
+
+        withScope(function (Scope $scope) use ($transaction): void {
+            $event = Event::createEvent();
+            $event->setTransaction($emptyTransaction = '');
+
+            $this->assertSame($emptyTransaction, $event->getTransaction());
+
+            $event = $scope->applyToEvent($event);
+
+            $this->assertNotNull($event);
+
+            $this->assertSame($transaction, $event->getTransaction());
+        });
+    }
+
+    public function testTransactionIsNotAppliedToEventWhenTransactionIsAlreadySet(): void
+    {
+        /** @var ClientInterface&MockObject $client */
+        $client = $this->createMock(ClientInterface::class);
+        $client->expects($this->once())
+            ->method('getIntegration')
+            ->willReturn(self::$integration);
+
+        SentrySdk::getCurrentHub()->bindClient($client);
+
+        Integration::setTransaction('some-transaction-name');
+
+        withScope(function (Scope $scope): void {
+            $event = Event::createEvent();
+
+            $event->setTransaction($eventTransaction = 'some-other-transaction-name');
+
+            $this->assertSame($eventTransaction, $event->getTransaction());
+
+            $event = $scope->applyToEvent($event);
+
+            $this->assertNotNull($event);
+
+            $this->assertSame($eventTransaction, $event->getTransaction());
+        });
+    }
+}


### PR DESCRIPTION
I noticed that sometimes the transaction on an event is an empty string.

If this is the case we should try to add our own transaction name too, not just for `null`.

Added some tests to verify the behaviour too.