### PR TITLE
Fix consume PSR body streams when determining size

### DIFF
--- a/src/Sentry/Laravel/EventHandler.php
+++ b/src/Sentry/Laravel/EventHandler.php
@@ -291,8 +291,8 @@ class EventHandler
                 'status_code' => $event->response->status(),
                 'http.query' => $fullUri->getQuery(),
                 'http.fragment' => $fullUri->getFragment(),
-                'request_body_size' => strlen($event->request->body()),
-                'response_body_size' => strlen($event->response->body()),
+                'request_body_size' => $event->request->toPsrRequest()->getBody()->getSize(),
+                'response_body_size' => $event->response->toPsrResponse()->getBody()->getSize(),
             ]
         ));
     }
@@ -315,7 +315,7 @@ class EventHandler
                 'method' => $event->request->method(),
                 'http.query' => $fullUri->getQuery(),
                 'http.fragment' => $fullUri->getFragment(),
-                'request_body_size' => strlen($event->request->body()),
+                'request_body_size' => $event->request->toPsrRequest()->getBody()->getSize(),
             ]
         ));
     }

--- a/test/Sentry/Features/HttpClientIntegrationTest.php
+++ b/test/Sentry/Features/HttpClientIntegrationTest.php
@@ -11,6 +11,15 @@ use Sentry\Laravel\Tests\TestCase;
 
 class HttpClientIntegrationTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        if (!class_exists(ResponseReceived::class)) {
+            $this->markTestSkipped('The Laravel HTTP client events are only available in Laravel 8.0+');
+        }
+
+        parent::setUp();
+    }
+
     public function testHttpClientBreadcrumbIsRecordedForResponseReceivedEvent(): void
     {
         $this->dispatchLaravelEvent(new ResponseReceived(

--- a/test/Sentry/Features/HttpClientIntegrationTest.php
+++ b/test/Sentry/Features/HttpClientIntegrationTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Sentry\Laravel\Tests\Features;
+
+use GuzzleHttp\Psr7\Request as PsrRequest;
+use GuzzleHttp\Psr7\Response as PsrResponse;
+use Illuminate\Http\Client\Events\ResponseReceived;
+use Illuminate\Http\Client\Request;
+use Illuminate\Http\Client\Response;
+use Sentry\Laravel\Tests\TestCase;
+
+class HttpClientIntegrationTest extends TestCase
+{
+    public function testHttpClientBreadcrumbIsRecordedForResponseReceivedEvent(): void
+    {
+        $this->dispatchLaravelEvent(new ResponseReceived(
+            new Request(new PsrRequest('GET', 'https://example.com', [], 'request')),
+            new Response(new PsrResponse(200, [], 'response'))
+        ));
+
+        $this->assertCount(1, $this->getCurrentBreadcrumbs());
+
+        $metadata = $this->getLastBreadcrumb()->getMetadata();
+
+        $this->assertEquals('GET', $metadata['method']);
+        $this->assertEquals('https://example.com', $metadata['url']);
+        $this->assertEquals(200, $metadata['status_code']);
+        $this->assertEquals(7, $metadata['request_body_size']);
+        $this->assertEquals(8, $metadata['response_body_size']);
+    }
+
+    public function testHttpClientBreadcrumbDoesntConsumeBodyStream(): void
+    {
+        $this->dispatchLaravelEvent(new ResponseReceived(
+            $request = new Request(new PsrRequest('GET', 'https://example.com', [], 'request')),
+            $response = new Response(new PsrResponse(200, [], 'response'))
+        ));
+
+        $this->assertCount(1, $this->getCurrentBreadcrumbs());
+
+        $this->assertEquals('request', $request->toPsrRequest()->getBody()->getContents());
+        $this->assertEquals('response', $response->toPsrResponse()->getBody()->getContents());
+    }
+}


### PR DESCRIPTION
Fixes #754

We should not read the body to determine it's size since it could read the stream to completion. Rewinding is also a little convoluted since it requires checking if possible so I opted to get the size from the PSR object, downside is that it could fail to return a size because it's not known, but I don't think that's much of an issue for most use cases.