### PR TITLE
feat: Add support for Dynamic Sampling

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.2 | ^8.0",
         "illuminate/support": "5.0 - 5.8 | ^6.0 | ^7.0 | ^8.0 | ^9.0",
-        "sentry/sentry": "^3.3",
+        "sentry/sentry": "^3.9",
         "sentry/sdk": "^3.1",
         "symfony/psr-http-message-bridge": "^1.0 | ^2.0",
         "nyholm/psr7": "^1.0"

--- a/src/Sentry/Laravel/Console/TestCommand.php
+++ b/src/Sentry/Laravel/Console/TestCommand.php
@@ -140,6 +140,7 @@ class TestCommand extends Command
             $transactionContext = new TransactionContext();
             $transactionContext->setSampled(true);
             $transactionContext->setName('Sentry Test Transaction');
+            $transactionContext->setSource(TransactionSource::custom());
             $transactionContext->setOp('sentry.test');
 
             $transaction = $hub->startTransaction($transactionContext);

--- a/src/Sentry/Laravel/EventHandler.php
+++ b/src/Sentry/Laravel/EventHandler.php
@@ -283,7 +283,7 @@ class EventHandler
      */
     protected function routerMatchedHandler(Route $route)
     {
-        $routeName = Integration::extractNameForRoute($route);
+        [$routeName] = Integration::extractNameAndSourceForRoute($route);
 
         Integration::addBreadcrumb(new Breadcrumb(
             Breadcrumb::LEVEL_INFO,

--- a/src/Sentry/Laravel/Integration.php
+++ b/src/Sentry/Laravel/Integration.php
@@ -6,6 +6,7 @@ use Illuminate\Routing\Route;
 use Illuminate\Support\Str;
 use Sentry\SentrySdk;
 use Sentry\Tracing\Span;
+use Sentry\Tracing\TransactionSource;
 use function Sentry\addBreadcrumb;
 use function Sentry\configureScope;
 use Sentry\Breadcrumb;
@@ -122,27 +123,45 @@ class Integration implements IntegrationInterface
      * @param \Illuminate\Routing\Route $route
      *
      * @return string
+     *
+     * @deprecated This will be removed in version 3.0, use `extractNameAndSourceForRoute` instead.
      */
     public static function extractNameForRoute(Route $route): string
     {
+        return self::extractNameAndSourceForRoute($route)[0];
+    }
+
+    /**
+     * Extract the readable name for a route and the transaction source for where that route name came from.
+     *
+     * @param \Illuminate\Routing\Route $route
+     *
+     * @return array{0: string, 1: \Sentry\Tracing\TransactionSource}
+     */
+    public static function extractNameAndSourceForRoute(Route $route): array
+    {
+        $source = null;
         $routeName = null;
 
-        // someaction (route name/alias)
+        // some.action (route name/alias)
         if ($route->getName()) {
+            $source = TransactionSource::component();
             $routeName = self::extractNameForNamedRoute($route->getName());
         }
 
         // Some\Controller@someAction (controller action)
         if (empty($routeName) && $route->getActionName()) {
+            $source = TransactionSource::component();
             $routeName = self::extractNameForActionRoute($route->getActionName());
         }
 
-        // /someaction // Fallback to the url
+        // /some/{action} // Fallback to the route uri (with parameter placeholders)
         if (empty($routeName) || $routeName === 'Closure') {
+            $source = TransactionSource::route();
             $routeName = '/' . ltrim($route->uri(), '/');
         }
 
-        return $routeName;
+        return [$routeName, $source];
     }
 
     /**
@@ -152,24 +171,42 @@ class Integration implements IntegrationInterface
      * @param string $path      The path of the request
      *
      * @return string
+     *
+     * @deprecated This will be removed in version 3.0, use `extractNameAndSourceForLumenRoute` instead.
      */
     public static function extractNameForLumenRoute(array $routeData, string $path): string
     {
+        return self::extractNameAndSourceForLumenRoute($routeData, $path)[0];
+    }
+
+    /**
+     * Extract the readable name for a Lumen route and the transaction source for where that route name came from.
+     *
+     * @param array  $routeData The array of route data
+     * @param string $path      The path of the request
+     *
+     * @return array{0: string, 1: \Sentry\Tracing\TransactionSource}
+     */
+    public static function extractNameAndSourceForLumenRoute(array $routeData, string $path): array
+    {
+        $source = null;
         $routeName = null;
 
         $route = $routeData[1] ?? [];
 
-        // someaction (route name/alias)
+        // some.action (route name/alias)
         if (!empty($route['as'])) {
+            $source = TransactionSource::component();
             $routeName = self::extractNameForNamedRoute($route['as']);
         }
 
         // Some\Controller@someAction (controller action)
         if (empty($routeName) && !empty($route['uses'])) {
+            $source = TransactionSource::component();
             $routeName = self::extractNameForActionRoute($route['uses']);
         }
 
-        // /someaction // Fallback to the url
+        // /some/{action} // Fallback to the route uri (with parameter placeholders)
         if (empty($routeName) || $routeName === 'Closure') {
             $routeUri = array_reduce(
                 array_keys($routeData[2]),
@@ -179,10 +216,11 @@ class Integration implements IntegrationInterface
                 $path
             );
 
+            $source = TransactionSource::url();
             $routeName = '/' . ltrim($routeUri, '/');
         }
 
-        return $routeName;
+        return [$routeName, $source];
     }
 
     /**

--- a/src/Sentry/Laravel/Integration.php
+++ b/src/Sentry/Laravel/Integration.php
@@ -247,7 +247,25 @@ class Integration implements IntegrationInterface
         }
 
         $content = sprintf('<meta name="sentry-trace" content="%s"/>', $span->toTraceparent());
-        // $content .= sprintf('<meta name="sentry-trace-data" content="%s"/>', $span->getDescription());
+
+        return $content;
+    }
+
+    /**
+     * Retrieve the meta tags with baggage information to link this request to front-end requests.
+     * This propagates the Dynamic Sampling Context.
+     *
+     * @return string
+     */
+    public static function sentryBaggageMeta(): string
+    {
+        $span = self::currentTracingSpan();
+
+        if ($span === null) {
+            return '';
+        }
+
+        $content = sprintf('<meta name="baggage" content="%s"/>', $span->toBaggage());
 
         return $content;
     }

--- a/src/Sentry/Laravel/Integration.php
+++ b/src/Sentry/Laravel/Integration.php
@@ -124,6 +124,7 @@ class Integration implements IntegrationInterface
      *
      * @return string
      *
+     * @internal   This helper is used in various places to extra meaninful info from a Laravel Route object.
      * @deprecated This will be removed in version 3.0, use `extractNameAndSourceForRoute` instead.
      */
     public static function extractNameForRoute(Route $route): string
@@ -137,6 +138,8 @@ class Integration implements IntegrationInterface
      * @param \Illuminate\Routing\Route $route
      *
      * @return array{0: string, 1: \Sentry\Tracing\TransactionSource}
+     *
+     * @internal This helper is used in various places to extra meaninful info from a Laravel Route object.
      */
     public static function extractNameAndSourceForRoute(Route $route): array
     {
@@ -172,6 +175,7 @@ class Integration implements IntegrationInterface
      *
      * @return string
      *
+     * @internal   This helper is used in various places to extra meaninful info from a Lumen route data.
      * @deprecated This will be removed in version 3.0, use `extractNameAndSourceForLumenRoute` instead.
      */
     public static function extractNameForLumenRoute(array $routeData, string $path): string
@@ -186,6 +190,8 @@ class Integration implements IntegrationInterface
      * @param string $path      The path of the request
      *
      * @return array{0: string, 1: \Sentry\Tracing\TransactionSource}
+     *
+     * @internal This helper is used in various places to extra meaninful info from a Lumen route data.
      */
     public static function extractNameAndSourceForLumenRoute(array $routeData, string $path): array
     {

--- a/src/Sentry/Laravel/Tracing/EventHandler.php
+++ b/src/Sentry/Laravel/Tracing/EventHandler.php
@@ -297,12 +297,10 @@ class EventHandler
         }
 
         if ($parentSpan === null) {
-            $traceParent = $event->job->payload()[self::QUEUE_PAYLOAD_TRACE_PARENT_DATA] ?? null;
             $baggage = $event->job->payload()[self::QUEUE_PAYLOAD_BAGGAGE_DATA] ?? null;
+            $traceParent = $event->job->payload()[self::QUEUE_PAYLOAD_TRACE_PARENT_DATA] ?? null;
 
-            $context = $traceParent === null
-                ? new TransactionContext
-                : TransactionContext::fromHeaders($traceParent, $baggage);
+            $context = TransactionContext::fromHeaders($traceParent ?? '', $baggage ?? '');
 
             // If the parent transaction was not sampled we also stop the queue job from being recorded
             if ($context->getParentSampled() === false) {

--- a/src/Sentry/Laravel/Tracing/EventHandler.php
+++ b/src/Sentry/Laravel/Tracing/EventHandler.php
@@ -16,10 +16,13 @@ use Sentry\SentrySdk;
 use Sentry\Tracing\SpanContext;
 use Sentry\Tracing\SpanStatus;
 use Sentry\Tracing\TransactionContext;
+use Sentry\Tracing\TransactionSource;
 
 class EventHandler
 {
     public const QUEUE_PAYLOAD_TRACE_PARENT_DATA = 'sentry_trace_parent_data';
+
+    public const QUEUE_PAYLOAD_BAGGAGE_DATA = 'sentry_baggage_data';
 
     /**
      * Map event handlers to events.
@@ -153,6 +156,7 @@ class EventHandler
 
                 if ($currentSpan !== null && $payload !== null) {
                     $payload[self::QUEUE_PAYLOAD_TRACE_PARENT_DATA] = $currentSpan->toTraceparent();
+                    $payload[self::QUEUE_PAYLOAD_BAGGAGE_DATA] = $currentSpan->toBaggage();
                 }
 
                 return $payload;
@@ -294,10 +298,11 @@ class EventHandler
 
         if ($parentSpan === null) {
             $traceParent = $event->job->payload()[self::QUEUE_PAYLOAD_TRACE_PARENT_DATA] ?? null;
+            $baggage = $event->job->payload()[self::QUEUE_PAYLOAD_BAGGAGE_DATA] ?? null;
 
             $context = $traceParent === null
                 ? new TransactionContext
-                : TransactionContext::fromSentryTrace($traceParent);
+                : TransactionContext::fromHeaders($traceParent, $baggage);
 
             // If the parent transaction was not sampled we also stop the queue job from being recorded
             if ($context->getParentSampled() === false) {
@@ -325,6 +330,7 @@ class EventHandler
 
         if ($context instanceof TransactionContext) {
             $context->setName($resolvedJobName ?? $event->job->getName());
+            $context->setSource(TransactionSource::task());
         }
 
         $context->setOp('queue.process');

--- a/src/Sentry/Laravel/Tracing/Integrations/LighthouseIntegration.php
+++ b/src/Sentry/Laravel/Tracing/Integrations/LighthouseIntegration.php
@@ -13,6 +13,7 @@ use Sentry\Integration\IntegrationInterface;
 use Sentry\Laravel\Integration;
 use Sentry\SentrySdk;
 use Sentry\Tracing\SpanContext;
+use Sentry\Tracing\TransactionSource;
 
 class LighthouseIntegration implements IntegrationInterface
 {
@@ -157,7 +158,7 @@ class LighthouseIntegration implements IntegrationInterface
             return;
         }
 
-        array_walk($groupedOperations, static function (array &$operations, string $operationType) {
+        array_walk($groupedOperations, static function (&$operations, string $operationType) {
             sort($operations, SORT_STRING);
 
             $operations = "{$operationType}{" . implode(',', $operations) . '}';
@@ -168,6 +169,7 @@ class LighthouseIntegration implements IntegrationInterface
         $transactionName = 'lighthouse?' . implode('&', $groupedOperations);
 
         $transaction->setName($transactionName);
+        $transaction->getMetadata()->setSource(TransactionSource::custom());
 
         Integration::setTransaction($transactionName);
     }


### PR DESCRIPTION
This adds support for Dynamic Sampling, introduced in https://github.com/getsentry/sentry-php/pull/1360.
Once we released the PHP SDK, we can progress here.

Remaining ToDos

- [x] In the `Middleware`, I'm setting `TransactionSource::url()`, but maybe `TransactionSource::route()` is more appropriate.
- [x] The `LighthouseIntegration.php` is currently not setting a `TransactionSource`, as we might not have access to the context here.