### PR TITLE
Fix TypeError in SentryHandler when passing non-string tags through log channels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Update phpdoc on facade for better IDE autocompletion (#504)
 - Exceptions captured using log channels (Monolog) will now have the correct severity set (#505)
+- Tags passed through log channels (Monolog) context are cast as string to prevent type errors (#507)
 
 ## 2.7.0
 

--- a/src/Sentry/Laravel/SentryHandler.php
+++ b/src/Sentry/Laravel/SentryHandler.php
@@ -188,7 +188,7 @@ class SentryHandler extends AbstractProcessingHandler
 
                 if (!empty($record['context']['tags'])) {
                     foreach ($record['context']['tags'] as $key => $tag) {
-                        $scope->setTag($key, $tag);
+                        $scope->setTag($key, (string)$tag);
                     }
                     unset($record['context']['tags']);
                 }

--- a/src/Sentry/Laravel/SentryHandler.php
+++ b/src/Sentry/Laravel/SentryHandler.php
@@ -205,7 +205,7 @@ class SentryHandler extends AbstractProcessingHandler
                 }
 
                 if (!empty($record['context']['user'])) {
-                    $scope->setUser((array)$record['context']['user'], true);
+                    $scope->setUser((array)$record['context']['user']);
                     unset($record['context']['user']);
                 }
 


### PR DESCRIPTION
Since sentry-php package has migrated to strict types, laravel logging does not work anymore as it should. We have a lot of cases through out the project where we use null values and int values to tag logs by and this change could fix that. Also we should maintain backward compatibility. 

Laravel framework itself does not use strict types, so this package should follow same philosophy. Also log handler should be as fail proof as possible.

Example:
```php
 \Log::info("paypal transaction failed", [
    'tags' => [
          'order_id' => $order->id,//int
          'transaction_token' => $transaction['token'],
          'ppid' => $transaction['gateway_transaction_id'] ?? null,//string or null
    ]
]);
```

Stacktrace:
```
TypeError thrown with message "Sentry\State\Scope::setTag(): Argument #2 ($value) must be of type string, null given, called in /var/www/vendor/sentry/sentry-laravel/src/Sentry/Laravel/SentryHandler.php on line 191"

Stacktrace:
#84 TypeError in /var/www/vendor/sentry/sentry/src/State/Scope.php:85
#83 Sentry\State\Scope:setTag in /var/www/vendor/sentry/sentry-laravel/src/Sentry/Laravel/SentryHandler.php:191
#82 Sentry\Laravel\SentryHandler:Sentry\Laravel\{closure} in /var/www/vendor/sentry/sentry/src/State/Hub.php:93
#81 Sentry\State\Hub:withScope in /var/www/vendor/sentry/sentry-laravel/src/Sentry/Laravel/SentryHandler.php:249
#80 Sentry\Laravel\SentryHandler:write in /var/www/vendor/monolog/monolog/src/Monolog/Handler/AbstractProcessingHandler.php:48
#79 Monolog\Handler\AbstractProcessingHandler:handle in /var/www/vendor/monolog/monolog/src/Monolog/Logger.php:326
#78 Monolog\Logger:addRecord in /var/www/vendor/monolog/monolog/src/Monolog/Logger.php:520
#77 Monolog\Logger:info in /var/www/vendor/laravel/framework/src/Illuminate/Log/Logger.php:183
#76 Illuminate\Log\Logger:writeLog in /var/www/vendor/laravel/framework/src/Illuminate/Log/Logger.php:130
#75 Illuminate\Log\Logger:info in /var/www/vendor/laravel/framework/src/Illuminate/Log/LogManager.php:599
#74 Illuminate\Log\LogManager:info in /var/www/vendor/laravel/framework/src/Illuminate/Support/Facades/Facade.php:261
#73 Illuminate\Support\Facades\Facade:__callStatic in /var/www/app/Payments/Gateways/SpreedlyGateway.php:196
...
#68 App\Payments\AbstractGateway:nextPage in /var/www/vendor/laravel/framework/src/Illuminate/Container/BoundMethod.php:36
#67 Illuminate\Container\BoundMethod:Illuminate\Container\{closure} in /var/www/vendor/laravel/framework/src/Illuminate/Container/Util.php:40
#66 Illuminate\Container\Util:unwrapIfClosure in /var/www/vendor/laravel/framework/src/Illuminate/Container/BoundMethod.php:93
#65 Illuminate\Container\BoundMethod:callBoundMethod in /var/www/vendor/laravel/framework/src/Illuminate/Container/BoundMethod.php:37
#64 Illuminate\Container\BoundMethod:call in /var/www/vendor/laravel/framework/src/Illuminate/Container/Container.php:651
#63 Illuminate\Container\Container:call in /var/www/app/Http/Controllers/CheckoutController.php:212
#62 App\Http\Controllers\CheckoutController:processReturn in /var/www/vendor/laravel/framework/src/Illuminate/Routing/ControllerDispatcher.php:48
#61 Illuminate\Routing\ControllerDispatcher:dispatch in /var/www/vendor/laravel/framework/src/Illuminate/Routing/Route.php:254
#60 Illuminate\Routing\Route:runController in /var/www/vendor/laravel/framework/src/Illuminate/Routing/Route.php:197
#59 Illuminate\Routing\Route:run in /var/www/vendor/laravel/framework/src/Illuminate/Routing/Router.php:695
#58 Illuminate\Routing\Router:Illuminate\Routing\{closure} in /var/www/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php:128
#57 Illuminate\Pipeline\Pipeline:Illuminate\Pipeline\{closure} in /var/www/app/Http/Middleware/LoadSale.php:34
#56 App\Http\Middleware\LoadSale:handle in /var/www/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php:167
#55 Illuminate\Pipeline\Pipeline:Illuminate\Pipeline\{closure} in /var/www/app/Http/Middleware/SaveParams.php:36
#54 App\Http\Middleware\SaveParams:handle in /var/www/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php:167
#53 Illuminate\Pipeline\Pipeline:Illuminate\Pipeline\{closure} in /var/www/vendor/laravel/framework/src/Illuminate/Routing/Middleware/SubstituteBindings.php:50
#52 Illuminate\Routing\Middleware\SubstituteBindings:handle in /var/www/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php:167
#51 Illuminate\Pipeline\Pipeline:Illuminate\Pipeline\{closure} in /var/www/vendor/laravel/framework/src/Illuminate/Foundation/Http/Middleware/VerifyCsrfToken.php:78
#50 Illuminate\Foundation\Http\Middleware\VerifyCsrfToken:handle in /var/www/app/Http/Middleware/VerifyCsrfToken.php:40
#49 App\Http\Middleware\VerifyCsrfToken:handle in /var/www/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php:167
#48 Illuminate\Pipeline\Pipeline:Illuminate\Pipeline\{closure} in /var/www/vendor/laravel/framework/src/Illuminate/View/Middleware/ShareErrorsFromSession.php:49
#47 Illuminate\View\Middleware\ShareErrorsFromSession:handle in /var/www/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php:167
#46 Illuminate\Pipeline\Pipeline:Illuminate\Pipeline\{closure} in /var/www/vendor/laravel/framework/src/Illuminate/Session/Middleware/StartSession.php:121
#45 Illuminate\Session\Middleware\StartSession:handleStatefulRequest in /var/www/vendor/laravel/framework/src/Illuminate/Session/Middleware/StartSession.php:64
#44 Illuminate\Session\Middleware\StartSession:handle in /var/www/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php:167
#43 Illuminate\Pipeline\Pipeline:Illuminate\Pipeline\{closure} in /var/www/vendor/laravel/framework/src/Illuminate/Cookie/Middleware/AddQueuedCookiesToResponse.php:37
#42 Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse:handle in /var/www/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php:167
#41 Illuminate\Pipeline\Pipeline:Illuminate\Pipeline\{closure} in /var/www/vendor/laravel/framework/src/Illuminate/Cookie/Middleware/EncryptCookies.php:67
#40 Illuminate\Cookie\Middleware\EncryptCookies:handle in /var/www/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php:167
#39 Illuminate\Pipeline\Pipeline:Illuminate\Pipeline\{closure} in /var/www/vendor/laravel/framework/src/Illuminate/Foundation/Http/Middleware/TransformsRequest.php:21
#38 Illuminate\Foundation\Http\Middleware\TransformsRequest:handle in /var/www/vendor/laravel/framework/src/Illuminate/Foundation/Http/Middleware/ConvertEmptyStringsToNull.php:31
#37 Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull:handle in /var/www/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php:167
#36 Illuminate\Pipeline\Pipeline:Illuminate\Pipeline\{closure} in /var/www/vendor/laravel/framework/src/Illuminate/Foundation/Http/Middleware/TransformsRequest.php:21
#35 Illuminate\Foundation\Http\Middleware\TransformsRequest:handle in /var/www/vendor/laravel/framework/src/Illuminate/Foundation/Http/Middleware/TrimStrings.php:40
#34 Illuminate\Foundation\Http\Middleware\TrimStrings:handle in /var/www/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php:167
#33 Illuminate\Pipeline\Pipeline:Illuminate\Pipeline\{closure} in /var/www/app/Http/Middleware/MysqlSetMasterConnection.php:23
#32 App\Http\Middleware\MysqlSetMasterConnection:handle in /var/www/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php:167
#31 Illuminate\Pipeline\Pipeline:Illuminate\Pipeline\{closure} in /var/www/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php:103
#30 Illuminate\Pipeline\Pipeline:then in /var/www/vendor/laravel/framework/src/Illuminate/Routing/Router.php:697
#29 Illuminate\Routing\Router:runRouteWithinStack in /var/www/vendor/laravel/framework/src/Illuminate/Routing/Router.php:672
#28 Illuminate\Routing\Router:runRoute in /var/www/vendor/laravel/framework/src/Illuminate/Routing/Router.php:636
#27 Illuminate\Routing\Router:dispatchToRoute in /var/www/vendor/laravel/framework/src/Illuminate/Routing/Router.php:625
#26 Illuminate\Routing\Router:dispatch in /var/www/vendor/laravel/framework/src/Illuminate/Foundation/Http/Kernel.php:166
#25 Illuminate\Foundation\Http\Kernel:Illuminate\Foundation\Http\{closure} in /var/www/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php:128
#24 Illuminate\Pipeline\Pipeline:Illuminate\Pipeline\{closure} in /var/www/vendor/sentry/sentry-laravel/src/Sentry/Laravel/Http/SetRequestIpMiddleware.php:55
#23 Sentry\Laravel\Http\SetRequestIpMiddleware:handle in /var/www/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php:167
#22 Illuminate\Pipeline\Pipeline:Illuminate\Pipeline\{closure} in /var/www/vendor/sentry/sentry-laravel/src/Sentry/Laravel/Http/SetRequestMiddleware.php:52
#21 Sentry\Laravel\Http\SetRequestMiddleware:handle in /var/www/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php:167
#20 Illuminate\Pipeline\Pipeline:Illuminate\Pipeline\{closure} in /var/www/vendor/barryvdh/laravel-debugbar/src/Middleware/InjectDebugbar.php:67
#19 Barryvdh\Debugbar\Middleware\InjectDebugbar:handle in /var/www/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php:167
#18 Illuminate\Pipeline\Pipeline:Illuminate\Pipeline\{closure} in /var/www/app/Http/Middleware/NoCacheUpgradeWithNoStore.php:15
#17 App\Http\Middleware\NoCacheUpgradeWithNoStore:handle in /var/www/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php:167
#16 Illuminate\Pipeline\Pipeline:Illuminate\Pipeline\{closure} in /var/www/vendor/fideloper/proxy/src/TrustProxies.php:57
#15 Fideloper\Proxy\TrustProxies:handle in /var/www/app/Http/Middleware/TrustProxies.php:50
#14 App\Http\Middleware\TrustProxies:handle in /var/www/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php:167
#13 Illuminate\Pipeline\Pipeline:Illuminate\Pipeline\{closure} in /var/www/app/Http/Middleware/HttpsMiddleware.php:19
#12 App\Http\Middleware\HttpsMiddleware:handle in /var/www/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php:167
#11 Illuminate\Pipeline\Pipeline:Illuminate\Pipeline\{closure} in /var/www/app/Stats/StatsMiddleware.php:21
#10 App\Stats\StatsMiddleware:handle in /var/www/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php:167
#9 Illuminate\Pipeline\Pipeline:Illuminate\Pipeline\{closure} in /var/www/vendor/laravel/framework/src/Illuminate/Foundation/Http/Middleware/ValidatePostSize.php:27
#8 Illuminate\Foundation\Http\Middleware\ValidatePostSize:handle in /var/www/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php:167
#7 Illuminate\Pipeline\Pipeline:Illuminate\Pipeline\{closure} in /var/www/vendor/laravel/framework/src/Illuminate/Foundation/Http/Middleware/PreventRequestsDuringMaintenance.php:86
#6 Illuminate\Foundation\Http\Middleware\PreventRequestsDuringMaintenance:handle in /var/www/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php:167
#5 Illuminate\Pipeline\Pipeline:Illuminate\Pipeline\{closure} in /var/www/vendor/sentry/sentry-laravel/src/Sentry/Laravel/Tracing/Middleware.php:53
#4 Sentry\Laravel\Tracing\Middleware:handle in /var/www/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php:167
#3 Illuminate\Pipeline\Pipeline:Illuminate\Pipeline\{closure} in /var/www/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php:103
#2 Illuminate\Pipeline\Pipeline:then in /var/www/vendor/laravel/framework/src/Illuminate/Foundation/Http/Kernel.php:141
#1 Illuminate\Foundation\Http\Kernel:sendRequestThroughRouter in /var/www/vendor/laravel/framework/src/Illuminate/Foundation/Http/Kernel.php:110
#0 Illuminate\Foundation\Http\Kernel:handle in /var/www/public/index.php:59
```