### PR TITLE
Add helper to report lazy loading violations

### DIFF
--- a/src/Sentry/Laravel/Features/Concerns/ResolvesEventOrigin.php
+++ b/src/Sentry/Laravel/Features/Concerns/ResolvesEventOrigin.php
@@ -2,10 +2,16 @@
 
 namespace Sentry\Laravel\Features\Concerns;
 
+use Illuminate\Contracts\Container\Container;
 use Sentry\Laravel\Tracing\BacktraceHelper;
 
 trait ResolvesEventOrigin
 {
+    protected function container(): Container
+    {
+        return app();
+    }
+
     protected function resolveEventOrigin(): ?string
     {
         $backtraceHelper = $this->makeBacktraceHelper();

--- a/src/Sentry/Laravel/Integration.php
+++ b/src/Sentry/Laravel/Integration.php
@@ -216,29 +216,43 @@ class Integration implements IntegrationInterface
 
             public function __invoke(Model $model, string $relation): void
             {
-                SentrySdk::getCurrentHub()->withScope(function (Scope $scope) use ($model, $relation) {
-                    $scope->setContext('violation', [
-                        'model'    => get_class($model),
-                        'relation' => $relation,
-                        'origin'   => $this->resolveEventOrigin(),
-                    ]);
+                $currentSpan = SentrySdk::getCurrentHub()->getSpan();
 
-                    SentrySdk::getCurrentHub()->captureEvent(
-                        tap(Event::createEvent(), static function (Event $event) {
-                            $event->setLevel(Severity::warning());
-                        }),
-                        EventHint::fromArray([
-                            'exception' => new LazyLoadingViolationException($model, $relation),
-                            'mechanism' => new ExceptionMechanism(ExceptionMechanism::TYPE_GENERIC, true),
-                        ])
-                    );
-                });
+                if ($currentSpan !== null) {
+                    $currentSpan->setData([
+                        'lazy_loading_violation' => [
+                            'model'    => get_class($model),
+                            'relation' => $relation,
+                            'origin'   => $this->resolveEventOrigin(),
+                        ],
+                    ]);
+                }
+
+                // @TODO: We are currently reporting the violation on the current span, but we might want to give users the option to report it as a separate event?
+                // SentrySdk::getCurrentHub()->withScope(function (Scope $scope) use ($model, $relation) {
+                //     $scope->setContext('violation', [
+                //         'model'    => get_class($model),
+                //         'relation' => $relation,
+                //         'origin'   => $this->resolveEventOrigin(),
+                //     ]);
+                //
+                //     SentrySdk::getCurrentHub()->captureEvent(
+                //         tap(Event::createEvent(), static function (Event $event) {
+                //             $event->setLevel(Severity::warning());
+                //         }),
+                //         EventHint::fromArray([
+                //             'exception' => new LazyLoadingViolationException($model, $relation),
+                //             'mechanism' => new ExceptionMechanism(ExceptionMechanism::TYPE_GENERIC, true),
+                //         ])
+                //     );
+                // });
 
                 // Forward the violation to the next handler if there is one
                 if ($this->callback !== null) {
                     call_user_func($this->callback, $model, $relation);
                 }
             }
+
         };
     }
 


### PR DESCRIPTION
In Laravel you can instruct Eloquent to report whenever you forget to eager load a relation (causing N+1 problems) and you can register a callback to report those exceptions in production instead of throwing an exception breaking your application. Since a lazy loading violation is a performance problem and not a app-breaking problem it is common to forward these to the logs and Sentry by doing the following:

```php
Model::preventLazyLoading();

// In production we just report the lazy loading violation instead of crashing the application since it's a performance issue not a security issue
if (app()->isProduction()) {
    Model::handleLazyLoadingViolationUsing(
        static fn (Model $model, string $relation) => report(new LazyLoadingViolationException($model, $relation)),
    );
}
```

See Laravel docs: https://laravel.com/docs/10.x/eloquent-relationships#preventing-lazy-loading.

This uses the `report` helper to report the exception to the framework logging it to the log files and to Sentry (if installed).

I propose a new helper that allows you to do the following:

```php
Model::preventLazyLoading();

// In production we just report the lazy loading violation instead of crashing the application since it's a performance issue not a security issue
if (app()->isProduction()) {
    Model::handleLazyLoadingViolationUsing(
        \Sentry\Laravel\Integration::lazyLoadingViolationReporter(),
    );
}
```

This is a little syntax sugar over the manual method and also adds a "context" with information about the violation (even though all that information is already available to the user via the exception message and the shown backtrace) but also set's the exception as handled and set's the level to warning.

There is a notable upside to this, and that is that since the exception is created in our vendored code it is marked as _not_ in-app and the stacktrace therefore shows the correct line where the violation occured from instead of the users service provider where the violation would otherwise most likely be reported from.

We could simplify this even more but I am concerned that that would cause undefined behaviour since I don't find it clear that when you'd call something like `Integration::reportLazyLoadingViolations()` that we'd only do that in production (what about other env's like staging?) and such so I opted to go for the more explicit route.