### PR TITLE
Less sensitive data by default

### DIFF
--- a/config/sentry.php
+++ b/config/sentry.php
@@ -26,7 +26,7 @@ return [
         'sql_queries' => true,
 
         // Capture bindings on SQL queries logged in breadcrumbs
-        'sql_bindings' => true,
+        'sql_bindings' => false,
 
         // Capture queue job information in breadcrumbs
         'queue_info' => true,


### PR DESCRIPTION
This PR changes the following:

- Do not show SQL query bindings in breadcrumbs by default
- Filter session cookie and remember cookies from the request by default