### PR TITLE
Fix incorrect annotation on Facade

### DIFF
--- a/src/Sentry/Laravel/Facade.php
+++ b/src/Sentry/Laravel/Facade.php
@@ -16,7 +16,7 @@ use Sentry\State\HubInterface;
  * @method static void bindClient(\Sentry\ClientInterface $client)
  * @method static \Sentry\EventId|null captureMessage(string $message, \Sentry\Severity|null $level = null, \Sentry\EventHint|null $hint = null)
  * @method static \Sentry\EventId|null captureException(\Throwable $exception, \Sentry\EventHint|null $hint = null)
- * @method static \Sentry\EventId|null captureEvent(\Throwable $exception, \Sentry\EventHint|null $hint = null)
+ * @method static \Sentry\EventId|null captureEvent(\Sentry\Event $event, \Sentry\EventHint|null $hint = null)
  * @method static \Sentry\EventId|null captureLastError(\Sentry\EventHint|null $hint = null)
  * @method static bool addBreadcrumb(\Sentry\Breadcrumb $breadcrumb)
  * @method static \Sentry\Integration\IntegrationInterface|null getIntegration(string $className)


### PR DESCRIPTION
`captureEvent` should accept `\Sentry\Event` instead of `\Throwable`