### PR TITLE
Fix missing scope information on unhandled exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fix missing scope information on unhandled exceptions (#611)
+
 ## 3.1.0
 
 - Unhandled exceptions are now correctly marked as `handled: false` and displayed as such on the issues list and detail page (#608)

--- a/src/Sentry/Laravel/Integration.php
+++ b/src/Sentry/Laravel/Integration.php
@@ -177,20 +177,10 @@ class Integration implements IntegrationInterface
      */
     public static function captureUnhandledException(Throwable $throwable): ?EventId
     {
-        $client = SentrySdk::getCurrentHub()->getClient();
-
-        // When Sentry is not configured, because for example no DSN
-        // is set the client can be null. If that is the case we cannot
-        // transmit the event so, exit early to prevent doing useless work
-        if ($client === null) {
-            return null;
-        }
-
         $hint = EventHint::fromArray([
-            'exception' => $throwable,
             'mechanism' => new ExceptionMechanism(ExceptionMechanism::TYPE_GENERIC, false),
         ]);
 
-        return $client->captureEvent(Event::createEvent(), $hint);
+        return SentrySdk::getCurrentHub()->captureException($throwable, $hint);
     }
 }


### PR DESCRIPTION
Because of a mistake when we introduced `captureUnhandledException` the event is sent using the client and not the hub, the client doesn't enricht events with the scope, the hub does.

This corrects this mistake.

Few notes:
- Removing the `null` check on the client is safe since the hub already does this
- Removing the `exception` from the hint is safe since the client will add that itself