### PR TITLE
Make it configurable if the performance traces continues after the response has been sent

### DIFF
--- a/config/sentry.php
+++ b/config/sentry.php
@@ -71,6 +71,10 @@ return [
 
         // Indicates that requests without a matching route should be traced
         'missing_routes' => false,
+
+        // Indicates if the performance trace should continue after the response has been sent to the user until the application terminates
+        // This is required to capture any spans that are created after the response has been sent like queue jobs dispatched using `dispatch(...)->afterResponse()` for example
+        'continue_after_response' => true,
     ],
 
     // @see: https://docs.sentry.io/platforms/php/guides/laravel/configuration/options/#send-default-pii

--- a/src/Sentry/Laravel/Tracing/ServiceProvider.php
+++ b/src/Sentry/Laravel/Tracing/ServiceProvider.php
@@ -39,7 +39,7 @@ class ServiceProvider extends BaseServiceProvider
             });
         }
 
-        $tracingConfig = $this->getUserConfig()['tracing'] ?? [];
+        $tracingConfig = $this->getTracingConfig();
 
         $this->bindEvents($tracingConfig);
 
@@ -61,7 +61,9 @@ class ServiceProvider extends BaseServiceProvider
     public function register(): void
     {
         $this->app->singleton(Middleware::class, function () {
-            return new Middleware($this->app);
+            $continueAfterResponse = ($this->getTracingConfig()['continue_after_response'] ?? true) === true;
+
+            return new Middleware($this->app, $continueAfterResponse);
         });
 
         $this->app->singleton(BacktraceHelper::class, function () {
@@ -130,6 +132,11 @@ class ServiceProvider extends BaseServiceProvider
         });
 
         return new ViewEngineDecorator($realEngine, $viewFactory);
+    }
+
+    private function getTracingConfig(): array
+    {
+        return $this->getUserConfig()['tracing'] ?? [];
     }
 
     private function decorateRoutingDispatchers(): void


### PR DESCRIPTION
As requested by @diogogomeswww (https://github.com/getsentry/sentry-laravel/pull/707#issuecomment-1631043333)