### PR TITLE
Improve span timing

### DIFF
--- a/src/Sentry/Laravel/Tracing/ServiceProvider.php
+++ b/src/Sentry/Laravel/Tracing/ServiceProvider.php
@@ -4,7 +4,6 @@ namespace Sentry\Laravel\Tracing;
 
 use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Contracts\Events\Dispatcher;
-use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Contracts\Http\Kernel as HttpKernelInterface;
 use Illuminate\Contracts\View\Engine;
 use Illuminate\Contracts\View\View;


### PR DESCRIPTION
Correct(er) start times for `app.bootstrap` and `app.php.autoload` spans. We had a itty bitty tiny gap at the start because we used `REQUEST_TIME_FLOAT` as the start time for one and `LARAVEL_START` for the other and they differ just a little. 