### PR TITLE
Cron monitoring improvements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": "^7.2 | ^8.0",
         "illuminate/support": "^6.0 | ^7.0 | ^8.0 | ^9.0 | ^10.0",
-        "sentry/sentry": "^3.19",
+        "sentry/sentry": "^3.20",
         "sentry/sdk": "^3.4",
         "symfony/psr-http-message-bridge": "^1.0 | ^2.0",
         "nyholm/psr7": "^1.0"


### PR DESCRIPTION
Making use of the new cron monitoring upsert possibilities we can add some information to automatically create a cron monitor by "simply" scheduling an command and calling `->sentryMonitor()` on it.

```php
    protected function schedule(Schedule $schedule): void
    {
        $schedule->command(MyCommand::class)->everyMinute()->sentryMonitor();
    }
```

The `sentryMonitor` method has a few (all optional) arguments:

```php
->sentryMonitor(
    monitorSlug: null,         // you can set a custom slug here, needed for crons created from UI or duplicated scheduled commands (same command scheduled more than once)
    checkInMargin: 60,         // amount of seconds (?) the command is allowed to be late to check in
    maxRuntime: 300,           // amount of seconds (?) the command is allowed to run
    updateMonitorConfig: true, // indicates if we should send the monitor config with the checking to update the schedule and other config automatically (can be disabled in case you want control over it in the UI
)
```

Would be nice to have:

- [ ] Upsert the cron name instead of it being set equal to the slug (is this possible?)

---

This depends on the release of:

- getsentry/sentry-php#1511