### PR TITLE
Introduce `captureUnhandledException`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add new method to report unhandled exceptions from the Laravel error handler (#608)
+
 ## 3.0.1
 
 - Remove incorrect checks if performance tracing should be enabled and rely on the transaction sampling decision instead (#600)


### PR DESCRIPTION
Currently we ask users to implement this in their error handler:

```php
public function register()
{
    $this->reportable(function (Throwable $e) {
        if (app()->bound('sentry')) {
            app('sentry')->captureException($e);
        }
    });
}
```

However going forward we are going to change this to:

```php
public function register()
{
    $this->reportable(function (Throwable $e) {
        \Sentry\Laravel\Integration::captureUnhandledException($e);
    });
}
```

The old way will still work but the "new way" will make sure exception are correctly marked as unhandled in the Sentry UI.

Fixes #607 (TODO: Docs PR)