### PR TITLE
Fix driver not being registered when DSN not set

### DIFF
--- a/src/Sentry/Laravel/Features/Storage/Integration.php
+++ b/src/Sentry/Laravel/Features/Storage/Integration.php
@@ -23,6 +23,16 @@ class Integration extends Feature
 
     public function setup(): void
     {
+        $this->registerDiskDriver();
+    }
+
+    public function setupInactive(): void
+    {
+        $this->registerDiskDriver();
+    }
+
+    private function registerDiskDriver(): void
+    {
         $this->container()->afterResolving(FilesystemManager::class, function (FilesystemManager $filesystemManager): void {
             $filesystemManager->extend(
                 self::STORAGE_DRIVER_NAME,

--- a/test/Sentry/Features/StorageIntegrationTest.php
+++ b/test/Sentry/Features/StorageIntegrationTest.php
@@ -161,4 +161,18 @@ class StorageIntegrationTest extends TestCase
 
         $this->assertCount(0, $this->getCurrentBreadcrumbs());
     }
+
+    public function testDriverWorksWhenDisabled(): void
+    {
+        $this->resetApplicationWithConfig([
+            'sentry.dsn' => null,
+            'filesystems.disks.local.driver' => 'sentry',
+            'filesystems.disks.local.sentry_disk_name' => 'local',
+            'filesystems.disks.local.sentry_original_driver' => 'local',
+        ]);
+
+        Storage::exists('foo');
+
+        $this->expectNotToPerformAssertions();
+    }
 }


### PR DESCRIPTION
See tests, we basically did not register the driver causing `Driver [sentry] is not supported.` when DSN is not set, for example locally.