### PR TITLE
fix: check index is availability in method SentryHandler::handleBatch

### DIFF
--- a/src/Sentry/Laravel/SentryHandler.php
+++ b/src/Sentry/Laravel/SentryHandler.php
@@ -90,7 +90,9 @@ class SentryHandler extends AbstractProcessingHandler
         $record = array_reduce(
             $records,
             function ($highest, $record) {
-                if ($record['level'] > $highest['level']) {
+                if (!isset($highest['level'])
+                    || $record['level'] > $highest['level']
+                ) {
                     return $record;
                 }
 

--- a/src/Sentry/Laravel/SentryHandler.php
+++ b/src/Sentry/Laravel/SentryHandler.php
@@ -90,9 +90,7 @@ class SentryHandler extends AbstractProcessingHandler
         $record = array_reduce(
             $records,
             function ($highest, $record) {
-                if (!isset($highest['level'])
-                    || $record['level'] > $highest['level']
-                ) {
+                if ($highest === null || $record['level'] > $highest['level']) {
                     return $record;
                 }
 


### PR DESCRIPTION
When flushing logrecords with the handleBatch method the code now checks if $highets['level'] is available before using it.

fixes getsentry/sentry-laravel#514