### PR TITLE
Fix missing breadcrumbs for jobs throwing an exception

### DIFF
--- a/src/Sentry/Laravel/EventHandler.php
+++ b/src/Sentry/Laravel/EventHandler.php
@@ -376,8 +376,6 @@ class EventHandler
 
     protected function queueJobExceptionOccurredHandler(QueueEvents\JobExceptionOccurred $event): void
     {
-        $this->cleanupScopeForTaskWithinLongRunningProcessWhen($this->pushedQueueScopeCount > 0);
-
         $this->afterTaskWithinLongRunningProcess();
     }
 

--- a/src/Sentry/Laravel/EventHandler.php
+++ b/src/Sentry/Laravel/EventHandler.php
@@ -409,6 +409,8 @@ class EventHandler
 
     protected function queueJobProcessingHandler(QueueEvents\JobProcessing $event): void
     {
+        $this->cleanupScopeForTaskWithinLongRunningProcessWhen($this->pushedQueueScopeCount > 0);
+
         $this->prepareScopeForTaskWithinLongRunningProcess();
 
         ++$this->pushedQueueScopeCount;

--- a/test/Sentry/EventHandler/QueueEventsTest.php
+++ b/test/Sentry/EventHandler/QueueEventsTest.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Sentry\Laravel\Tests\EventHandler;
+
+use Exception;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Sentry\Breadcrumb;
+use Sentry\Laravel\Tests\TestCase;
+use function Sentry\addBreadcrumb;
+use function Sentry\captureException;
+
+class QueueEventsTest extends TestCase
+{
+    public function testQueueJobSetsBreadcrumbsCorrectly(): void
+    {
+        dispatch(new QueueEventsTestJobWithBreadcrumb);
+
+        $this->assertCount(0, $this->getCurrentBreadcrumbs());
+    }
+
+    public function testQueueJobThatReportsSetsBreadcrumbsCorrectly(): void
+    {
+        dispatch(new QueueEventsTestJobThatReportsAnExceptionWithBreadcrumb);
+
+        $this->assertCount(0, $this->getCurrentBreadcrumbs());
+    }
+
+    public function testQueueJobThatThrowsSetsBreadcrumbsCorrectly(): void
+    {
+        try {
+            dispatch(new QueueEventsTestJobThatThrowsAnUnhandledExceptionWithBreadcrumb);
+        } catch (Exception $e) {
+            $this->assertCount(2, $this->getCurrentBreadcrumbs());
+
+            $firstBreadcrumb = $this->getCurrentBreadcrumbs()[0];
+            $this->assertEquals('queue.job', $firstBreadcrumb->getCategory());
+
+            $secondBreadcrumb = $this->getCurrentBreadcrumbs()[1];
+            $this->assertEquals('test', $secondBreadcrumb->getCategory());
+        }
+    }
+
+    public function testQueueJobsWithBreadcrumbSetInBetweenIsKept(): void
+    {
+        dispatch(new QueueEventsTestJobWithBreadcrumb);
+
+        addBreadcrumb(new Breadcrumb(Breadcrumb::LEVEL_INFO, Breadcrumb::LEVEL_DEBUG, 'test2', 'test2'));
+
+        dispatch(new QueueEventsTestJobWithBreadcrumb);
+
+        $this->assertCount(1, $this->getCurrentBreadcrumbs());
+    }
+}
+
+function queueEventsTestAddTestBreadcrumb(): void
+{
+    addBreadcrumb(
+        new Breadcrumb(
+            Breadcrumb::LEVEL_INFO,
+            Breadcrumb::LEVEL_DEBUG,
+            'test',
+            'test'
+        )
+    );
+}
+
+class QueueEventsTestJobWithBreadcrumb implements ShouldQueue
+{
+    public function handle(): void
+    {
+        queueEventsTestAddTestBreadcrumb();
+    }
+}
+
+class QueueEventsTestJobThatReportsAnExceptionWithBreadcrumb implements ShouldQueue
+{
+    public function handle(): void
+    {
+        queueEventsTestAddTestBreadcrumb();
+
+        captureException(new Exception('This is a test exception'));
+    }
+}
+
+class QueueEventsTestJobThatThrowsAnUnhandledExceptionWithBreadcrumb implements ShouldQueue
+{
+    public function handle(): void
+    {
+        queueEventsTestAddTestBreadcrumb();
+
+        throw new Exception('This is a test exception');
+    }
+}

--- a/test/Sentry/EventHandler/QueueEventsTest.php
+++ b/test/Sentry/EventHandler/QueueEventsTest.php
@@ -11,36 +11,71 @@ use function Sentry\captureException;
 
 class QueueEventsTest extends TestCase
 {
-    public function testQueueJobSetsBreadcrumbsCorrectly(): void
+    public function testQueueJobPushesAndPopsScopeWithBreadcrumbs(): void
     {
         dispatch(new QueueEventsTestJobWithBreadcrumb);
 
         $this->assertCount(0, $this->getCurrentBreadcrumbs());
     }
 
-    public function testQueueJobThatReportsSetsBreadcrumbsCorrectly(): void
+    public function testQueueJobThatReportsPushesAndPopsScopeWithBreadcrumbs(): void
     {
         dispatch(new QueueEventsTestJobThatReportsAnExceptionWithBreadcrumb);
 
         $this->assertCount(0, $this->getCurrentBreadcrumbs());
+
+        $this->assertNotNull($this->getLastEvent());
+
+        $event = $this->getLastEvent();
+
+        $this->assertCount(2, $event->getBreadcrumbs());
     }
 
-    public function testQueueJobThatThrowsSetsBreadcrumbsCorrectly(): void
+    public function testQueueJobThatThrowsLeavesPushedScopeWithBreadcrumbs(): void
     {
         try {
             dispatch(new QueueEventsTestJobThatThrowsAnUnhandledExceptionWithBreadcrumb);
         } catch (Exception $e) {
-            $this->assertCount(2, $this->getCurrentBreadcrumbs());
-
-            $firstBreadcrumb = $this->getCurrentBreadcrumbs()[0];
-            $this->assertEquals('queue.job', $firstBreadcrumb->getCategory());
-
-            $secondBreadcrumb = $this->getCurrentBreadcrumbs()[1];
-            $this->assertEquals('test', $secondBreadcrumb->getCategory());
+            // No action required, expected to throw
         }
+
+        // We still expect to find the breadcrumbs from the job here so they are attached to reported exceptions
+
+        $this->assertCount(2, $this->getCurrentBreadcrumbs());
+
+        $firstBreadcrumb = $this->getCurrentBreadcrumbs()[0];
+        $this->assertEquals('queue.job', $firstBreadcrumb->getCategory());
+
+        $secondBreadcrumb = $this->getCurrentBreadcrumbs()[1];
+        $this->assertEquals('test', $secondBreadcrumb->getCategory());
     }
 
-    public function testQueueJobsWithBreadcrumbSetInBetweenIsKept(): void
+    public function testQueueJobsThatThrowPopsAndPushesScopeWithBreadcrumbsBeforeNewJob(): void
+    {
+        try {
+            dispatch(new QueueEventsTestJobThatThrowsAnUnhandledExceptionWithBreadcrumb('test #1'));
+        } catch (Exception $e) {
+            // No action required, expected to throw
+        }
+
+        try {
+            dispatch(new QueueEventsTestJobThatThrowsAnUnhandledExceptionWithBreadcrumb('test #2'));
+        } catch (Exception $e) {
+            // No action required, expected to throw
+        }
+
+        // We only expect to find the breadcrumbs from the second job here
+
+        $this->assertCount(2, $this->getCurrentBreadcrumbs());
+
+        $firstBreadcrumb = $this->getCurrentBreadcrumbs()[0];
+        $this->assertEquals('queue.job', $firstBreadcrumb->getCategory());
+
+        $secondBreadcrumb = $this->getCurrentBreadcrumbs()[1];
+        $this->assertEquals('test #2', $secondBreadcrumb->getMessage());
+    }
+
+    public function testQueueJobsWithBreadcrumbSetInBetweenKeepsNonJobBreadcrumbsOnCurrentScope(): void
     {
         dispatch(new QueueEventsTestJobWithBreadcrumb);
 
@@ -52,14 +87,14 @@ class QueueEventsTest extends TestCase
     }
 }
 
-function queueEventsTestAddTestBreadcrumb(): void
+function queueEventsTestAddTestBreadcrumb($message = null): void
 {
     addBreadcrumb(
         new Breadcrumb(
             Breadcrumb::LEVEL_INFO,
             Breadcrumb::LEVEL_DEBUG,
             'test',
-            'test'
+            $message ?? 'test'
         )
     );
 }
@@ -84,9 +119,16 @@ class QueueEventsTestJobThatReportsAnExceptionWithBreadcrumb implements ShouldQu
 
 class QueueEventsTestJobThatThrowsAnUnhandledExceptionWithBreadcrumb implements ShouldQueue
 {
+    private $message;
+
+    public function __construct($message = null)
+    {
+        $this->message = $message;
+    }
+
     public function handle(): void
     {
-        queueEventsTestAddTestBreadcrumb();
+        queueEventsTestAddTestBreadcrumb($this->message);
 
         throw new Exception('This is a test exception');
     }

--- a/test/Sentry/TestCase.php
+++ b/test/Sentry/TestCase.php
@@ -88,6 +88,7 @@ abstract class TestCase extends LaravelTestCase
         return $method->invoke($hub);
     }
 
+    /** @return array<array-key, \Sentry\Breadcrumb> */
     protected function getCurrentBreadcrumbs(): array
     {
         $scope = $this->getCurrentScope();


### PR DESCRIPTION
Fixes #632.

There is a downside with this "fix" (hence still a draft).

We might be leaking memory here since we never cleanup any breadcrumbs from failed queue jobs. When a queue workers is running this might be an issue where these breadcrumbs will never be visible but are kept in memory. So when a queue worker churns through say 500 jobs that threw exceptions it has 1500 breadcrumbs (3 per scope) and 500 scopes (unless we limit the amount of scopes already!?).

So not a 100% sure this is the way.

A fix for this can be where we pop the scope if we need to before we run a job, however that breaks [this](https://github.com/getsentry/sentry-laravel/pull/633/files#diff-212611d9baa058b4d98139c7480ad5b39c8f94a5425e2f6e6f5698815c422489R43-R51) test where the middle breadcrumb from this test is being lost which is not ideal either.