### PR TITLE
feat: Add support for Scheduled Tasks monitoring

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.2 | ^8.0",
         "illuminate/support": "^6.0 | ^7.0 | ^8.0 | ^9.0 | ^10.0",
-        "sentry/sentry": "^3.12",
+        "sentry/sentry": "^3.16",
         "sentry/sdk": "^3.3",
         "symfony/psr-http-message-bridge": "^1.0 | ^2.0",
         "nyholm/psr7": "^1.0"

--- a/src/Sentry/Laravel/Features/ConsoleIntegration.php
+++ b/src/Sentry/Laravel/Features/ConsoleIntegration.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Sentry\Laravel\Features;
+
+use Illuminate\Console\Scheduling\Event as SchedulingEvent;
+use Illuminate\Contracts\Foundation\Application;
+use Sentry\CheckIn;
+use Sentry\CheckInStatus;
+use Sentry\Event as SentryEvent;
+use Sentry\SentrySdk;
+
+class ConsoleIntegration extends Feature
+{
+    /**
+     * @var array<string, CheckIn> The list of checkins that are currently in progress.
+     */
+    private $checkInStore = [];
+
+    public function isApplicable(): bool
+    {
+        return $this->container()->make(Application::class)->runningInConsole();
+    }
+
+    public function setup(): void
+    {
+        SchedulingEvent::macro('sentryMonitor', function (string $monitorSlug) {
+            /** @var SchedulingEvent $this */
+            $mutex = $this->mutexName();
+
+            return $this
+                ->before(function () use ($mutex, $monitorSlug) {
+                    $this->startCheckIn($mutex, $monitorSlug);
+                })
+                ->onSuccess(function () use ($mutex) {
+                    $this->finishCheckIn($mutex, CheckInStatus::ok());
+                })
+                ->onFailure(function () use ($mutex) {
+                    $this->finishCheckIn($mutex, CheckInStatus::error());
+                });
+        });
+    }
+
+    private function startCheckIn(string $mutex, string $slug): void
+    {
+        $options = SentrySdk::getCurrentHub()->getClient()->getOptions();
+
+        $checkIn = new CheckIn(
+            $slug,
+            CheckInStatus::inProgress(),
+            null,
+            $options->getEnvironment(),
+            $options->getRelease()
+        );
+
+        $this->checkInStore[$mutex] = $checkIn;
+
+        $this->sendCheckIn($checkIn);
+    }
+
+    private function finishCheckIn(string $mutex, CheckInStatus $status): void
+    {
+        $checkIn = $this->checkInStore[$mutex] ?? null;
+
+        // This should never happen (because we should always start before we finish), but better safe than sorry
+        if ($checkIn === null) {
+            return;
+        }
+
+        // We don't need to keep the checkin in memory anymore since we finished
+        unset($this->checkInStore[$mutex]);
+
+        $checkIn->setStatus($status);
+
+        $this->sendCheckIn($checkIn);
+    }
+
+    private function sendCheckIn(CheckIn $checkIn): void
+    {
+        $event = SentryEvent::createCheckIn();
+        $event->setCheckIn($checkIn);
+
+        SentrySdk::getCurrentHub()->captureEvent($event);
+    }
+}

--- a/src/Sentry/Laravel/ServiceProvider.php
+++ b/src/Sentry/Laravel/ServiceProvider.php
@@ -5,16 +5,12 @@ namespace Sentry\Laravel;
 use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\Http\Kernel as HttpKernelInterface;
-use Illuminate\Console\Scheduling\Event as LaravelEvent;
 use Illuminate\Foundation\Application as Laravel;
 use Illuminate\Foundation\Http\Kernel as HttpKernel;
 use Illuminate\Log\LogManager;
 use RuntimeException;
-use Sentry\CheckIn;
-use Sentry\CheckInStatus;
 use Sentry\ClientBuilder;
 use Sentry\ClientBuilderInterface;
-use Sentry\Event as SentryEvent;
 use Sentry\Integration as SdkIntegration;
 use Sentry\Laravel\Console\PublishCommand;
 use Sentry\Laravel\Console\TestCommand;
@@ -49,6 +45,7 @@ class ServiceProvider extends BaseServiceProvider
      */
     protected const FEATURES = [
         Features\CacheIntegration::class,
+        Features\ConsoleIntegration::class,
         Features\LivewirePackageIntegration::class,
     ];
 
@@ -63,7 +60,6 @@ class ServiceProvider extends BaseServiceProvider
             $this->bindEvents();
 
             $this->setupFeatures();
-            $this->setupCronMonitoring();
 
             if ($this->app->bound(HttpKernelInterface::class)) {
                 /** @var \Illuminate\Foundation\Http\Kernel $httpKernel */
@@ -146,48 +142,6 @@ class ServiceProvider extends BaseServiceProvider
                 // Ensure that features do not break the whole application
             }
         }
-    }
-
-    /**
-     * Setup Cron Monitoring.
-     */
-    private function setupCronMonitoring(): void
-    {
-        LaravelEvent::macro('sentryMonitor', function (string $monitorSlug) {
-            $hub = SentrySdk::getCurrentHub();
-            $checkIn = new CheckIn(
-                $monitorSlug,
-                CheckInStatus::inProgress(),
-                null,
-                $hub->getClient()->getOptions()->getEnvironment(),
-                $hub->getClient()->getOptions()->getRelease()
-            );
-        
-            /** @var \Illuminate\Console\Scheduling\Event $this */
-            return $this
-                ->before(function () use ($hub, $checkIn) {
-                    $event = SentryEvent::createCheckIn();
-                    $event->setCheckIn($checkIn);
-
-                    $hub->captureEvent($event);
-                })
-                ->onSuccess(function () use ($hub, $checkIn) {
-                    $checkIn->setStatus(CheckInStatus::ok());
-
-                    $event = SentryEvent::createCheckIn();
-                    $event->setCheckIn($checkIn);
-
-                    $hub->captureEvent($event);
-                })
-                ->onFailure(function () use ($hub, $checkIn) {
-                    $checkIn->setStatus(CheckInStatus::error());
-
-                    $event = SentryEvent::createCheckIn();
-                    $event->setCheckIn($checkIn);
-
-                    $hub->captureEvent($event);
-                });
-        });
     }
 
     /**


### PR DESCRIPTION
This adds support for our new [Cron Monitors](https://docs.sentry.io/product/crons/) feature, to monitor Laravel's Scheduled Tasks.

```php
<?php

namespace App\Console;

use Illuminate\Console\Scheduling\Schedule;
use Illuminate\Foundation\Console\Kernel as ConsoleKernel;

class Kernel extends ConsoleKernel
{
    protected function schedule(Schedule $schedule)
    {
        $schedule->command('emails:send')
            ->everyHour()
            ->sentryMonitor(env('MONITOR_SLUG'));
    }
}
```

Needs https://github.com/getsentry/sentry-php/pull/1467 to be merged and released first.

Closes #628