### PR TITLE
traces_sampler - support dependency injection

### DIFF
--- a/src/Sentry/Laravel/ServiceProvider.php
+++ b/src/Sentry/Laravel/ServiceProvider.php
@@ -141,7 +141,7 @@ class ServiceProvider extends BaseServiceProvider
             Integration::setControllersBaseNamespace($userConfig['controllers_base_namespace']);
         }
 
-        $this->app->bind(ClientBuilderInterface::class, function (Application $app) {
+        $this->app->bind(ClientBuilderInterface::class, function ($app) {
             $basePath   = base_path();
             $userConfig = $this->getUserConfig();
 
@@ -159,6 +159,7 @@ class ServiceProvider extends BaseServiceProvider
 
             if (isset($options['traces_sampler']) === true) {
                 /** @var CallableProxy $proxy */
+                /** @var Application $app */
                 $proxy = $app->make(CallableProxy::class);
 
                 $options['traces_sampler'] = $proxy->proxyTraceSampler($options['traces_sampler']);

--- a/src/Sentry/Laravel/Tracing/CallableProxy.php
+++ b/src/Sentry/Laravel/Tracing/CallableProxy.php
@@ -6,7 +6,6 @@ namespace Sentry\Laravel\Tracing;
 
 use Illuminate\Contracts\Container\Container;
 use ReflectionClass;
-use ReflectionMethod;
 use Sentry\Tracing\SamplingContext;
 
 class CallableProxy
@@ -24,7 +23,7 @@ class CallableProxy
     /**
      * @param array|callable|null $tracesSampler
      *
-     * @return array|callable
+     * @return array|callable|null
      */
     public function proxyTraceSampler($tracesSampler)
     {

--- a/src/Sentry/Laravel/Tracing/CallableProxy.php
+++ b/src/Sentry/Laravel/Tracing/CallableProxy.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sentry\Laravel\Tracing;
+
+use Illuminate\Contracts\Container\Container;
+use ReflectionClass;
+use ReflectionMethod;
+use Sentry\Tracing\SamplingContext;
+
+class CallableProxy
+{
+    /**
+     * @var Container
+     */
+    private $container;
+
+    public function __construct(Container $container)
+    {
+        $this->container = $container;
+    }
+
+    /**
+     * @param array|callable|null $tracesSampler
+     *
+     * @return array|callable
+     */
+    public function proxyTraceSampler($tracesSampler)
+    {
+        if ($tracesSampler === null) {
+            return null;
+        }
+
+        if (is_callable($tracesSampler) === true) {
+            return function ($context) use ($tracesSampler) {
+                return $this->container->call($tracesSampler, [SamplingContext::class => $context]);
+            };
+        }
+
+        if (is_array($tracesSampler) === false || count($tracesSampler) !== 2) {
+            return $tracesSampler;
+        }
+
+        return function ($context) use ($tracesSampler) {
+            $class = $tracesSampler[0];
+            $method = $tracesSampler[1];
+
+            $reflection = new ReflectionClass($class);
+            $methodDefinition = $reflection->getMethod($method);
+
+            // Check if static method is used otherwise create the class
+            if ($methodDefinition->isStatic() === true) {
+                $classOrObject = $class;
+            } else {
+                $classOrObject = $this->container->make($class);
+            }
+
+            return $this->container->call([$classOrObject, $method], [SamplingContext::class => $context]);
+        };
+    }
+}

--- a/test/Sentry/ServiceProviderWithSamplerFromConfigTest.php
+++ b/test/Sentry/ServiceProviderWithSamplerFromConfigTest.php
@@ -53,7 +53,7 @@ class ServiceProviderWithSamplerFromConfigTest extends SentryLaravelTestCase
 
     public function testTracesSamplerWithStaticMethodInClassButDoesNotExists(): void
     {
-        $this->expectExceptionMessage('Class "asd" does not exist');
+        $this->expectExceptionMessage('does not exist');
         $this->resetApplicationWithConfig([
             'sentry.traces_sampler' => ['asd', 'asd'],
         ]);

--- a/test/Sentry/ServiceProviderWithSamplerFromConfigTest.php
+++ b/test/Sentry/ServiceProviderWithSamplerFromConfigTest.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace Sentry;
+
+use Illuminate\Contracts\Container\Container;
+use Sentry\Laravel\Tests\SentryLaravelTestCase;
+use Sentry\Laravel\Tests\TestSentryService;
+use Sentry\Tracing\SamplingContext;
+use Sentry\Tracing\TransactionContext;
+
+class ServiceProviderWithSamplerFromConfigTest extends SentryLaravelTestCase
+{
+
+    public function testEmptyTracesSampler(): void
+    {
+        $this->resetApplicationWithConfig([
+            'sentry.traces_sampler' => null,
+        ]);
+
+        $this->assertSampler(null);
+    }
+
+    public function testTracesSamplerWithClosure(): void
+    {
+        $this->resetApplicationWithConfig([
+            'sentry.traces_sampler' => function (TransactionContext $context) {
+                return 5;
+            },
+        ]);
+
+        $this->assertSampler(5);
+    }
+
+    public function testTracesSamplerWithClosureAndDependencyInjection(): void
+    {
+        $this->resetApplicationWithConfig([
+            'sentry.traces_sampler' => function (TransactionContext $context, Container $container) {
+                $this->assertSame($this->app->make(Container::class), $container);
+                return 5;
+            },
+        ]);
+
+        $this->assertSampler(5);
+    }
+
+    public function testTracesSamplerWithInvalidValue(): void
+    {
+        $this->expectExceptionMessage('with value array is expected to be of type');
+        $this->resetApplicationWithConfig([
+            'sentry.traces_sampler' => ['asd'],
+        ]);
+    }
+
+    public function testTracesSamplerWithStaticMethodInClassButDoesNotExists(): void
+    {
+        $this->expectExceptionMessage('Class "asd" does not exist');
+        $this->resetApplicationWithConfig([
+            'sentry.traces_sampler' => ['asd', 'asd'],
+        ]);
+
+        $this->assertSampler(null);
+    }
+
+    public function testTracesSamplerWithUnknownMethod(): void
+    {
+        $this->expectExceptionMessage('test() does not exist');
+        $this->resetApplicationWithConfig([
+            'sentry.traces_sampler' => [TestSentryService::class, 'test'],
+        ]);
+
+        $this->assertSampler(null);
+    }
+
+    public function testTracesSamplerWithStaticMethod(): void
+    {
+        $this->resetApplicationWithConfig([
+            'sentry.traces_sampler' => [TestSentryService::class, 'staticSampler'],
+        ]);
+
+        $this->assertSampler(1);
+    }
+
+    public function testTracesSamplerWithStaticMethodWithDependencyInjection(): void
+    {
+        $this->resetApplicationWithConfig([
+            'sentry.traces_sampler' => [TestSentryService::class, 'staticSamplerDependency'],
+        ]);
+
+        $this->assertSampler(2);
+    }
+
+    public function testTracesSamplerWithObjectMethod(): void
+    {
+        $this->resetApplicationWithConfig([
+            'sentry.traces_sampler' => [TestSentryService::class, 'sampler'],
+        ]);
+
+        $this->assertSampler(3);
+    }
+
+    public function testTracesSamplerWithObjectMethodWithDependencyInjection(): void
+    {
+        $this->resetApplicationWithConfig([
+            'sentry.traces_sampler' => [TestSentryService::class, 'samplerDependency'],
+        ]);
+
+        $this->assertSampler(4);
+    }
+
+    protected function assertSampler(?float $expected): void
+    {
+        $options = $this->getHubFromContainer()->getClient()->getOptions();
+        $samplingContext = SamplingContext::getDefault(new TransactionContext());
+
+        $tracesSampler = $options->getTracesSampler();
+
+        $sampleRate = null !== $tracesSampler
+            ? $tracesSampler($samplingContext)
+            : null;
+
+        $this->assertEquals($expected, $sampleRate);
+    }
+
+}

--- a/test/Sentry/TestSentryService.php
+++ b/test/Sentry/TestSentryService.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Sentry\Laravel\Tests;
 
 use Illuminate\Contracts\Container\Container;
+use Sentry\ServiceProviderWithSamplerFromConfigTest;
 use Sentry\Tracing\SamplingContext;
 
 class TestSentryService
@@ -14,6 +15,11 @@ class TestSentryService
      */
     protected $container;
 
+    /**
+     * @var ServiceProviderWithSamplerFromConfigTest
+     */
+    static $testCase;
+
     public function __construct(Container $container)
     {
         $this->container = $container;
@@ -21,21 +27,29 @@ class TestSentryService
 
     public static function staticSampler(SamplingContext $context): float
     {
+        self::$testCase->assertSame(self::$testCase->samplingContext, $context);
+
         return 1;
     }
 
     public static function staticSamplerDependency(SamplingContext $context): float
     {
+        self::$testCase->assertSame(self::$testCase->samplingContext, $context);
+
         return 2;
     }
 
     public function sampler(SamplingContext $context): float
     {
+        self::$testCase->assertSame(self::$testCase->samplingContext, $context);
+
         return 3;
     }
 
     public function samplerDependency(SamplingContext $context, Container $container): float
     {
+        self::$testCase->assertSame(self::$testCase->samplingContext, $context);
+
         return 4;
     }
 }

--- a/test/Sentry/TestSentryService.php
+++ b/test/Sentry/TestSentryService.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sentry\Laravel\Tests;
+
+use Illuminate\Contracts\Container\Container;
+use Sentry\Tracing\SamplingContext;
+
+class TestSentryService
+{
+    /**
+     * @var Container
+     */
+    protected $container;
+
+    public function __construct(Container $container)
+    {
+        $this->container = $container;
+    }
+
+    public static function staticSampler(SamplingContext $context): float
+    {
+        return 1;
+    }
+
+    public static function staticSamplerDependency(SamplingContext $context): float
+    {
+        return 2;
+    }
+
+    public function sampler(SamplingContext $context): float
+    {
+        return 3;
+    }
+
+    public function samplerDependency(SamplingContext $context, Container $container): float
+    {
+        return 4;
+    }
+}


### PR DESCRIPTION
Use container dependency injection for provided callable / class method traces_sampler

- Supports static / non-static method in the class
- Supports callables

Related to to #536


Is it possible write tests targeting Lumen? Not use if it works.