### PR TITLE
Fix repeated booted callback registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Remove wrapper around the context of log entry breadcrumbs (#405)
 - Ensure user integrations are always executed after SDK integrations (#474)
+- Fix repeated booted callback registration from performance tracing middleware (#475)
 
 ## 2.4.2
 

--- a/src/Sentry/Laravel/Tracing/ServiceProvider.php
+++ b/src/Sentry/Laravel/Tracing/ServiceProvider.php
@@ -39,7 +39,7 @@ class ServiceProvider extends BaseServiceProvider
 
         if (!$this->app instanceof Lumen) {
             $this->app->booted(function () {
-                $this->app->make(Middleware::class)->setBootedTimestamp(microtime(true));
+                $this->app->make(Middleware::class)->setBootedTimestamp();
             });
         }
     }

--- a/src/Sentry/Laravel/Tracing/ServiceProvider.php
+++ b/src/Sentry/Laravel/Tracing/ServiceProvider.php
@@ -36,6 +36,10 @@ class ServiceProvider extends BaseServiceProvider
     public function register(): void
     {
         $this->app->singleton(Middleware::class);
+
+        $this->app->booted(function () {
+            $this->app->make(Middleware::class)->setBootedTimestamp(microtime(true));
+        });
     }
 
     private function bindEvents(): void

--- a/src/Sentry/Laravel/Tracing/ServiceProvider.php
+++ b/src/Sentry/Laravel/Tracing/ServiceProvider.php
@@ -37,9 +37,11 @@ class ServiceProvider extends BaseServiceProvider
     {
         $this->app->singleton(Middleware::class);
 
-        $this->app->booted(function () {
-            $this->app->make(Middleware::class)->setBootedTimestamp(microtime(true));
-        });
+        if (!$this->app instanceof Lumen) {
+            $this->app->booted(function () {
+                $this->app->make(Middleware::class)->setBootedTimestamp(microtime(true));
+            });
+        }
     }
 
     private function bindEvents(): void


### PR DESCRIPTION
Fixes #472 

The `Middleware` class was relying on booted callback to measure the amount of time it takes for application to bootstrap, observing the difference between the Laravel start time (using the defined constant) or request start time from SAPI (if one is available) and falling back onto the timestamp when the request hit middleware. There were two issues with this approach:

- once request hits middleware, the framework has already finished booting by this point in time and the registered booted callback is fired immediately anyway, so there is no reason to have a step of indirection like that;
- but secondly, and more importantly, adding booted callback on each request meant that if the middleware to be used in long running process, such as when running from RoadRunner, Swoole or PSR-7 based web server and reusing application instances, they will accumulate and eventually tripping the memory limit or be OOM-killed;

therefore, after a brief conversation in #472, we agreed on inlining the booted callback into the middleware itself, which this commit is addressing.