### PR TITLE
Replace compiled view paths in profiles

### DIFF
--- a/src/Sentry/Laravel/Profiling/FrameProcessor.php
+++ b/src/Sentry/Laravel/Profiling/FrameProcessor.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Sentry\Laravel\Profiling;
+
+use Illuminate\Support\Str;
+use Sentry\Laravel\Tracing\BacktraceHelper;
+
+class FrameProcessor
+{
+    /**
+     * @param array $frame
+     *
+     * @return array
+     */
+    public function __invoke(array $frame): array
+    {
+        // Check if we are dealing with a frame for a cached view path
+        if (Str::startsWith($frame['filename'], '/storage/framework/views/')) {
+            $originalViewPath = $this->backtraceHelper()->getOriginalViewPathForCompiledViewPath($frame['abs_path']);
+
+            if ($originalViewPath !== null) {
+                // For views both the filename and function is the view path so we set them both to the original view path
+                $frame['filename'] = $frame['function'] = $originalViewPath;
+            }
+        }
+
+        return $frame;
+    }
+
+    private function backtraceHelper(): BacktraceHelper
+    {
+        static $helper = null;
+
+        if ($helper === null) {
+            $helper = app(BacktraceHelper::class);
+        }
+
+        return $helper;
+    }
+}

--- a/src/Sentry/Laravel/Tracing/BacktraceHelper.php
+++ b/src/Sentry/Laravel/Tracing/BacktraceHelper.php
@@ -75,12 +75,24 @@ class BacktraceHelper
             return null;
         }
 
+        return $this->getOriginalViewPathForCompiledViewPath($frame->getAbsoluteFilePath());
+    }
+
+    /**
+     * Takes a path and if it's a compiled view returns the original view path.
+     *
+     * @param string $suspectedViewPath
+     *
+     * @return string|null
+     */
+    public function getOriginalViewPathForCompiledViewPath(string $suspectedViewPath): ?string
+    {
         // If for some reason the file does not exists, skip resolving
-        if (!file_exists($frame->getAbsoluteFilePath())) {
+        if (!file_exists($suspectedViewPath)) {
             return null;
         }
 
-        $viewFileContents = file_get_contents($frame->getAbsoluteFilePath());
+        $viewFileContents = file_get_contents($suspectedViewPath);
 
         preg_match('/PATH (?<originalPath>.*?) ENDPATH/', $viewFileContents, $matches);
 

--- a/src/Sentry/Laravel/Tracing/ServiceProvider.php
+++ b/src/Sentry/Laravel/Tracing/ServiceProvider.php
@@ -16,8 +16,10 @@ use Illuminate\View\Factory as ViewFactory;
 use InvalidArgumentException;
 use Laravel\Lumen\Application as Lumen;
 use Sentry\Laravel\BaseServiceProvider;
+use Sentry\Laravel\Profiling\FrameProcessor;
 use Sentry\Laravel\Tracing\Routing\TracingCallableDispatcherTracing;
 use Sentry\Laravel\Tracing\Routing\TracingControllerDispatcherTracing;
+use Sentry\Profiling\Profile;
 use Sentry\Serializer\RepresentationSerializer;
 
 class ServiceProvider extends BaseServiceProvider
@@ -56,6 +58,8 @@ class ServiceProvider extends BaseServiceProvider
                 $httpKernel->prependMiddleware(Middleware::class);
             }
         }
+
+        Profile::setFrameProcessor(new FrameProcessor);
     }
 
     public function register(): void


### PR DESCRIPTION
This works with: getsentry/sentry-php#1574, and is a PoC to show what that PR could be used for.

It replaces compiled view paths with their non-compiled paths (the ones you would actually look at in your editor).

Todo:

- [ ] getsentry/sentry-php#1574
- [ ] Check and make sure we should replace `filename` / `function` and not more / other info
- [ ] When zero-downtime deployments are in play the compiled path can be outside the `base_path`, we might need to add `realpath(storage_path())` as a prefix path to fix this. This requires some more testing / investigating
- [ ] Possibly memoize the results to prevent multiple I/O operations for the same path? (uses a little memory)