### PR TITLE
Livewire 3 & Volt

### DIFF
--- a/src/Sentry/Laravel/Features/LivewirePackageIntegration.php
+++ b/src/Sentry/Laravel/Features/LivewirePackageIntegration.php
@@ -137,7 +137,7 @@ class LivewirePackageIntegration extends Feature
                 return false;
             }
 
-            return $request->header('x-livewire') === 'true';
+            return $request->hasHeader('x-livewire');
         } catch (\Throwable $e) {
             // If the request cannot be resolved, it's probably not a Livewire request.
             return false;

--- a/src/Sentry/Laravel/Features/LivewirePackageIntegration.php
+++ b/src/Sentry/Laravel/Features/LivewirePackageIntegration.php
@@ -92,7 +92,7 @@ class LivewirePackageIntegration extends Feature
         }
 
         if ($this->isTracingFeatureEnabled(self::FEATURE_KEY)) {
-            $this->updateTransactionName($component::getName());
+            $this->updateTransactionName($component->getName());
         }
     }
 


### PR DESCRIPTION
This is tracking Livewire 3 support.

Known issues or observed problems:

- [x] Livewire request not detected (`x-livewire` header present but now empty)
- [ ] `component.booted` no longer fired or incorrectly listened to
- [ ] Check if changes needed to properly annotate Volt components

Let us know if you see anything else awry when using Livewire 3!