### PR TITLE
Set `traces_sample_rate` to `null` by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Set `traces_sample_rate` to `null` by default (#616)
+
 ## 3.1.1
 
 - Fix missing scope information on unhandled exceptions (#611)

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.2 | ^8.0",
         "illuminate/support": "^6.0 | ^7.0 | ^8.0 | ^9.0",
-        "sentry/sentry": "^3.10",
+        "sentry/sentry": "^3.12",
         "sentry/sdk": "^3.3",
         "symfony/psr-http-message-bridge": "^1.0 | ^2.0",
         "nyholm/psr7": "^1.0"

--- a/config/sentry.php
+++ b/config/sentry.php
@@ -51,9 +51,10 @@ return [
         'missing_routes' => false,
     ],
 
-    // @see: https://docs.sentry.io/platforms/php/configuration/options/#send-default-pii
+    // @see: https://docs.sentry.io/platforms/php/guides/laravel/configuration/options/#send-default-pii
     'send_default_pii' => env('SENTRY_SEND_DEFAULT_PII', false),
 
-    'traces_sample_rate' => (float)(env('SENTRY_TRACES_SAMPLE_RATE', 0.0)),
+    // @see: https://docs.sentry.io/platforms/php/guides/laravel/configuration/options/#traces-sample-rate
+    'traces_sample_rate' => env('SENTRY_TRACES_SAMPLE_RATE') === null ? null : (float)env('SENTRY_TRACES_SAMPLE_RATE'),
 
 ];


### PR DESCRIPTION
- [x] Pin `sentry/sentry` to version including: getsentry/sentry-php#1428

(missing `sentry/sentry` release is failing the tests)