### PR TITLE
feat: Add http client breadcrumbs

### DIFF
--- a/config/sentry.php
+++ b/config/sentry.php
@@ -26,6 +26,9 @@ return [
 
         // Capture command information in breadcrumbs
         'command_info' => true,
+
+        // Capture HTTP client requests information in breadcrumbs
+        'http_client_requests' => true,
     ],
 
     'tracing' => [
@@ -43,9 +46,6 @@ return [
 
         // Capture views as spans
         'views' => true,
-
-        // Capture HTTP client requests as spans
-        'http_client_requests' => true,
 
         // Indicates if the tracing integrations supplied by Sentry should be loaded
         'default_integrations' => true,

--- a/config/sentry.php
+++ b/config/sentry.php
@@ -47,6 +47,9 @@ return [
         // Capture views as spans
         'views' => true,
 
+        // Capture HTTP client requests as spans
+        'http_client_requests' => true,
+
         // Indicates if the tracing integrations supplied by Sentry should be loaded
         'default_integrations' => true,
 

--- a/src/Sentry/Laravel/EventHandler.php
+++ b/src/Sentry/Laravel/EventHandler.php
@@ -555,9 +555,7 @@ class EventHandler
         }
 
         $level = Breadcrumb::LEVEL_INFO;
-        if ($event->response->clientError()) {
-            $level = Breadcrumb::LEVEL_WARNING;
-        } elseif ($event->response->serverError()) {
+        if ($event->response->failed()) {
             $level = Breadcrumb::LEVEL_ERROR;
         }
 

--- a/src/Sentry/Laravel/EventHandler.php
+++ b/src/Sentry/Laravel/EventHandler.php
@@ -670,9 +670,9 @@ class EventHandler
 
     /**
      * Construct a full URI
-     * 
-     * @param string $url 
-     * @return UriInterface 
+     *
+     * @param string $url
+     * @return UriInterface
      */
     private function getFullUri(string $url): UriInterface
     {
@@ -681,9 +681,9 @@ class EventHandler
 
     /**
      * Construct a partial URI, excluding the authority and the query and fragment parts.
-     * 
-     * @param UriInterface $uri 
-     * @return UriInterface 
+     *
+     * @param UriInterface $uri
+     * @return UriInterface
      */
     private function getPartialUri(UriInterface $uri): UriInterface
     {

--- a/src/Sentry/Laravel/EventHandler.php
+++ b/src/Sentry/Laravel/EventHandler.php
@@ -555,7 +555,9 @@ class EventHandler
         }
 
         $level = Breadcrumb::LEVEL_INFO;
-        if (!$event->response->successful()) {
+        if ($event->response->clientError()) {
+            $level = Breadcrumb::LEVEL_WARNING;
+        } elseif ($event->response->serverError()) {
             $level = Breadcrumb::LEVEL_ERROR;
         }
 

--- a/src/Sentry/Laravel/EventHandler.php
+++ b/src/Sentry/Laravel/EventHandler.php
@@ -562,7 +562,6 @@ class EventHandler
         }
 
         $fullUri = $this->getFullUri($event->request->url());
-        $partialUri = $this->getPartialUri($fullUri);
 
         Integration::addBreadcrumb(new Breadcrumb(
             $level,
@@ -570,7 +569,7 @@ class EventHandler
             'http',
             null,
             [
-                'url' => (string) $partialUri,
+                'url' => (string) $this->getPartialUri($fullUri),
                 'method' => $event->request->method(),
                 'status_code' => $event->response->status(),
                 'http.query' => $fullUri->getQuery(),

--- a/src/Sentry/Laravel/Util/WorksWithUris.php
+++ b/src/Sentry/Laravel/Util/WorksWithUris.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Sentry\Laravel\Util;
+
+use GuzzleHttp\Psr7\Uri;
+use Psr\Http\Message\UriInterface;
+
+trait WorksWithUris
+{
+    /**
+     * Construct a full URI.
+     *
+     * @param string $url
+     *
+     * @return UriInterface
+     */
+    protected function getFullUri(string $url): UriInterface
+    {
+        return new Uri($url);
+    }
+
+    /**
+     * Construct a partial URI, excluding the authority, query and fragment parts.
+     *
+     * @param UriInterface $uri
+     *
+     * @return string
+     */
+    protected function getPartialUri(UriInterface $uri): string
+    {
+        return (string) Uri::fromParts([
+            'scheme' => $uri->getScheme(),
+            'host' => $uri->getHost(),
+            'port' => $uri->getPort(),
+            'path' => $uri->getPath(),
+        ]);
+    }
+}


### PR DESCRIPTION
This adds breadcrumbs for HTTP client calls.

The whole URI dance is done due to:

1. Laravel does not expose the URI on the `Illuminate\Http\Client\Request` class
2. We need to remove the authority, any query strings as well as the fragment from the breadcrumb `url`, and set the query and fragment on their correlating `http.xxx` key. This is done so Relay can apply proper scrubbing without any guesswork. See https://develop.sentry.dev/sdk/data-handling/#breadcrumbs for more context.

We could also make the argument we likely will need the URI part in all three SDKs, so maybe the generic SDK is a good place for this as well.
