### PR TITLE
fix: Make sentryMonitor macro chainable

### DIFF
--- a/src/Sentry/Laravel/Features/ConsoleIntegration.php
+++ b/src/Sentry/Laravel/Features/ConsoleIntegration.php
@@ -60,6 +60,7 @@ class ConsoleIntegration extends Feature
     {
         SchedulingEvent::macro('sentryMonitor', function (string $monitorSlug) {
             // When there is no Sentry DSN set there is nothing for us to do, but we still want to allow the user to setup the macro
+            return $this;
         });
     }
 


### PR DESCRIPTION
To make the macro chainable, we need to return `$this`.

```
    $schedule->command('do:stuff')
        ->everyMinute()
        ->sentryMonitor('do-stuff-monitor')
        ->withoutOverlapping();
```

Would throw `Call to a member function withoutOverlapping() on null` otherwise.

Followup for #698