### PR TITLE
Make the Sentry handler safer dealing with unknown values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fix log channel context handling crash when unexpected values are passed (#644)
+
 ## 3.2.0
 
 The Sentry SDK team is happy to announce the immediate availability of Sentry Laravel SDK v3.2.0.

--- a/src/Sentry/Laravel/SentryHandler.php
+++ b/src/Sentry/Laravel/SentryHandler.php
@@ -342,7 +342,7 @@ class SentryHandler extends AbstractProcessingHandler
     }
 
     /**
-     * Test if the value passed can be casted to a string.
+     * Check if the value passed can be cast to a string.
      *
      * @param mixed $value
      *

--- a/test/Sentry/LogChannelTest.php
+++ b/test/Sentry/LogChannelTest.php
@@ -3,6 +3,7 @@
 namespace Sentry\Laravel\Tests;
 
 use Monolog\Handler\FingersCrossedHandler;
+use Sentry\Event;
 use Sentry\Laravel\LogChannel;
 use Sentry\Laravel\SentryHandler;
 
@@ -32,5 +33,84 @@ class LogChannelTest extends TestCase
         $loggerWithoutActionLevel = $logChannel(['action_level' => null]);
 
         $this->assertContainsOnlyInstancesOf(SentryHandler::class, $loggerWithoutActionLevel->getHandlers());
+    }
+
+    /**
+     * @dataProvider handlerDataProvider
+     */
+    public function testHandlerWritingExpectedEventsAndContext(array $context, callable $asserter): void
+    {
+        $logChannel = new LogChannel($this->app);
+
+        $logger = $logChannel();
+
+        $logger->error('test message', $context);
+
+        $lastEvent = $this->getLastEvent();
+
+        $this->assertNotNull($lastEvent);
+        $this->assertEquals('test message', $lastEvent->getMessage());
+        $this->assertEquals('error', $lastEvent->getLevel());
+
+        $asserter($lastEvent);
+    }
+
+    public function handlerDataProvider(): iterable
+    {
+        $context = ['foo' => 'bar'];
+
+        yield [
+            $context,
+            function (Event $event) use ($context) {
+                $this->assertEquals($context, $event->getExtra()['log_context']);
+            },
+        ];
+
+        $context = ['fingerprint' => ['foo', 'bar']];
+
+        yield [
+            $context,
+            function (Event $event) use ($context) {
+                $this->assertEquals($context['fingerprint'], $event->getFingerprint());
+                $this->assertEmpty($event->getExtra());
+            },
+        ];
+
+        $context = ['user' => 'invalid value'];
+
+        yield [
+            $context,
+            function (Event $event) use ($context) {
+                $this->assertNull($event->getUser());
+                $this->assertEquals($context, $event->getExtra()['log_context']);
+            },
+        ];
+
+        $context = ['user' => ['id' => 123]];
+
+        yield [
+            $context,
+            function (Event $event) {
+                $this->assertNotNull($event->getUser());
+                $this->assertEquals(123, $event->getUser()->getId());
+                $this->assertEmpty($event->getExtra());
+            },
+        ];
+
+        $context = ['tags' => [
+            'foo' => 'bar',
+            'bar' => 123,
+        ]];
+
+        yield [
+            $context,
+            function (Event $event) {
+                $this->assertSame([
+                    'foo' => 'bar',
+                    'bar' => '123',
+                ], $event->getTags());
+                $this->assertEmpty($event->getExtra());
+            },
+        ];
     }
 }

--- a/test/Sentry/TestCase.php
+++ b/test/Sentry/TestCase.php
@@ -24,14 +24,14 @@ abstract class TestCase extends LaravelTestCase
         // or use the `$this->resetApplicationWithConfig([ /* config */ ]);` helper method
     ];
 
-    /** @var array<int, array{0: Event, 1: EventHint}> */
+    /** @var array<int, array{0: Event, 1: EventHint|null}> */
     protected $lastSentryEvents = [];
 
     protected function getEnvironmentSetUp($app): void
     {
         $this->lastSentryEvents = [];
 
-        $app['config']->set('sentry.before_send', function (Event $event, EventHint $hint) {
+        $app['config']->set('sentry.before_send', function (Event $event, ?EventHint $hint) {
             $this->lastSentryEvents[] = [$event, $hint];
 
             return null;
@@ -107,5 +107,14 @@ abstract class TestCase extends LaravelTestCase
         }
 
         return end($breadcrumbs);
+    }
+
+    protected function getLastEvent(): ?Event
+    {
+        if (empty($this->lastSentryEvents)) {
+            return null;
+        }
+
+        return end($this->lastSentryEvents)[0];
     }
 }


### PR DESCRIPTION
I've added a bunch of checks and try to err on the side of caution where we might not set values on the scope but try to always get the event out the door instead of crashing.

Also added a few tests, long way from exhaustive but better than before.

Fixes #644.