### PR TITLE
fix: Fix not listening to queue events because `QueueManager` is registered as `queue` in the container and not by it's class name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fix not listening to queue events because `QueueManager` is registered as `queue` in the container and not by it's class name (#568)
+
 ## 2.13.0
 
 - Only catch `BindingResolutionException` when trying to get the PSR-7 request object from the container

--- a/src/Sentry/Laravel/Tracing/ServiceProvider.php
+++ b/src/Sentry/Laravel/Tracing/ServiceProvider.php
@@ -72,9 +72,9 @@ class ServiceProvider extends BaseServiceProvider
 
         $handler->subscribe();
 
-        if ($this->app->bound(QueueManager::class)) {
+        if ($this->app->bound('queue')) {
             $handler->subscribeQueueEvents(
-                $this->app->make(QueueManager::class)
+                $this->app->make('queue')
             );
         }
     }


### PR DESCRIPTION
Fix doesn't send queue job transaction trace.
Because Laravel 8.X and Lumen 8.X regist queue manager:
```php
$this->app->singleton('queue', function ($app) {
            // Once we have an instance of the queue manager, we will register the various
            // resolvers for the queue connectors. These connectors are responsible for
            // creating the classes that accept queue configs and instantiate queues.
            return tap(new QueueManager($app), function ($manager) {
                $this->registerConnectors($manager);
            });
});
```
see ```illumanate\queue\QueueServiceProvider.php registerManager```
so
```Tracing\ServiceProvider.php bindEvents```
```php
if ($this->app->bound(QueueManager::class)) {
            $handler->subscribeQueueEvents(
                $this->app->make(QueueManager::class)
            );
}
```

will always skip.