### PR TITLE
Add `profiles_sample_rate` to config file

### DIFF
--- a/config/sentry.php
+++ b/config/sentry.php
@@ -77,5 +77,7 @@ return [
 
     // @see: https://docs.sentry.io/platforms/php/guides/laravel/configuration/options/#traces-sample-rate
     'traces_sample_rate' => env('SENTRY_TRACES_SAMPLE_RATE') === null ? null : (float)env('SENTRY_TRACES_SAMPLE_RATE'),
+    
+    'profiles_sample_rate' => env('SENTRY_PROFILES_SAMPLE_RATE') === null ? null : (float)env('SENTRY_PROFILES_SAMPLE_RATE'),
 
 ];


### PR DESCRIPTION
Hi,

This will allow developers to specify the profiles_sample_rate via `.env` 

https://docs.sentry.io/platforms/php/profiling/

FYI: I have got this info from the Discord channel