### PR TITLE
Bump base SDK

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,8 +23,8 @@
     "require": {
         "php": "^7.2 | ^8.0",
         "illuminate/support": "^6.0 | ^7.0 | ^8.0 | ^9.0 | ^10.0",
-        "sentry/sentry": "^3.16",
-        "sentry/sdk": "^3.3",
+        "sentry/sentry": "^3.19",
+        "sentry/sdk": "^3.4",
         "symfony/psr-http-message-bridge": "^1.0 | ^2.0",
         "nyholm/psr7": "^1.0"
     },


### PR DESCRIPTION
Mainly to force update the [cURL issue](https://github.com/getsentry/sentry-php/issues/1537) fix, as we got some support requests internally.