### PR TITLE
Add `db.transaction` span

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Add tracing span for Laravel HTTP client requests (#585)
 - Simplify Sentry meta tag retrieval, by adding `Sentry\Laravel\Integration::sentryMeta()` (#586)
 - Fix tracing with nested queue jobs (mostly when running jobs in the `sync` driver) (#592)
+- Add a `db.transaction` span, this span indicates the time that is spent inside a database transaction (#594)
 
 ## 2.14.2
 


### PR DESCRIPTION
Add wrapping span when actions are executed within a database transaction.

![image](https://user-images.githubusercontent.com/1090754/195849509-838ca215-c458-4aa8-bb6a-6f97411441bc.png)

Maybe this should be called `db.sql.transaction` instead, tbd!