### PR TITLE
Cache performance spans & breadcrumbs

### DIFF
--- a/config/sentry.php
+++ b/config/sentry.php
@@ -15,6 +15,9 @@ return [
         // Capture Laravel logs in breadcrumbs
         'logs' => true,
 
+        // Capture Laravel cache events in breadcrumbs
+        'cache' => true,
+
         // Capture Livewire components in breadcrumbs
         'livewire' => true,
 
@@ -55,6 +58,12 @@ return [
 
         // Capture HTTP client requests as spans
         'http_client_requests' => true,
+
+        // Capture Redis operations as spans (this enables Redis events in Laravel)
+        'redis_commands' => env('SENTRY_TRACE_REDIS_COMMANDS', false),
+
+        // Try to find out where the Redis command originated from and add it to the command spans
+        'redis_origin' => true,
 
         // Indicates if the tracing integrations supplied by Sentry should be loaded
         'default_integrations' => true,

--- a/src/Sentry/Laravel/Features/CacheIntegration.php
+++ b/src/Sentry/Laravel/Features/CacheIntegration.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace Sentry\Laravel\Features;
+
+use Illuminate\Cache\Events;
+use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Redis\Events as RedisEvents;
+use Illuminate\Redis\RedisManager;
+use Sentry\Breadcrumb;
+use Sentry\Laravel\Features\Concerns\ResolvesEventOrigin;
+use Sentry\Laravel\Integration;
+use Sentry\SentrySdk;
+use Sentry\Tracing\SpanContext;
+
+class CacheIntegration extends Feature
+{
+    use ResolvesEventOrigin;
+
+    public function isApplicable(): bool
+    {
+        return $this->isTracingFeatureEnabled('redis_commands') || $this->isBreadcrumbFeatureEnabled('cache');
+    }
+
+    public function setup(Dispatcher $events): void
+    {
+        if ($this->isBreadcrumbFeatureEnabled('cache')) {
+            $events->listen([
+                Events\CacheHit::class,
+                Events\CacheMissed::class,
+                Events\KeyWritten::class,
+                Events\KeyForgotten::class,
+            ], [$this, 'handleCacheEvent']);
+        }
+
+        if ($this->isTracingFeatureEnabled('redis_commands', false)) {
+            $events->listen(RedisEvents\CommandExecuted::class, [$this, 'handleRedisCommand']);
+
+            $this->container()->afterResolving(RedisManager::class, static function (RedisManager $redis): void {
+                $redis->enableEvents();
+            });
+        }
+    }
+
+    public function handleCacheEvent(Events\CacheEvent $event): void
+    {
+        switch (true) {
+            case $event instanceof Events\KeyWritten:
+                $message = 'Written';
+                break;
+            case $event instanceof Events\KeyForgotten:
+                $message = 'Forgotten';
+                break;
+            case $event instanceof Events\CacheMissed:
+                $message = 'Missed';
+                break;
+            case $event instanceof Events\CacheHit:
+                $message = 'Read';
+                break;
+            default:
+                // In case events are added in the future we do nothing when an unknown event is encountered
+                return;
+        }
+
+        Integration::addBreadcrumb(new Breadcrumb(
+            Breadcrumb::LEVEL_INFO,
+            Breadcrumb::TYPE_DEFAULT,
+            'cache',
+            "{$message}: {$event->key}",
+            $event->tags ? ['tags' => $event->tags] : []
+        ));
+    }
+
+    public function handleRedisCommand(RedisEvents\CommandExecuted $event): void
+    {
+        $parentSpan = SentrySdk::getCurrentHub()->getSpan();
+
+        // If there is no tracing span active there is no need to handle the event
+        if ($parentSpan === null) {
+            return;
+        }
+
+        $context = new SpanContext();
+        $context->setOp('db.redis');
+        $context->setDescription(strtoupper($event->command) . ' ' . ($event->parameters[0] ?? null));
+        $context->setStartTimestamp(microtime(true) - $event->time / 1000);
+        $context->setEndTimestamp($context->getStartTimestamp() + $event->time / 1000);
+
+        $data = [
+            'db.redis.connection' => $event->connectionName,
+        ];
+
+        if ($this->shouldSendDefaultPii()) {
+            $data['db.redis.parameters'] = $event->parameters;
+        }
+
+        if ($this->isTracingFeatureEnabled('redis_origin')) {
+            $commandOrigin = $this->resolveEventOrigin();
+
+            if ($commandOrigin !== null) {
+                $data['db.redis.origin'] = $commandOrigin;
+            }
+        }
+
+        $context->setData($data);
+
+        $parentSpan->startChild($context);
+    }
+}

--- a/src/Sentry/Laravel/Features/Concerns/ResolvesEventOrigin.php
+++ b/src/Sentry/Laravel/Features/Concerns/ResolvesEventOrigin.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Sentry\Laravel\Features\Concerns;
+
+use Sentry\Laravel\Tracing\BacktraceHelper;
+
+trait ResolvesEventOrigin
+{
+    protected function resolveEventOrigin(): ?string
+    {
+        $backtraceHelper = $this->makeBacktraceHelper();
+
+        $firstAppFrame = $backtraceHelper->findFirstInAppFrameForBacktrace(debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS));
+
+        if ($firstAppFrame === null) {
+            return null;
+        }
+
+        $filePath = $backtraceHelper->getOriginalViewPathForFrameOfCompiledViewPath($firstAppFrame) ?? $firstAppFrame->getFile();
+
+        return "{$filePath}:{$firstAppFrame->getLine()}";
+    }
+
+    private function makeBacktraceHelper(): BacktraceHelper
+    {
+        return $this->container()->make(BacktraceHelper::class);
+    }
+}

--- a/src/Sentry/Laravel/Features/Feature.php
+++ b/src/Sentry/Laravel/Features/Feature.php
@@ -5,13 +5,14 @@ namespace Sentry\Laravel\Features;
 use Illuminate\Contracts\Container\Container;
 use Sentry\Integration\IntegrationInterface;
 use Sentry\Laravel\BaseServiceProvider;
+use Sentry\SentrySdk;
 
 /**
  * @method void setup() Setup the feature in the environment.
  *
  * @internal
  */
-abstract class Feature implements IntegrationInterface
+abstract class Feature
 {
     /**
      * @var Container The Laravel application container.
@@ -48,9 +49,9 @@ abstract class Feature implements IntegrationInterface
     abstract public function isApplicable(): bool;
 
     /**
-     * Initializes the current integration by registering it once.
+     * Initializes the feature.
      */
-    public function setupOnce(): void
+    public function boot(): void
     {
         if (method_exists($this, 'setup') && $this->isApplicable()) {
             try {
@@ -81,6 +82,20 @@ abstract class Feature implements IntegrationInterface
         $config = $this->container['config'][BaseServiceProvider::$abstract];
 
         return empty($config) ? [] : $config;
+    }
+
+    /**
+     * Should default PII be sent by default.
+     */
+    protected function shouldSendDefaultPii(): bool
+    {
+        $client = SentrySdk::getCurrentHub()->getClient();
+
+        if ($client === null) {
+            return false;
+        }
+
+        return $client->getOptions()->shouldSendDefaultPii();
     }
 
     /**

--- a/src/Sentry/Laravel/Tracing/EventHandler.php
+++ b/src/Sentry/Laravel/Tracing/EventHandler.php
@@ -233,7 +233,7 @@ class EventHandler
             $queryOrigin = $this->resolveQueryOriginFromBacktrace();
 
             if ($queryOrigin !== null) {
-                $context->setData(['sql.origin' => $queryOrigin]);
+                $context->setData(['db.sql.origin' => $queryOrigin]);
             }
         }
 

--- a/test/Sentry/Features/CacheIntegrationTest.php
+++ b/test/Sentry/Features/CacheIntegrationTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Sentry\Features;
+
+use Illuminate\Support\Facades\Cache;
+use Sentry\Laravel\Tests\TestCase;
+
+class CacheIntegrationTest extends TestCase
+{
+    public function testCacheBreadcrumbForWriteAndHitIsRecorded(): void
+    {
+        Cache::put($key = 'foo', 'bar');
+
+        $this->assertEquals("Written: {$key}", $this->getLastBreadcrumb()->getMessage());
+
+        Cache::get('foo');
+
+        $this->assertEquals("Read: {$key}", $this->getLastBreadcrumb()->getMessage());
+    }
+
+    public function testCacheBreadcrumbForWriteAndForgetIsRecorded(): void
+    {
+        Cache::put($key = 'foo', 'bar');
+
+        $this->assertEquals("Written: {$key}", $this->getLastBreadcrumb()->getMessage());
+
+        Cache::forget($key);
+
+        $this->assertEquals("Forgotten: {$key}", $this->getLastBreadcrumb()->getMessage());
+    }
+
+    public function testCacheBreadcrumbForMissIsRecorded(): void
+    {
+        Cache::get($key = 'foo');
+
+        $this->assertEquals("Missed: {$key}", $this->getLastBreadcrumb()->getMessage());
+    }
+
+    public function testCacheBreadcrumIsNotRecordedWhenDisabled(): void
+    {
+        $this->resetApplicationWithConfig([
+            'sentry.breadcrumbs.cache' => false,
+        ]);
+
+        $this->assertFalse($this->app['config']->get('sentry.breadcrumbs.cache'));
+
+        Cache::get('foo');
+
+        $this->assertEmpty($this->getCurrentBreadcrumbs());
+    }
+}

--- a/test/Sentry/TestCase.php
+++ b/test/Sentry/TestCase.php
@@ -8,14 +8,12 @@ use Sentry\Breadcrumb;
 use Sentry\ClientInterface;
 use Sentry\Event;
 use Sentry\EventHint;
-use Sentry\Laravel\Integration;
 use Sentry\State\Scope;
 use ReflectionProperty;
 use Sentry\Laravel\Tracing;
 use Sentry\State\HubInterface;
 use Sentry\Laravel\ServiceProvider;
 use Orchestra\Testbench\TestCase as LaravelTestCase;
-use Throwable;
 
 abstract class TestCase extends LaravelTestCase
 {


### PR DESCRIPTION
This adds:

- Cache breadcrumbs
- Redis command spans (optional)

We might want to extend this in the future to also trace the cache commands themselfs (like we do in Symfony) which requires decorating the cache drivers (not enough events to do it purely event based).

Fixes #627

Requires merging #657 first!