### PR TITLE
Introduce `Sentry\Laravel\trace` custom span helper

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,9 @@
         "laravel/lumen-framework": "*"
     },
     "autoload": {
+        "files": [
+            "src/Sentry/Laravel/functions.php"
+        ],
         "psr-0": {
             "Sentry\\Laravel\\": "src/"
         }

--- a/src/Sentry/Laravel/functions.php
+++ b/src/Sentry/Laravel/functions.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Sentry\Laravel;
+
+use Sentry\SentrySdk;
+use Sentry\Tracing\SpanContext;
+
+/**
+ * Execute the given callable while wrapping it in a span added to the current transaction.
+ *
+ * If there is currently no transaction active this is a no-op.
+ *
+ * @param callable                    $toMeasure The callable that is going to be measured
+ * @param \Sentry\Tracing\SpanContext $context   The context of the span to be created
+ *
+ * @return mixed
+ */
+function measure(callable $toMeasure, SpanContext $context)
+{
+    $hub = SentrySdk::getCurrentHub();
+
+    $parentSpan = $hub->getSpan();
+
+    // If there is no span set on the hub, there is no transaction
+    // active currently. If that is the case we don't create a unused
+    // span and we immediately execute the callable and return the result
+    if ($parentSpan === null) {
+        return $toMeasure();
+    }
+
+    $span = $parentSpan->startChild($context);
+
+    // Set the new child span as the current span on the hub so
+    // that if the callable also generates it's own spans they are
+    // going to be nexted under this span instead of our parent span.
+    $hub->setSpan($span);
+
+    try {
+        return $toMeasure();
+    } finally {
+        $span->finish();
+
+        // Revert the current span back to the parent span
+        // This ensures that after we are done next spans are
+        // correctly nested under the parent span as is expected
+        $hub->setSpan($parentSpan);
+    }
+}

--- a/src/Sentry/Laravel/functions.php
+++ b/src/Sentry/Laravel/functions.php
@@ -30,6 +30,12 @@ function trace(callable $trace, SpanContext $context)
             $scope->setSpan($span);
         }
 
-        return $trace($scope);
+        try {
+            return $trace($scope);
+        } finally {
+            if (isset($span)) {
+                $span->finish();
+            }
+        }
     });
 }

--- a/src/Sentry/Laravel/functions.php
+++ b/src/Sentry/Laravel/functions.php
@@ -9,10 +9,10 @@ use Sentry\Tracing\SpanContext;
 /**
  * Execute the given callable while wrapping it in a span added as a child to the current transaction and active span.
  *
- * If there is no transaction active this is a no-op and the scope passed to the trace callable will be `null`.
+ * If there is no transaction active this is a no-op and the scope passed to the trace callable will be unused.
  *
- * @param callable(\Sentry\State\Scope|null): mixed $trace   The callable that is going to be traced
- * @param \Sentry\Tracing\SpanContext               $context The context of the span to be created
+ * @param callable(\Sentry\State\Scope): mixed $trace   The callable that is going to be traced
+ * @param \Sentry\Tracing\SpanContext          $context The context of the span to be created
  *
  * @return mixed
  */
@@ -21,16 +21,14 @@ function trace(callable $trace, SpanContext $context)
     return SentrySdk::getCurrentHub()->withScope(function (Scope $scope) use ($context, $trace) {
         $parentSpan = $scope->getSpan();
 
-        // If there's no span set on the scope there is no transaction
-        // active currently. If that is the case we don't create a unused
-        // span and we immediately execute the callable and return the result
-        if ($parentSpan === null) {
-            return $trace(null);
+        // If there's a span set on the scope there is a transaction
+        // active currently. If that is the case we create a child span
+        // and set it on the scope. Otherwise we only execute the callable
+        if ($parentSpan !== null) {
+            $span = $parentSpan->startChild($context);
+
+            $scope->setSpan($span);
         }
-
-        $span = $parentSpan->startChild($context);
-
-        $scope->setSpan($span);
 
         return $trace($scope);
     });


### PR DESCRIPTION
Adding a helper method that reduces a lot of boilerplate of adding spans for user-code to a application, allowing users to quickly wrap existing calls with a span and it looks something like this:

```php
use Sentry\State\Scope;
use Sentry\Tracing\SpanContext;
use function Sentry\Laravel\trace;

$args = [...];

$resutl = trace(
    function (Scope $scope) use ($args) {
        $scope->setTag('some-tag', 'some-value');

        return $this->doSomethingMeasureable($args);
    },
    tap(new SpanContext, function (SpanContext $context) use ($args) {
        $context->setOp('something.measurable');
        $context->setData(['context' => $args]);
        $context->setDescription('Something measurable');
    }),
);
```

The `SpanContext` is a unfortunate object in our API at the moment and doesn't have a fluent interface so I've used the `tap()` helper from Laravel to keep it a little more readable.

In this exampel we also pass the current scope to the callback that is being traced, this might be a good idea or not... maybe the user should wrap this block in their own `withScope` but it seems easy enough to ignore if you don't want to do anything with the scope.

(this is inspired by a [homegrown method](https://gist.github.com/stayallive/ea992983593530f973b40a816b758ede) I'm using in my applications to make this easier but simplified to make it more general and acceptable)

_This is very much a concept and naming might probably change a lot in the process._