### PR TITLE
Support using SENTRY_RELEASE environment variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Remove incorrect checks if performance tracing should be enabled and rely on the transaction sampling decision instead (#600)
+- Fix `SENTRY_RELEASE` .env variable not working when using config caching (#603)
 
 ## 3.0.0
 

--- a/config/sentry.php
+++ b/config/sentry.php
@@ -4,8 +4,9 @@ return [
 
     'dsn' => env('SENTRY_LARAVEL_DSN', env('SENTRY_DSN')),
 
-    // capture release as git sha
-    'release' => env('SENTRY_RELEASE', trim(exec('git --git-dir ' . base_path('.git') . ' log --pretty="%h" -n1 HEAD'))),
+    // The release version of your application
+    // Example with dynamic git hash: trim(exec('git --git-dir ' . base_path('.git') . ' log --pretty="%h" -n1 HEAD'))
+    'release' => env('SENTRY_RELEASE'),
 
     // When left empty or `null` the Laravel environment will be used
     'environment' => env('SENTRY_ENVIRONMENT'),

--- a/config/sentry.php
+++ b/config/sentry.php
@@ -5,7 +5,7 @@ return [
     'dsn' => env('SENTRY_LARAVEL_DSN', env('SENTRY_DSN')),
 
     // capture release as git sha
-    // 'release' => trim(exec('git --git-dir ' . base_path('.git') . ' log --pretty="%h" -n1 HEAD')),
+    'release' => env('SENTRY_RELEASE', trim(exec('git --git-dir ' . base_path('.git') . ' log --pretty="%h" -n1 HEAD'))),
 
     // When left empty or `null` the Laravel environment will be used
     'environment' => env('SENTRY_ENVIRONMENT'),


### PR DESCRIPTION
According to the [PHP SDK docs](https://docs.sentry.io/platforms/php/configuration/options/#release) a user can set the `SENTRY_RELEASE` environment variable. But with the Laravel specific package the `release` option is commented out and not using the default value.