### PR TITLE
Allow setting up features in an inactive state

### DIFF
--- a/src/Sentry/Laravel/Features/ConsoleIntegration.php
+++ b/src/Sentry/Laravel/Features/ConsoleIntegration.php
@@ -56,6 +56,13 @@ class ConsoleIntegration extends Feature
         });
     }
 
+    public function setupInactive(): void
+    {
+        SchedulingEvent::macro('sentryMonitor', function (string $monitorSlug) {
+            // When there is no Sentry DSN set there is nothing for us to do, but we still want to allow the user to setup the macro
+        });
+    }
+
     private function startCheckIn(string $mutex, string $slug, bool $useCache, int $useCacheTtlInMinutes): void
     {
         $checkIn = $this->createCheckIn($slug, CheckInStatus::inProgress());

--- a/src/Sentry/Laravel/Features/Feature.php
+++ b/src/Sentry/Laravel/Features/Feature.php
@@ -3,12 +3,13 @@
 namespace Sentry\Laravel\Features;
 
 use Illuminate\Contracts\Container\Container;
-use Sentry\Integration\IntegrationInterface;
 use Sentry\Laravel\BaseServiceProvider;
 use Sentry\SentrySdk;
+use Throwable;
 
 /**
  * @method void setup() Setup the feature in the environment.
+ * @method void setupInactive() Setup the feature in the environment in an inactive state (when no DSN was set).
  *
  * @internal
  */
@@ -56,7 +57,21 @@ abstract class Feature
         if (method_exists($this, 'setup') && $this->isApplicable()) {
             try {
                 $this->container->call([$this, 'setup']);
-            } catch (\Throwable $exception) {
+            } catch (Throwable $exception) {
+                // If the feature setup fails, we don't want to prevent the rest of the SDK from working.
+            }
+        }
+    }
+
+    /**
+     * Initializes the feature in an inactive state (when no DSN was set).
+     */
+    public function bootInactive(): void
+    {
+        if (method_exists($this, 'setupInactive') && $this->isApplicable()) {
+            try {
+                $this->container->call([$this, 'setupInactive']);
+            } catch (Throwable $exception) {
                 // If the feature setup fails, we don't want to prevent the rest of the SDK from working.
             }
         }

--- a/src/Sentry/Laravel/ServiceProvider.php
+++ b/src/Sentry/Laravel/ServiceProvider.php
@@ -18,6 +18,7 @@ use Sentry\EventHint;
 use Sentry\Integration as SdkIntegration;
 use Sentry\Laravel\Console\PublishCommand;
 use Sentry\Laravel\Console\TestCommand;
+use Sentry\Laravel\Features\Feature;
 use Sentry\Laravel\Http\LaravelRequestFetcher;
 use Sentry\Laravel\Http\SetRequestIpMiddleware;
 use Sentry\Laravel\Http\SetRequestMiddleware;
@@ -26,6 +27,7 @@ use Sentry\SentrySdk;
 use Sentry\State\Hub;
 use Sentry\State\HubInterface;
 use Sentry\Tracing\TransactionMetadata;
+use Throwable;
 
 class ServiceProvider extends BaseServiceProvider
 {
@@ -61,10 +63,10 @@ class ServiceProvider extends BaseServiceProvider
     {
         $this->app->make(HubInterface::class);
 
+        $this->setupFeatures();
+
         if ($this->hasDsnSet()) {
             $this->bindEvents();
-
-            $this->setupFeatures();
 
             if ($this->app instanceof Lumen) {
                 $this->app->middleware(SetRequestMiddleware::class);
@@ -146,10 +148,17 @@ class ServiceProvider extends BaseServiceProvider
      */
     protected function setupFeatures(): void
     {
+        $bootActive = $this->hasDsnSet();
+
         foreach (self::FEATURES as $feature) {
             try {
-                $this->app->make($feature)->boot();
-            } catch (\Throwable $e) {
+                /** @var Feature $featureInstance */
+                $featureInstance = $this->app->make($feature);
+
+                $bootActive
+                    ? $featureInstance->boot()
+                    : $featureInstance->bootInactive();
+            } catch (Throwable $e) {
                 // Ensure that features do not break the whole application
             }
         }


### PR DESCRIPTION
Some features might create macro's that should be defined if the SDK is active or not so Ive introduced a new setup method for features so they can register inert versions of their macro's. It isn't a nice approach but I figured it's the nicest way to prevent doing too much work or needing to do much guarding whenever a DSN is not set,

This fixes #696.