### PR TITLE
Allow extending the Laravel specific config options

### DIFF
--- a/src/Sentry/Laravel/ServiceProvider.php
+++ b/src/Sentry/Laravel/ServiceProvider.php
@@ -26,7 +26,7 @@ class ServiceProvider extends BaseServiceProvider
     /**
      * List of configuration options that are Laravel specific and should not be sent to the base PHP SDK.
      */
-    private const LARAVEL_SPECIFIC_OPTIONS = [
+    protected const LARAVEL_SPECIFIC_OPTIONS = [
         // We do not want these settings to hit the PHP SDK because they are Laravel specific and the PHP SDK will throw errors
         'tracing',
         'breadcrumbs',
@@ -143,7 +143,7 @@ class ServiceProvider extends BaseServiceProvider
             $basePath   = base_path();
             $userConfig = $this->getUserConfig();
 
-            foreach (self::LARAVEL_SPECIFIC_OPTIONS as $laravelSpecificOptionName) {
+            foreach (static::LARAVEL_SPECIFIC_OPTIONS as $laravelSpecificOptionName) {
                 unset($userConfig[$laravelSpecificOptionName]);
             }
 


### PR DESCRIPTION
Adding custom config keys to `/config/sentry.php` causes the Sentry SDK to throw an error.

This change allows hiding the new config from the Sentry SDK by adding custom config values to the `LARAVEL_SPECIFIC_OPTIONS` array in a custom service provider:


```php
//    /config/sentry.php

return [
    'custom_config_key' => 'some value',      // adding this caused the SDK to throw an error

    // the rest of Sentry's config
    // ...
];
```


```php
class App\Providers\CustomSentryServiceProvider extends Sentry\Laravel\ServiceProvider
{
    protected const LARAVEL_SPECIFIC_OPTIONS = [
        'custom_config_key',

        // other Laravel-specific config
        // ...
    ];
}
```