### PR TITLE
Fix null description not allowed

### DIFF
--- a/src/Sentry/Laravel/Features/Storage/SentryFilesystem.php
+++ b/src/Sentry/Laravel/Features/Storage/SentryFilesystem.php
@@ -46,7 +46,7 @@ class SentryFilesystem implements Filesystem
      *
      * @return mixed
      */
-    protected function withSentry(string $method, array $args, string $description, array $data)
+    protected function withSentry(string $method, array $args, ?string $description, array $data)
     {
         $op = "file.{$method}"; // See https://develop.sentry.dev/sdk/performance/span-operations/#web-server
         $data = array_merge($data, $this->defaultData);

--- a/test/Sentry/Features/StorageIntegrationTest.php
+++ b/test/Sentry/Features/StorageIntegrationTest.php
@@ -29,6 +29,7 @@ class StorageIntegrationTest extends TestCase
         Storage::assertExists('foo', 'bar');
         Storage::delete('foo');
         Storage::delete(['foo', 'bar']);
+        Storage::files();
 
         $spans = $transaction->getSpanRecorder()->getSpans();
 
@@ -62,6 +63,12 @@ class StorageIntegrationTest extends TestCase
         $this->assertSame('file.delete', $span->getOp());
         $this->assertSame('2 paths', $span->getDescription());
         $this->assertSame(['paths' => ['foo', 'bar'], 'disk' => 'local', 'driver' => 'local'], $span->getData());
+
+        $this->assertArrayHasKey(6, $spans);
+        $span = $spans[6];
+        $this->assertSame('file.files', $span->getOp());
+        $this->assertNull($span->getDescription());
+        $this->assertSame(['directory' => null, 'recursive' => false, 'disk' => 'local', 'driver' => 'local'], $span->getData());
     }
 
     public function testDoesntCreateSpansWhenDisabled(): void
@@ -99,6 +106,7 @@ class StorageIntegrationTest extends TestCase
         Storage::assertExists('foo', 'bar');
         Storage::delete('foo');
         Storage::delete(['foo', 'bar']);
+        Storage::files();
 
         $breadcrumbs = $this->getCurrentBreadcrumbs();
 
@@ -132,6 +140,12 @@ class StorageIntegrationTest extends TestCase
         $this->assertSame('file.delete', $span->getCategory());
         $this->assertSame('2 paths', $span->getMessage());
         $this->assertSame(['paths' => ['foo', 'bar'], 'disk' => 'local', 'driver' => 'local'], $span->getMetadata());
+
+        $this->assertArrayHasKey(5, $breadcrumbs);
+        $span = $breadcrumbs[5];
+        $this->assertSame('file.files', $span->getCategory());
+        $this->assertNull($span->getMessage());
+        $this->assertSame(['directory' => null, 'recursive' => false, 'disk' => 'local', 'driver' => 'local'], $span->getMetadata());
     }
 
     public function testDoesntCreateBreadcrumbsWhenDisabled(): void


### PR DESCRIPTION
Fixes #749.

When using `Storage::files()` (without argument) the description is `null` which was not accepted by the `withSentry` helper even though valid in spans and breadcrumbs.