### PR TITLE
Replace usage of removed Sentry\FlushableClientInterface with Sentry\ClientInterface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Correctly call flush on the PHP SDK client (#484)
+
 ## 2.5.1
 
 - Fix problem with queue tracing when triggered from unit tests or when missing a queue name in the event

--- a/src/Sentry/Laravel/Integration.php
+++ b/src/Sentry/Laravel/Integration.php
@@ -113,7 +113,7 @@ class Integration implements IntegrationInterface
     {
         $client = SentrySdk::getCurrentHub()->getClient();
 
-        if ($client instanceof ClientInterface) {
+        if ($client !== null) {
             $client->flush();
         }
     }

--- a/src/Sentry/Laravel/Integration.php
+++ b/src/Sentry/Laravel/Integration.php
@@ -4,10 +4,8 @@ namespace Sentry\Laravel;
 
 use Illuminate\Routing\Route;
 use Illuminate\Support\Str;
-use Sentry\ClientInterface;
 use Sentry\SentrySdk;
 use Sentry\Tracing\Span;
-use Sentry\Tracing\Transaction;
 use function Sentry\addBreadcrumb;
 use function Sentry\configureScope;
 use Sentry\Breadcrumb;

--- a/src/Sentry/Laravel/Integration.php
+++ b/src/Sentry/Laravel/Integration.php
@@ -4,7 +4,7 @@ namespace Sentry\Laravel;
 
 use Illuminate\Routing\Route;
 use Illuminate\Support\Str;
-use Sentry\FlushableClientInterface;
+use Sentry\ClientInterface;
 use Sentry\SentrySdk;
 use Sentry\Tracing\Span;
 use Sentry\Tracing\Transaction;
@@ -113,7 +113,7 @@ class Integration implements IntegrationInterface
     {
         $client = SentrySdk::getCurrentHub()->getClient();
 
-        if ($client instanceof FlushableClientInterface) {
+        if ($client instanceof ClientInterface) {
             $client->flush();
         }
     }


### PR DESCRIPTION
This fixes an issue where the condition `if ($client instanceof FlushableClientInterface) {` always returns `false`, as Sentry SDK removed `FlushableClientInterface` in 3.0.0 - see https://github.com/getsentry/sentry-php/blob/master/CHANGELOG.md#300-2020-09-28

Replacing with `ClientInterface` which is implemented by `Client` and also enforces the `flush` method.