### PR TITLE
Add Laravel 10 support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,7 +20,7 @@ jobs:
       matrix:
         php: [ "8.2", "8.1", "8.0", "7.4", "7.3", "7.2" ]
         packages:
-          # All versions below should be test on PHP ^7.1 (Sentry SDK requirement)
+          # All versions below should be test on PHP ^7.1 (Sentry SDK requirement) and PHP < 8.0 (PHPUnit requirement)
           - { laravel: ^6.0,  testbench: 4.7.*, phpunit: 8.4.* }
           - { laravel: ^7.0,  testbench: 5.1.*, phpunit: 8.4.* }
 
@@ -29,21 +29,33 @@ jobs:
 
           # All versions below only support PHP ^8.0 (Laravel requirement)
           - { laravel: ^9.0,  testbench: ^7.0, phpunit: 9.5.* }
+
+          # All versions below only support PHP ^8.1 (Laravel requirement)
+          - { laravel: ^10.0,  testbench: ^8.0, phpunit: 9.5.* }
         exclude:
           - php: "7.2"
+            packages: { laravel: ^8.0,  testbench: ^6.0, phpunit: 9.3.* }
+          - php: "7.2"
             packages: { laravel: ^9.0,  testbench: ^7.0, phpunit: 9.5.* }
+          - php: "7.2"
+            packages: { laravel: ^10.0,  testbench: ^8.0, phpunit: 9.5.* }
+
           - php: "7.3"
             packages: { laravel: ^9.0,  testbench: ^7.0, phpunit: 9.5.* }
+          - php: "7.3"
+            packages: { laravel: ^10.0,  testbench: ^8.0, phpunit: 9.5.* }
+
           - php: "7.4"
             packages: { laravel: ^9.0,  testbench: ^7.0, phpunit: 9.5.* }
-
-          - php: "7.2"
-            packages: { laravel: ^8.0,  testbench: ^6.0, phpunit: 9.3.* }
+          - php: "7.4"
+            packages: { laravel: ^10.0,  testbench: ^8.0, phpunit: 9.5.* }
 
           - php: "8.0"
             packages: { laravel: ^6.0,  testbench: 4.7.*, phpunit: 8.4.* }
           - php: "8.0"
             packages: { laravel: ^7.0,  testbench: 5.1.*, phpunit: 8.4.* }
+          - php: "8.0"
+            packages: { laravel: ^10.0,  testbench: ^8.0, phpunit: 9.5.* }
 
           - php: "8.1"
             packages: { laravel: ^6.0,  testbench: 4.7.*, phpunit: 8.4.* }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add Laravel 10 support (#630)
+
 ## 3.1.3
 
 - Increase debug trace limit count to 20 in `Integration::makeAnEducatedGuessIfTheExceptionMaybeWasHandled()` (#622)

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     ],
     "require": {
         "php": "^7.2 | ^8.0",
-        "illuminate/support": "^6.0 | ^7.0 | ^8.0 | ^9.0",
+        "illuminate/support": "^6.0 | ^7.0 | ^8.0 | ^9.0 | ^10.0",
         "sentry/sentry": "^3.12",
         "sentry/sdk": "^3.3",
         "symfony/psr-http-message-bridge": "^1.0 | ^2.0",
@@ -38,8 +38,8 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^8.4 | ^9.3",
-        "laravel/framework": "^6.0 | ^7.0 | ^8.0 | ^9.0",
-        "orchestra/testbench": "^4.7 | ^5.1 | ^6.0 | ^7.0",
+        "laravel/framework": "^6.0 | ^7.0 | ^8.0 | ^9.0 | ^10.0",
+        "orchestra/testbench": "^4.7 | ^5.1 | ^6.0 | ^7.0 | ^8.0",
         "friendsofphp/php-cs-fixer": "^3.11",
         "mockery/mockery": "^1.3"
     },

--- a/src/Sentry/Laravel/SentryHandler.php
+++ b/src/Sentry/Laravel/SentryHandler.php
@@ -4,6 +4,7 @@ namespace Sentry\Laravel;
 
 use Monolog\DateTimeImmutable;
 use Monolog\Logger;
+use Monolog\LogRecord;
 use Monolog\Formatter\LineFormatter;
 use Monolog\Formatter\FormatterInterface;
 use Monolog\Handler\AbstractProcessingHandler;
@@ -168,7 +169,7 @@ class SentryHandler extends AbstractProcessingHandler
      * {@inheritdoc}
      * @suppress PhanTypeMismatchArgument
      */
-    protected function write(array $record): void
+    protected function write(array|LogRecord $record): void
     {
         $exception = $record['context']['exception'] ?? null;
         $isException = $exception instanceof Throwable;

--- a/src/Sentry/Laravel/SentryHandler.php
+++ b/src/Sentry/Laravel/SentryHandler.php
@@ -10,6 +10,7 @@ use Monolog\Formatter\FormatterInterface;
 use Monolog\Handler\AbstractProcessingHandler;
 use Sentry\Breadcrumb;
 use Sentry\Event;
+use Sentry\Monolog\CompatibilityProcessingHandlerTrait;
 use Sentry\Severity;
 use Sentry\State\HubInterface;
 use Sentry\State\Scope;
@@ -17,6 +18,8 @@ use Throwable;
 
 class SentryHandler extends AbstractProcessingHandler
 {
+    use CompatibilityProcessingHandlerTrait;
+
     /**
      * @var string the current application environment (staging|preprod|prod)
      */
@@ -147,29 +150,14 @@ class SentryHandler extends AbstractProcessingHandler
      */
     protected function getLogLevel(int $logLevel): Severity
     {
-        switch ($logLevel) {
-            case Logger::DEBUG:
-                return Severity::debug();
-            case Logger::NOTICE:
-            case Logger::INFO:
-                return Severity::info();
-            case Logger::WARNING:
-                return Severity::warning();
-            case Logger::ALERT:
-            case Logger::EMERGENCY:
-            case Logger::CRITICAL:
-                return Severity::fatal();
-            case Logger::ERROR:
-            default:
-                return Severity::error();
-        }
+        return $this->getSeverityFromLevel($logLevel);
     }
 
     /**
      * {@inheritdoc}
      * @suppress PhanTypeMismatchArgument
      */
-    protected function write(array|LogRecord $record): void
+    protected function doWrite($record): void
     {
         $exception = $record['context']['exception'] ?? null;
         $isException = $exception instanceof Throwable;


### PR DESCRIPTION
This PR aims to add support for Laravel 10, which is [expected to be released at February 7th, 2023](https://laravel.com/docs/master/releases#support-policy).

Open problem: the update to Laravel 10 comes with an update to Monolog v3, which changes the signature on the `AbstractProcessingHandler::write` method. This can be circumvented on PHP ^8.0 by using a union type in the class extension, but this does not work on PHP 7.x as it has no union types.

Possible solutions:
- drop support for older Laravel versions
- drop support for PHP 7.x: see https://github.com/jnoordsij/sentry-laravel/pull/2
- find some sort of polyfill to allow for union types on PHP 7.x