### PR TITLE
ref: Add `tracing.http_client_requests` option

### DIFF
--- a/config/sentry.php
+++ b/config/sentry.php
@@ -26,9 +26,6 @@ return [
 
         // Capture command information in breadcrumbs
         'command_info' => true,
-
-        // Capture HTTP client requests information in breadcrumbs
-        'http_client_requests' => true,
     ],
 
     'tracing' => [
@@ -46,6 +43,9 @@ return [
 
         // Capture views as spans
         'views' => true,
+
+        // Capture HTTP client requests as spans
+        'http_client_requests' => true,
 
         // Indicates if the tracing integrations supplied by Sentry should be loaded
         'default_integrations' => true,

--- a/config/sentry.php
+++ b/config/sentry.php
@@ -26,6 +26,9 @@ return [
 
         // Capture command information in breadcrumbs
         'command_info' => true,
+
+        // Capture HTTP client requests information in breadcrumbs
+        'http_client_requests' => true,
     ],
 
     'tracing' => [


### PR DESCRIPTION
We should allow people to opt out of HTTP client tracing. Feels like we missed this in https://github.com/getsentry/sentry-laravel/pull/585 🙂 