### PR TITLE
fix: Status code not populated on transaction if response did not inherit from the Laravel Response class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Fix status code not always populated on transaction if response did not inherit from `Illuminate\Http\Response` like `Illuminate\Http\JsonResponse` (#573)
+- Fix status code not populated on transaction if response did not inherit from `Illuminate\Http\Response` like `Illuminate\Http\JsonResponse` (#573)
 
 ## 2.13.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fix status code not always populated on transaction if response did not inherit from `Illuminate\Http\Response` like `Illuminate\Http\JsonResponse` (#573)
+
 ## 2.13.0
 
 - Only catch `BindingResolutionException` when trying to get the PSR-7 request object from the container

--- a/src/Sentry/Laravel/Tracing/Middleware.php
+++ b/src/Sentry/Laravel/Tracing/Middleware.php
@@ -5,6 +5,7 @@ namespace Sentry\Laravel\Tracing;
 use Closure;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Routing\Route;
 use Sentry\Laravel\Integration;
 use Sentry\SentrySdk;
@@ -57,7 +58,7 @@ class Middleware
      * Handle the application termination.
      *
      * @param \Illuminate\Http\Request  $request
-     * @param \Illuminate\Http\Response $response
+     * @param \Illuminate\Http\Response|\Illuminate\Http\JsonResponse $response
      *
      * @return void
      */
@@ -76,7 +77,7 @@ class Middleware
                 $this->hydrateRequestData($request);
             }
 
-            if ($response instanceof Response) {
+            if ($response instanceof Response || $response instanceof JsonResponse) {
                 $this->hydrateResponseData($response);
             }
 

--- a/src/Sentry/Laravel/Tracing/Middleware.php
+++ b/src/Sentry/Laravel/Tracing/Middleware.php
@@ -4,8 +4,6 @@ namespace Sentry\Laravel\Tracing;
 
 use Closure;
 use Illuminate\Http\Request;
-use Illuminate\Http\Response;
-use Illuminate\Http\JsonResponse;
 use Illuminate\Routing\Route;
 use Sentry\Laravel\Integration;
 use Sentry\SentrySdk;
@@ -13,6 +11,7 @@ use Sentry\State\HubInterface;
 use Sentry\Tracing\Span;
 use Sentry\Tracing\SpanContext;
 use Sentry\Tracing\TransactionContext;
+use Symfony\Component\HttpFoundation\Response;
 
 class Middleware
 {
@@ -57,8 +56,8 @@ class Middleware
     /**
      * Handle the application termination.
      *
-     * @param \Illuminate\Http\Request  $request
-     * @param \Illuminate\Http\Response|\Illuminate\Http\JsonResponse $response
+     * @param \Illuminate\Http\Request                   $request
+     * @param \Symfony\Component\HttpFoundation\Response $response
      *
      * @return void
      */
@@ -77,7 +76,7 @@ class Middleware
                 $this->hydrateRequestData($request);
             }
 
-            if ($response instanceof Response || $response instanceof JsonResponse) {
+            if ($response instanceof Response) {
                 $this->hydrateResponseData($response);
             }
 
@@ -209,7 +208,7 @@ class Middleware
 
     private function hydrateResponseData(Response $response): void
     {
-        $this->transaction->setHttpStatus($response->status());
+        $this->transaction->setHttpStatus($response->getStatusCode());
     }
 
     private function updateTransactionNameIfDefault(?string $name): void


### PR DESCRIPTION
Fixing terminate method if return is JsonResponse instance