### PR TITLE
Update branch aliasses with new versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -61,7 +61,9 @@
     },
     "extra": {
         "branch-alias": {
+            "dev-3.x": "3.x-dev",
             "dev-master": "2.x-dev",
+            "dev-1.x": "1.x-dev",
             "dev-0.x": "0.x-dev"
         },
         "laravel": {


### PR DESCRIPTION
We were missing an alias (although not really needed... but still) and I've added 3.x.

In the 3.x branch we already have update the branch aliasses to point correctly once we merge it back to master.