### PR TITLE
Add `http.route` span

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Add tracing span for Laravel HTTP client requests (#585)
 - Simplify Sentry meta tag retrieval, by adding `Sentry\Laravel\Integration::sentryMeta()` (#586)
 - Fix tracing with nested queue jobs (mostly when running jobs in the `sync` driver) (#592)
+- Add a `http.route` span, this span indicates the time that is spent inside a controller method or route closure (#593)
 
 ## 2.14.2
 

--- a/src/Sentry/Laravel/Tracing/Routing/TracingCallableDispatcherTracing.php
+++ b/src/Sentry/Laravel/Tracing/Routing/TracingCallableDispatcherTracing.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Sentry\Laravel\Tracing\Routing;
+
+use Illuminate\Routing\Contracts\CallableDispatcher;
+use Illuminate\Routing\Route;
+
+class TracingCallableDispatcherTracing extends TracingRoutingDispatcher implements CallableDispatcher
+{
+    /** @var \Illuminate\Routing\Contracts\CallableDispatcher */
+    private $dispatcher;
+
+    public function __construct(CallableDispatcher $dispatcher)
+    {
+        $this->dispatcher = $dispatcher;
+    }
+
+    public function dispatch(Route $route, $callable)
+    {
+        return $this->wrapRouteDispatch(function () use ($route, $callable) {
+            return $this->dispatcher->dispatch($route, $callable);
+        }, $route);
+    }
+}

--- a/src/Sentry/Laravel/Tracing/Routing/TracingControllerDispatcherTracing.php
+++ b/src/Sentry/Laravel/Tracing/Routing/TracingControllerDispatcherTracing.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Sentry\Laravel\Tracing\Routing;
+
+use Illuminate\Routing\Contracts\ControllerDispatcher;
+use Illuminate\Routing\Route;
+
+class TracingControllerDispatcherTracing extends TracingRoutingDispatcher implements ControllerDispatcher
+{
+    /** @var \Illuminate\Routing\Contracts\ControllerDispatcher */
+    private $dispatcher;
+
+    public function __construct(ControllerDispatcher $dispatcher)
+    {
+        $this->dispatcher = $dispatcher;
+    }
+
+    public function dispatch(Route $route, $controller, $method)
+    {
+        return $this->wrapRouteDispatch(function () use ($route, $controller, $method) {
+            return $this->dispatcher->dispatch($route, $controller, $method);
+        }, $route);
+    }
+
+    public function getMiddleware($controller, $method)
+    {
+        return $this->dispatcher->getMiddleware($controller, $method);
+    }
+}

--- a/src/Sentry/Laravel/Tracing/Routing/TracingRoutingDispatcher.php
+++ b/src/Sentry/Laravel/Tracing/Routing/TracingRoutingDispatcher.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Sentry\Laravel\Tracing\Routing;
+
+use Illuminate\Routing\Route;
+use Sentry\SentrySdk;
+use Sentry\Tracing\SpanContext;
+
+abstract class TracingRoutingDispatcher
+{
+    protected function wrapRouteDispatch(callable $dispatch, Route $route)
+    {
+        $parentSpan = SentrySdk::getCurrentHub()->getSpan();
+
+        // When there is no active transaction we can skip doing anything and just immediately return the callable
+        if ($parentSpan === null) {
+            return $dispatch();
+        }
+
+        $context = new SpanContext;
+        $context->setOp('http.route');
+        $context->setDescription($route->getActionName());
+
+        $span = $parentSpan->startChild($context);
+
+        SentrySdk::getCurrentHub()->setSpan($span);
+
+        try {
+            return $dispatch();
+        } finally {
+            $span->finish();
+
+            SentrySdk::getCurrentHub()->setSpan($parentSpan);
+        }
+    }
+}


### PR DESCRIPTION
This change add a `http.route` span which show the time is spent inside the route controller or closure handler.

![image](https://user-images.githubusercontent.com/1090754/195846202-7e455005-bf18-47c7-82b8-715ea56ba0f3.png)