### PR TITLE
GraphQL and HTTP client improvements

### DIFF
--- a/src/Sentry/Laravel/EventHandler.php
+++ b/src/Sentry/Laravel/EventHandler.php
@@ -291,6 +291,8 @@ class EventHandler
                 'status_code' => $event->response->status(),
                 'http.query' => $fullUri->getQuery(),
                 'http.fragment' => $fullUri->getFragment(),
+                'request_body_size' => strlen($event->request->body()),
+                'response_body_size' => strlen($event->response->body()),
             ]
         ));
     }
@@ -313,6 +315,7 @@ class EventHandler
                 'method' => $event->request->method(),
                 'http.query' => $fullUri->getQuery(),
                 'http.fragment' => $fullUri->getFragment(),
+                'request_body_size' => strlen($event->request->body()),
             ]
         ));
     }


### PR DESCRIPTION
- Set `api_target` on GraphQL request bodies to `graphql` to allow Sentry to highlight it nicely

    ![image](https://github.com/getsentry/sentry-laravel/assets/1090754/6ca5c6d6-e90b-4685-9f38-018eb7e5eee3)

    Since we are not technically doing a HTTP client request but we are the GraphQL server I have not included the response since we have never done that in PHP yet. And since I couldn't find any docs on the GraphQL server thingies I tried this (2d35c899334888fed0190a50d4c39736751aa076) and it looks very nice but not a 100% confident it is "correct".


- Add missing `response_body_size` and `request_body_size` to HTTP client breadcrumbs (https://develop.sentry.dev/sdk/features/#http-client-integrations)