### PR TITLE
fix: Fix CheckIn constructor argument order

### DIFF
--- a/src/Sentry/Laravel/Features/ConsoleIntegration.php
+++ b/src/Sentry/Laravel/Features/ConsoleIntegration.php
@@ -118,8 +118,8 @@ class ConsoleIntegration extends Feature
             $slug,
             $status,
             $id,
-            $options->getEnvironment(),
-            $options->getRelease()
+            $options->getRelease(),
+            $options->getEnvironment()
         );
     }
 


### PR DESCRIPTION
The signature is

```php
    public function __construct(
        string $monitorSlug,
        CheckInStatus $status,
        string $id = null,
        ?string $release = null,
        ?string $environment = null,
        $duration = null
    ) {
```