### PR TITLE
Always start performance tracing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Remove incorrect checks if performance tracing should be enabled and rely on the transaction sampling decision instead (#600)
+- 
 ## 3.0.0
 
 **New features**
@@ -21,7 +23,6 @@
     - Drop support for Laravel 5.x (#581)
 - Remove `Sentry\Integration::extractNameForRoute()`, it's alternative `Sentry\Integration::extractNameAndSourceForRoute()` is marked as `@internal` (#580)
 - Remove internal `Sentry\Integration::currentTracingSpan()`, use `SentrySdk::getCurrentHub()->getSpan()` if you were using this internal method (#592)
-- Remove incorrect checks if performance tracing should be enabled and rely on the transaction sampling decision instead (#600)
 
 **Other changes**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 - Remove incorrect checks if performance tracing should be enabled and rely on the transaction sampling decision instead (#600)
-- 
+
 ## 3.0.0
 
 **New features**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
     - Drop support for Laravel 5.x (#581)
 - Remove `Sentry\Integration::extractNameForRoute()`, it's alternative `Sentry\Integration::extractNameAndSourceForRoute()` is marked as `@internal` (#580)
 - Remove internal `Sentry\Integration::currentTracingSpan()`, use `SentrySdk::getCurrentHub()->getSpan()` if you were using this internal method (#592)
+- Remove incorrect checks if performance tracing should be enabled and rely on the transaction sampling decision instead (#600)
 
 **Other changes**
 

--- a/composer.json
+++ b/composer.json
@@ -23,8 +23,8 @@
     "require": {
         "php": "^7.2 | ^8.0",
         "illuminate/support": "^6.0 | ^7.0 | ^8.0 | ^9.0",
-        "sentry/sentry": "^3.9",
-        "sentry/sdk": "^3.1",
+        "sentry/sentry": "^3.10",
+        "sentry/sdk": "^3.3",
         "symfony/psr-http-message-bridge": "^1.0 | ^2.0",
         "nyholm/psr7": "^1.0"
     },

--- a/src/Sentry/Laravel/EventHandler.php
+++ b/src/Sentry/Laravel/EventHandler.php
@@ -14,7 +14,6 @@ use Illuminate\Database\Events as DatabaseEvents;
 use Illuminate\Http\Request;
 use Illuminate\Log\Events as LogEvents;
 use Illuminate\Queue\Events as QueueEvents;
-use Illuminate\Queue\QueueManager;
 use Illuminate\Routing\Events as RoutingEvents;
 use Laravel\Octane\Events as Octane;
 use Laravel\Sanctum\Events as Sanctum;

--- a/src/Sentry/Laravel/ServiceProvider.php
+++ b/src/Sentry/Laravel/ServiceProvider.php
@@ -238,7 +238,7 @@ class ServiceProvider extends BaseServiceProvider
 
         $enableDefaultTracingIntegrations = $userConfig['tracing']['default_integrations'] ?? true;
 
-        if ($enableDefaultTracingIntegrations && $this->couldHavePerformanceTracingEnabled()) {
+        if ($enableDefaultTracingIntegrations) {
             $integrationsToResolve = array_merge($integrationsToResolve, TracingServiceProvider::DEFAULT_INTEGRATIONS);
         }
 

--- a/src/Sentry/Laravel/Tracing/EventHandler.php
+++ b/src/Sentry/Laravel/Tracing/EventHandler.php
@@ -206,7 +206,6 @@ class EventHandler
 
         $parentSpan = SentrySdk::getCurrentHub()->getSpan();
 
-        // If there is no tracing span active there is no need to handle the event
         if ($parentSpan === null) {
             return;
         }

--- a/src/Sentry/Laravel/Tracing/EventHandler.php
+++ b/src/Sentry/Laravel/Tracing/EventHandler.php
@@ -206,6 +206,7 @@ class EventHandler
 
         $parentSpan = SentrySdk::getCurrentHub()->getSpan();
 
+        // If there is no tracing span active there is no need to handle the event
         if ($parentSpan === null) {
             return;
         }
@@ -249,6 +250,7 @@ class EventHandler
     {
         $parentSpan = SentrySdk::getCurrentHub()->getSpan();
 
+        // If there is no tracing span active there is no need to handle the event
         if ($parentSpan === null) {
             return;
         }
@@ -283,6 +285,7 @@ class EventHandler
     {
         $parentSpan = SentrySdk::getCurrentHub()->getSpan();
 
+        // If there is no tracing span active there is no need to handle the event
         if ($parentSpan === null) {
             return;
         }
@@ -386,12 +389,10 @@ class EventHandler
     {
         $span = $this->popSpan();
 
-        if ($span === null) {
-            return;
+        if ($span !== null) {
+            $span->finish();
+            $span->setStatus($status);
         }
-
-        $span->setStatus($status);
-        $span->finish();
     }
 
     private function pushSpan(Span $span): void

--- a/src/Sentry/Laravel/Tracing/Middleware.php
+++ b/src/Sentry/Laravel/Tracing/Middleware.php
@@ -63,7 +63,7 @@ class Middleware
     public function terminate(Request $request, $response): void
     {
         // If there is no transaction or the HubInterface is not bound in the container there is nothing for us to do
-        if ($this->transaction !== null || !app()->bound(HubInterface::class)) {
+        if ($this->transaction === null || !app()->bound(HubInterface::class)) {
             return;
         }
 

--- a/src/Sentry/Laravel/Tracing/Routing/TracingRoutingDispatcher.php
+++ b/src/Sentry/Laravel/Tracing/Routing/TracingRoutingDispatcher.php
@@ -12,6 +12,9 @@ abstract class TracingRoutingDispatcher
     {
         $parentSpan = SentrySdk::getCurrentHub()->getSpan();
 
+        // When there is no span we can skip creating
+        // the span and just immediately return with the
+        // callable result because there is no transaction.
         if ($parentSpan === null) {
             return $dispatch();
         }

--- a/src/Sentry/Laravel/Tracing/Routing/TracingRoutingDispatcher.php
+++ b/src/Sentry/Laravel/Tracing/Routing/TracingRoutingDispatcher.php
@@ -12,7 +12,6 @@ abstract class TracingRoutingDispatcher
     {
         $parentSpan = SentrySdk::getCurrentHub()->getSpan();
 
-        // When there is no active transaction we can skip doing anything and just immediately return the callable
         if ($parentSpan === null) {
             return $dispatch();
         }


### PR DESCRIPTION
As mentioned in #595, we are incorrectly "guarding" against enabling performance tracing when no sample rate or sampler callback is set. This removes that check and always enables performance tracing.

This has minimal impact on the users application since we always check if there is an active transaction/span before doing any real work so most code becomes a no-op if the transaction is not sampled.

This should be merged to `master` after #587.

This will also have no real work effect until getsentry/sentry-php#1405 has been solved.