### PR TITLE
Solves #516: Enable action_level configuration for using FingersCrossedHandler

### DIFF
--- a/src/Sentry/Laravel/LogChannel.php
+++ b/src/Sentry/Laravel/LogChannel.php
@@ -2,6 +2,7 @@
 
 namespace Sentry\Laravel;
 
+use Monolog\Handler\FingersCrossedHandler;
 use Monolog\Logger;
 use Illuminate\Log\LogManager;
 use Sentry\State\HubInterface;
@@ -22,6 +23,10 @@ class LogChannel extends LogManager
             $config['report_exceptions'] ?? true,
             isset($config['formatter']) && $config['formatter'] !== 'default'
         );
+
+        if (isset($config['action_level'])) {
+            $handler = new FingersCrossedHandler($handler, $config['action_level']);
+        }
 
         return new Logger(
             $this->parseChannel($config),

--- a/test/Sentry/Laravel/LogChannelTest.php
+++ b/test/Sentry/Laravel/LogChannelTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Sentry\Laravel\Tests\Sentry\Laravel;
+
+use Monolog\Handler\FingersCrossedHandler;
+use Sentry\Laravel\LogChannel;
+use Sentry\Laravel\SentryHandler;
+use Sentry\Laravel\Tests\SentryLaravelTestCase;
+
+class LogChannelTest  extends SentryLaravelTestCase
+{
+    public function test_creating_handler_without_action_level_config()
+    {
+        $logChannel = new LogChannel($this->app);
+        $logger = $logChannel([]);
+
+        $this->assertContainsOnlyInstancesOf(SentryHandler::class, $logger->getHandlers());
+    }
+
+    public function test_creating_handler_with_action_level_config()
+    {
+        $logChannel = new LogChannel($this->app);
+        $logger = $logChannel(['action_level' => 'critical']);
+
+        $this->assertContainsOnlyInstancesOf(FingersCrossedHandler::class, $logger->getHandlers());
+
+        $currentHandler = current($logger->getHandlers());
+        $this->assertInstanceOf(SentryHandler::class, $currentHandler->getHandler());
+
+        $loggerWithoutActionLevel = $logChannel(['action_level' => null]);
+
+        $this->assertContainsOnlyInstancesOf(SentryHandler::class, $loggerWithoutActionLevel->getHandlers());
+    }
+}


### PR DESCRIPTION
This update enables the user to provide the Sentry log channel with an action_level configuration. The inspiration for the configuration is taken from the Symfony Monolog configuration style.

All records at or above the provided level configuration will be buffered but not written to the logs. When a log record with a level at or above the action_level configuration is provided all the previously buffered log records will be flushed as context['logs'] and under Breadcrumbs in the Sentry log record.

closes getsentry/sentry-laravel#516
See https://symfony.com/doc/current/logging.html#handlers-that-modify-log-entries