### PR TITLE
Cleanup event handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
     - Drop support for Laravel 5.x (#581)
 - Remove `Sentry\Integration::extractNameForRoute()`, it's alternative `Sentry\Integration::extractNameAndSourceForRoute()` is marked as `@internal` (#580)
 - Remove extracting route name or controller for transaction names (#583). This unifies the transaction names to a more concise format.
-- Remove internal `Sentry\Integration::currentTransaction()` and `Sentry\Integration::currentTracingSpan()`, use `SentrySdk::getCurrentHub()->getTransaction()` and `SentrySdk::getCurrentHub()->getSpan()` directly (#592)
+- Remove internal `Sentry\Integration::currentTracingSpan()`, use `SentrySdk::getCurrentHub()->getSpan()` if you were using this internal method. (#592)
 
 **Other changes**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
     - Drop support for Laravel 5.x (#581)
 - Remove `Sentry\Integration::extractNameForRoute()`, it's alternative `Sentry\Integration::extractNameAndSourceForRoute()` is marked as `@internal` (#580)
 - Remove extracting route name or controller for transaction names (#583). This unifies the transaction names to a more concise format.
+- Remove internal `Sentry\Integration::currentTransaction()` and `Sentry\Integration::currentTracingSpan()`, use `SentrySdk::getCurrentHub()->getTransaction()` and `SentrySdk::getCurrentHub()->getSpan()` directly (#592)
 
 **Other changes**
 
@@ -19,6 +20,7 @@
 - Set the tracing transaction name on the `Illuminate\Routing\Events\RouteMatched` instead of at the end of the request (#580)
 - Add tracing span for Laravel HTTP client requests (#585)
 - Simplify Sentry meta tag retrieval, by adding `Sentry\Laravel\Integration::sentryMeta()` (#586)
+- Fix tracing with nested queue jobs (mostly when running jobs in the `sync` driver) (#592)
 
 ## 2.14.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Add tracing span for Laravel HTTP client requests (#585)
 - Simplify Sentry meta tag retrieval, by adding `Sentry\Laravel\Integration::sentryMeta()` (#586)
 - Fix tracing with nested queue jobs (mostly when running jobs in the `sync` driver) (#592)
+- Add a `http.route` span, this span indicates the time that is spent inside a controller method or route closure (#593)
 - Add a `db.transaction` span, this span indicates the time that is spent inside a database transaction (#594)
 
 ## 2.14.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Add tracing span for Laravel HTTP client requests (#585)
 - Simplify Sentry meta tag retrieval, by adding `Sentry\Laravel\Integration::sentryMeta()` (#586)
 - Fix tracing with nested queue jobs (mostly when running jobs in the `sync` driver) (#592)
+- Add a `db.transaction` span, this span indicates the time that is spent inside a database transaction (#594)
 
 ## 2.14.2
 

--- a/src/Sentry/Laravel/Integration.php
+++ b/src/Sentry/Laravel/Integration.php
@@ -3,10 +3,7 @@
 namespace Sentry\Laravel;
 
 use Illuminate\Routing\Route;
-use Illuminate\Support\Str;
 use Sentry\SentrySdk;
-use Sentry\Tracing\Span;
-use Sentry\Tracing\Transaction;
 use Sentry\Tracing\TransactionSource;
 use function Sentry\addBreadcrumb;
 use function Sentry\configureScope;
@@ -118,7 +115,7 @@ class Integration implements IntegrationInterface
     {
         return [
             '/' . ltrim($route->uri(), '/'),
-            TransactionSource::route()
+            TransactionSource::route(),
         ];
     }
 
@@ -140,7 +137,7 @@ class Integration implements IntegrationInterface
      */
     public static function sentryTracingMeta(): string
     {
-        $span = self::currentTracingSpan();
+        $span = SentrySdk::getCurrentHub()->getSpan();
 
         if ($span === null) {
             return '';
@@ -157,36 +154,12 @@ class Integration implements IntegrationInterface
      */
     public static function sentryBaggageMeta(): string
     {
-        $span = self::currentTracingSpan();
+        $span = SentrySdk::getCurrentHub()->getSpan();
 
         if ($span === null) {
             return '';
         }
 
         return sprintf('<meta name="baggage" content="%s"/>', $span->toBaggage());
-    }
-
-    /**
-     * Get the current active tracing span from the scope.
-     *
-     * @return \Sentry\Tracing\Transaction|null
-     *
-     * @internal This is used internally as an easy way to retrieve the current active transaction.
-     */
-    public static function currentTransaction(): ?Transaction
-    {
-        return SentrySdk::getCurrentHub()->getTransaction();
-    }
-
-    /**
-     * Get the current active tracing span from the scope.
-     *
-     * @return \Sentry\Tracing\Span|null
-     *
-     * @internal This is used internally as an easy way to retrieve the current active tracing span.
-     */
-    public static function currentTracingSpan(): ?Span
-    {
-        return SentrySdk::getCurrentHub()->getSpan();
     }
 }

--- a/src/Sentry/Laravel/Tracing/EventHandler.php
+++ b/src/Sentry/Laravel/Tracing/EventHandler.php
@@ -144,6 +144,9 @@ class EventHandler
      *
      * @uses self::routeMatchedHandler()
      * @uses self::queryExecutedHandler()
+     * @uses self::httpClientRequestSendingHandler()
+     * @uses self::httpClientResponseReceivedHandler()
+     * @uses self::httpClientConnectionFailedHandler()
      */
     public function subscribe(): void
     {

--- a/src/Sentry/Laravel/Tracing/Integrations/LighthouseIntegration.php
+++ b/src/Sentry/Laravel/Tracing/Integrations/LighthouseIntegration.php
@@ -57,7 +57,7 @@ class LighthouseIntegration implements IntegrationInterface
 
     public function handleStartRequest(StartRequest $startRequest): void
     {
-        $this->previousSpan = Integration::currentTracingSpan();
+        $this->previousSpan = SentrySdk::getCurrentHub()->getSpan();
 
         if ($this->previousSpan === null) {
             return;

--- a/src/Sentry/Laravel/Tracing/Middleware.php
+++ b/src/Sentry/Laravel/Tracing/Middleware.php
@@ -29,13 +29,6 @@ class Middleware
     protected $appSpan;
 
     /**
-     * The span for the `route` part of the application.
-     *
-     * @var \Sentry\Tracing\Span|null
-     */
-    protected $routeSpan;
-
-    /**
      * The timestamp of application bootstrap completion.
      *
      * @var float|null
@@ -56,16 +49,7 @@ class Middleware
             $this->startTransaction($request, app(HubInterface::class));
         }
 
-        $response = $next($request);
-
-        if ($this->routeSpan) {
-            $this->routeSpan->finish();
-            $this->routeSpan = null;
-
-            SentrySdk::getCurrentHub()->setSpan($this->appSpan);
-        }
-
-        return $response;
+        return $next($request);
     }
 
     /**
@@ -112,11 +96,6 @@ class Middleware
     public function setBootedTimestamp(?float $timestamp = null): void
     {
         $this->bootedTimestamp = $timestamp ?? microtime(true);
-    }
-
-    public function setRouteSpan(Span $span): void
-    {
-        $this->routeSpan = $span;
     }
 
     private function startTransaction(Request $request, HubInterface $sentry): void

--- a/src/Sentry/Laravel/Tracing/Routing/TracingCallableDispatcherTracing.php
+++ b/src/Sentry/Laravel/Tracing/Routing/TracingCallableDispatcherTracing.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Sentry\Laravel\Tracing\Routing;
+
+use Illuminate\Routing\Contracts\CallableDispatcher;
+use Illuminate\Routing\Route;
+
+class TracingCallableDispatcherTracing extends TracingRoutingDispatcher implements CallableDispatcher
+{
+    /** @var \Illuminate\Routing\Contracts\CallableDispatcher */
+    private $dispatcher;
+
+    public function __construct(CallableDispatcher $dispatcher)
+    {
+        $this->dispatcher = $dispatcher;
+    }
+
+    public function dispatch(Route $route, $callable)
+    {
+        return $this->wrapRouteDispatch(function () use ($route, $callable) {
+            return $this->dispatcher->dispatch($route, $callable);
+        }, $route);
+    }
+}

--- a/src/Sentry/Laravel/Tracing/Routing/TracingControllerDispatcherTracing.php
+++ b/src/Sentry/Laravel/Tracing/Routing/TracingControllerDispatcherTracing.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Sentry\Laravel\Tracing\Routing;
+
+use Illuminate\Routing\Contracts\ControllerDispatcher;
+use Illuminate\Routing\Route;
+
+class TracingControllerDispatcherTracing extends TracingRoutingDispatcher implements ControllerDispatcher
+{
+    /** @var \Illuminate\Routing\Contracts\ControllerDispatcher */
+    private $dispatcher;
+
+    public function __construct(ControllerDispatcher $dispatcher)
+    {
+        $this->dispatcher = $dispatcher;
+    }
+
+    public function dispatch(Route $route, $controller, $method)
+    {
+        return $this->wrapRouteDispatch(function () use ($route, $controller, $method) {
+            return $this->dispatcher->dispatch($route, $controller, $method);
+        }, $route);
+    }
+
+    public function getMiddleware($controller, $method)
+    {
+        return $this->dispatcher->getMiddleware($controller, $method);
+    }
+}

--- a/src/Sentry/Laravel/Tracing/Routing/TracingRoutingDispatcher.php
+++ b/src/Sentry/Laravel/Tracing/Routing/TracingRoutingDispatcher.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Sentry\Laravel\Tracing\Routing;
+
+use Illuminate\Routing\Route;
+use Sentry\SentrySdk;
+use Sentry\Tracing\SpanContext;
+
+abstract class TracingRoutingDispatcher
+{
+    protected function wrapRouteDispatch(callable $dispatch, Route $route)
+    {
+        $parentSpan = SentrySdk::getCurrentHub()->getSpan();
+
+        // When there is no active transaction we can skip doing anything and just immediately return the callable
+        if ($parentSpan === null) {
+            return $dispatch();
+        }
+
+        $context = new SpanContext;
+        $context->setOp('http.route');
+        $context->setDescription($route->getActionName());
+
+        $span = $parentSpan->startChild($context);
+
+        SentrySdk::getCurrentHub()->setSpan($span);
+
+        try {
+            return $dispatch();
+        } finally {
+            $span->finish();
+
+            SentrySdk::getCurrentHub()->setSpan($parentSpan);
+        }
+    }
+}

--- a/src/Sentry/Laravel/Tracing/ViewEngineDecorator.php
+++ b/src/Sentry/Laravel/Tracing/ViewEngineDecorator.php
@@ -4,7 +4,6 @@ namespace Sentry\Laravel\Tracing;
 
 use Illuminate\Contracts\View\Engine;
 use Illuminate\View\Factory;
-use Sentry\Laravel\Integration;
 use Sentry\SentrySdk;
 use Sentry\Tracing\SpanContext;
 
@@ -29,7 +28,7 @@ final class ViewEngineDecorator implements Engine
      */
     public function get($path, array $data = []): string
     {
-        $parentSpan = Integration::currentTracingSpan();
+        $parentSpan = SentrySdk::getCurrentHub()->getSpan();
 
         if ($parentSpan === null) {
             return $this->engine->get($path, $data);

--- a/test/Sentry/Tracing/EventHandlerTest.php
+++ b/test/Sentry/Tracing/EventHandlerTest.php
@@ -17,7 +17,7 @@ class EventHandlerTest extends SentryLaravelTestCase
     {
         $this->safeExpectException(RuntimeException::class);
 
-        $handler = new EventHandler($this->app, $this->app->make(BacktraceHelper::class), []);
+        $handler = new EventHandler([], $this->app->make(BacktraceHelper::class));
 
         $handler->thisIsNotAHandlerAndShouldThrowAnException();
     }
@@ -31,7 +31,7 @@ class EventHandlerTest extends SentryLaravelTestCase
 
     private function tryAllEventHandlerMethods(array $methods): void
     {
-        $handler = new EventHandler($this->app, $this->app->make(BacktraceHelper::class), []);
+        $handler = new EventHandler([], $this->app->make(BacktraceHelper::class));
 
         $methods = array_map(static function ($method) {
             return "{$method}Handler";


### PR DESCRIPTION
This resolves issues where nested operations (like nested queue jobs) were not correctly handling the nesting and messing up the trace.

Also cleaned up and bundled some container resolving for the Dispatcher class.

And removed some `@internal` methods since they seemed much boilerplate for just a proxy.

This just needs a good test with actual async queues, but we can do that with the final 3.x tests.