### PR TITLE
Internal improvements

### DIFF
--- a/src/Sentry/Laravel/Features/Feature.php
+++ b/src/Sentry/Laravel/Features/Feature.php
@@ -9,9 +9,7 @@ use Throwable;
 
 /**
  * @method void onBoot() Setup the feature in the environment.
- * @method void onRegister() Register the feature in the environment.
  * @method void onBootInactive() Setup the feature in the environment in an inactive state (when no DSN was set).
- * @method void onRegisterInactive() Register the feature in the environment in an inactive state (when no DSN was set).
  *
  * @internal
  */
@@ -52,31 +50,11 @@ abstract class Feature
     abstract public function isApplicable(): bool;
 
     /**
-     * Register the feature.
+     * Register the feature in the environment.
      */
     public function register(): void
     {
-        if (method_exists($this, 'onRegister') && $this->isApplicable()) {
-            try {
-                $this->container->call([$this, 'onRegister']);
-            } catch (Throwable $exception) {
-                // If the feature setup fails, we don't want to prevent the rest of the SDK from working.
-            }
-        }
-    }
-
-    /**
-     * Register the feature in an inactive state (when no DSN was set).
-     */
-    public function registerInactive(): void
-    {
-        if (method_exists($this, 'onRegisterInactive') && $this->isApplicable()) {
-            try {
-                $this->container->call([$this, 'onRegisterInactive']);
-            } catch (Throwable $exception) {
-                // If the feature setup fails, we don't want to prevent the rest of the SDK from working.
-            }
-        }
+        // ...
     }
 
     /**

--- a/src/Sentry/Laravel/Features/LogIntegration.php
+++ b/src/Sentry/Laravel/Features/LogIntegration.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Sentry\Laravel\Features;
+
+use Illuminate\Support\Facades\Log;
+use Sentry\Laravel\LogChannel;
+
+class LogIntegration extends Feature
+{
+    public function isApplicable(): bool
+    {
+        return true;
+    }
+
+    public function register(): void
+    {
+        Log::extend('sentry', function ($app, array $config) {
+            return (new LogChannel($app))($config);
+        });
+    }
+}

--- a/src/Sentry/Laravel/Features/Storage/Integration.php
+++ b/src/Sentry/Laravel/Features/Storage/Integration.php
@@ -21,12 +21,7 @@ class Integration extends Feature
         return true;
     }
 
-    public function onRegister(): void
-    {
-        $this->registerDiskDriver();
-    }
-
-    public function onRegisterInactive(): void
+    public function register(): void
     {
         $this->registerDiskDriver();
     }

--- a/src/Sentry/Laravel/ServiceProvider.php
+++ b/src/Sentry/Laravel/ServiceProvider.php
@@ -8,7 +8,6 @@ use Illuminate\Contracts\Http\Kernel as HttpKernelInterface;
 use Illuminate\Foundation\Application as Laravel;
 use Illuminate\Foundation\Http\Kernel as HttpKernel;
 use Illuminate\Http\Request;
-use Illuminate\Log\LogManager;
 use Laravel\Lumen\Application as Lumen;
 use RuntimeException;
 use Sentry\ClientBuilder;
@@ -51,6 +50,7 @@ class ServiceProvider extends BaseServiceProvider
      * List of features that are provided by the SDK.
      */
     protected const FEATURES = [
+        Features\LogIntegration::class,
         Features\CacheIntegration::class,
         Features\QueueIntegration::class,
         Features\ConsoleIntegration::class,
@@ -106,12 +106,6 @@ class ServiceProvider extends BaseServiceProvider
         $this->mergeConfigFrom(__DIR__ . '/../../../config/sentry.php', static::$abstract);
 
         $this->configureAndRegisterClient();
-
-        if (($logManager = $this->app->make('log')) instanceof LogManager) {
-            $logManager->extend('sentry', function ($app, array $config) {
-                return (new LogChannel($app))($config);
-            });
-        }
 
         $this->registerFeatures();
     }

--- a/src/Sentry/Laravel/ServiceProvider.php
+++ b/src/Sentry/Laravel/ServiceProvider.php
@@ -23,8 +23,10 @@ use Sentry\Laravel\Features\Feature;
 use Sentry\Laravel\Http\LaravelRequestFetcher;
 use Sentry\Laravel\Http\SetRequestIpMiddleware;
 use Sentry\Laravel\Http\SetRequestMiddleware;
+use Sentry\Laravel\Tracing\BacktraceHelper;
 use Sentry\Laravel\Tracing\ServiceProvider as TracingServiceProvider;
 use Sentry\SentrySdk;
+use Sentry\Serializer\RepresentationSerializer;
 use Sentry\State\Hub;
 use Sentry\State\HubInterface;
 use Sentry\Tracing\TransactionMetadata;
@@ -328,6 +330,14 @@ class ServiceProvider extends BaseServiceProvider
         });
 
         $this->app->alias(HubInterface::class, static::$abstract);
+
+        $this->app->singleton(BacktraceHelper::class, function () {
+            $sentry = $this->app->make(HubInterface::class);
+
+            $options = $sentry->getClient()->getOptions();
+
+            return new BacktraceHelper($options, new RepresentationSerializer($options));
+        });
     }
 
     /**

--- a/src/Sentry/Laravel/ServiceProvider.php
+++ b/src/Sentry/Laravel/ServiceProvider.php
@@ -153,16 +153,12 @@ class ServiceProvider extends BaseServiceProvider
             $this->app->singleton($feature);
         }
 
-        $bootActive = $this->hasDsnSet();
-
         foreach (self::FEATURES as $feature) {
             try {
                 /** @var Feature $featureInstance */
                 $featureInstance = $this->app->make($feature);
 
-                $bootActive
-                    ? $featureInstance->register()
-                    : $featureInstance->registerInactive();
+                $featureInstance->register();
             } catch (Throwable $e) {
                 // Ensure that features do not break the whole application
             }

--- a/src/Sentry/Laravel/Tracing/BacktraceHelper.php
+++ b/src/Sentry/Laravel/Tracing/BacktraceHelper.php
@@ -8,6 +8,9 @@ use Sentry\FrameBuilder;
 use Illuminate\Support\Str;
 use Sentry\Serializer\RepresentationSerializerInterface;
 
+/**
+ * @internal
+ */
 class BacktraceHelper
 {
     /**

--- a/src/Sentry/Laravel/Tracing/ServiceProvider.php
+++ b/src/Sentry/Laravel/Tracing/ServiceProvider.php
@@ -67,10 +67,7 @@ class ServiceProvider extends BaseServiceProvider
 
     private function bindEvents(array $tracingConfig): void
     {
-        $handler = new EventHandler(
-            $tracingConfig,
-            $this->app->make(BacktraceHelper::class)
-        );
+        $handler = new EventHandler($tracingConfig);
 
         try {
             /** @var \Illuminate\Contracts\Events\Dispatcher $dispatcher */

--- a/src/Sentry/Laravel/Tracing/ServiceProvider.php
+++ b/src/Sentry/Laravel/Tracing/ServiceProvider.php
@@ -17,7 +17,6 @@ use Laravel\Lumen\Application as Lumen;
 use Sentry\Laravel\BaseServiceProvider;
 use Sentry\Laravel\Tracing\Routing\TracingCallableDispatcherTracing;
 use Sentry\Laravel\Tracing\Routing\TracingControllerDispatcherTracing;
-use Sentry\Serializer\RepresentationSerializer;
 
 class ServiceProvider extends BaseServiceProvider
 {
@@ -63,15 +62,6 @@ class ServiceProvider extends BaseServiceProvider
             $continueAfterResponse = ($this->getTracingConfig()['continue_after_response'] ?? true) === true;
 
             return new Middleware($this->app, $continueAfterResponse);
-        });
-
-        $this->app->singleton(BacktraceHelper::class, function () {
-            /** @var \Sentry\State\Hub $sentry */
-            $sentry = $this->app->make(self::$abstract);
-
-            $options = $sentry->getClient()->getOptions();
-
-            return new BacktraceHelper($options, new RepresentationSerializer($options));
         });
     }
 

--- a/test/Sentry/ClientBuilderDecoratorTest.php
+++ b/test/Sentry/ClientBuilderDecoratorTest.php
@@ -6,9 +6,9 @@ use Sentry\ClientBuilderInterface;
 
 class ClientBuilderDecoratorTest extends TestCase
 {
-    protected function getEnvironmentSetUp($app): void
+    protected function defineEnvironment($app): void
     {
-        parent::getEnvironmentSetUp($app);
+        parent::defineEnvironment($app);
 
         $app->extend(ClientBuilderInterface::class, function (ClientBuilderInterface $clientBuilder) {
             $clientBuilder->getOptions()->setEnvironment('from_service_container');

--- a/test/Sentry/Features/ConsoleIntegrationTest.php
+++ b/test/Sentry/Features/ConsoleIntegrationTest.php
@@ -52,12 +52,9 @@ class ConsoleIntegrationTest extends TestCase
         $this->getScheduler()->call(function () {})->sentryMonitor();
     }
 
+    /** @define-env envWithoutDsnSet */
     public function testScheduleMacroWithoutDsnSet(): void
     {
-        $this->resetApplicationWithConfig([
-            'sentry.dsn' => null,
-        ]);
-
         /** @var Event $scheduledEvent */
         $scheduledEvent = $this->getScheduler()->call(function () {})->sentryMonitor('test-monitor');
 
@@ -79,6 +76,7 @@ class ConsoleIntegrationTest extends TestCase
         $this->assertTrue(Event::hasMacro('sentryMonitor'));
     }
 
+    /** @define-env envWithoutDsnSet */
     public function testScheduleMacroIsRegisteredWithoutDsnSet(): void
     {
         if (!method_exists(Event::class, 'flushMacros')) {
@@ -87,9 +85,7 @@ class ConsoleIntegrationTest extends TestCase
 
         Event::flushMacros();
 
-        $this->resetApplicationWithConfig([
-            'sentry.dsn' => null,
-        ]);
+        $this->refreshApplication();
 
         $this->assertTrue(Event::hasMacro('sentryMonitor'));
     }

--- a/test/Sentry/Features/LogIntegrationTest.php
+++ b/test/Sentry/Features/LogIntegrationTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Sentry\Features;
+
+use Illuminate\Config\Repository;
+use Illuminate\Support\Facades\Log;
+use Sentry\Laravel\Tests\TestCase;
+use Sentry\Severity;
+
+class LogIntegrationTest extends TestCase
+{
+    protected function defineEnvironment($app): void
+    {
+        parent::defineEnvironment($app);
+
+        tap($app['config'], static function (Repository $config) {
+            $config->set('logging.channels.sentry', [
+                'driver' => 'sentry',
+            ]);
+
+            $config->set('logging.channels.sentry_error_level', [
+                'driver' => 'sentry',
+                'level' => 'error',
+            ]);
+        });
+    }
+
+    public function testLogChannelIsRegistered(): void
+    {
+        $this->expectNotToPerformAssertions();
+
+        Log::channel('sentry');
+    }
+
+    /** @define-env envWithoutDsnSet */
+    public function testLogChannelIsRegisteredWithoutDsn(): void
+    {
+        $this->expectNotToPerformAssertions();
+
+        Log::channel('sentry');
+    }
+
+    public function testLogChannelGeneratesEvents(): void
+    {
+        $logger = Log::channel('sentry');
+
+        $logger->info('Sentry Laravel info log message');
+
+        $this->assertEquals(1, $this->getEventsCount());
+
+        $event = $this->getLastEvent();
+
+        $this->assertEquals(Severity::info(), $event->getLevel());
+        $this->assertEquals('Sentry Laravel info log message', $event->getMessage());
+    }
+
+    public function testLogChannelGeneratesEventsOnlyForConfiguredLevel(): void
+    {
+        $logger = Log::channel('sentry_error_level');
+
+        $logger->info('Sentry Laravel info log message');
+        $logger->warning('Sentry Laravel warning log message');
+        $logger->error('Sentry Laravel error log message');
+
+        $this->assertEquals(1, $this->getEventsCount());
+
+        $event = $this->getLastEvent();
+
+        $this->assertEquals(Severity::error(), $event->getLevel());
+        $this->assertEquals('Sentry Laravel error log message', $event->getMessage());
+    }
+}

--- a/test/Sentry/Laravel/LaravelIntegrationsOptionTest.php
+++ b/test/Sentry/Laravel/LaravelIntegrationsOptionTest.php
@@ -12,9 +12,9 @@ use Sentry\Laravel\Tests\TestCase;
 
 class LaravelIntegrationsOptionTest extends TestCase
 {
-    protected function getEnvironmentSetUp($app): void
+    protected function defineEnvironment($app): void
     {
-        parent::getEnvironmentSetUp($app);
+        parent::defineEnvironment($app);
 
         $app->singleton('custom-sentry-integration', static function () {
             return new IntegrationsOptionTestIntegrationStub;

--- a/test/Sentry/ServiceProviderTest.php
+++ b/test/Sentry/ServiceProviderTest.php
@@ -10,7 +10,7 @@ use Sentry\State\HubInterface;
 
 class ServiceProviderTest extends TestCase
 {
-    protected function getEnvironmentSetUp($app): void
+    protected function defineEnvironment($app): void
     {
         $app['config']->set('sentry.dsn', 'https://publickey:secretkey@sentry.dev/123');
         $app['config']->set('sentry.error_types', E_ALL ^ E_DEPRECATED ^ E_USER_DEPRECATED);

--- a/test/Sentry/ServiceProviderWithCustomAliasTest.php
+++ b/test/Sentry/ServiceProviderWithCustomAliasTest.php
@@ -9,7 +9,7 @@ use Sentry\State\HubInterface;
 
 class ServiceProviderWithCustomAliasTest extends TestCase
 {
-    protected function getEnvironmentSetUp($app): void
+    protected function defineEnvironment($app): void
     {
         $app['config']->set('custom-sentry.dsn', 'http://publickey:secretkey@sentry.dev/123');
         $app['config']->set('custom-sentry.error_types', E_ALL ^ E_DEPRECATED ^ E_USER_DEPRECATED);

--- a/test/Sentry/ServiceProviderWithoutDsnTest.php
+++ b/test/Sentry/ServiceProviderWithoutDsnTest.php
@@ -8,7 +8,7 @@ use Illuminate\Routing\Events\RouteMatched;
 
 class ServiceProviderWithoutDsnTest extends \Orchestra\Testbench\TestCase
 {
-    protected function getEnvironmentSetUp($app): void
+    protected function defineEnvironment($app): void
     {
         $app['config']->set('sentry.dsn', null);
     }

--- a/test/Sentry/TestCase.php
+++ b/test/Sentry/TestCase.php
@@ -20,6 +20,8 @@ abstract class TestCase extends LaravelTestCase
 {
     private static $hasSetupGlobalEventProcessor = false;
 
+    protected $loadEnvironmentVariables = false;
+
     protected $setupConfig = [
         // Set config here before refreshing the app to set it in the container before Sentry is loaded
         // or use the `$this->resetApplicationWithConfig([ /* config */ ]);` helper method
@@ -28,7 +30,8 @@ abstract class TestCase extends LaravelTestCase
     /** @var array<int, array{0: Event, 1: EventHint|null}> */
     protected static $lastSentryEvents = [];
 
-    protected function getEnvironmentSetUp($app): void
+    /** @param \Illuminate\Foundation\Application $app */
+    protected function defineEnvironment($app): void
     {
         self::$lastSentryEvents = [];
 
@@ -46,7 +49,7 @@ abstract class TestCase extends LaravelTestCase
             return null;
         });
 
-        $app['config']->set('sentry.dsn', 'http://publickey:secretkey@sentry.dev/123');
+        $app['config']->set('sentry.dsn', 'https://publickey:secretkey@sentry.dev/123');
 
         foreach ($this->setupConfig as $key => $value) {
             $app['config']->set($key, $value);

--- a/test/Sentry/Tracing/EventHandlerTest.php
+++ b/test/Sentry/Tracing/EventHandlerTest.php
@@ -14,7 +14,7 @@ class EventHandlerTest extends TestCase
     {
         $this->expectException(RuntimeException::class);
 
-        $handler = new EventHandler([], $this->app->make(BacktraceHelper::class));
+        $handler = new EventHandler([]);
 
         /** @noinspection PhpUndefinedMethodInspection */
         $handler->thisIsNotAHandlerAndShouldThrowAnException();
@@ -29,7 +29,7 @@ class EventHandlerTest extends TestCase
 
     private function tryAllEventHandlerMethods(array $methods): void
     {
-        $handler = new EventHandler([], $this->app->make(BacktraceHelper::class));
+        $handler = new EventHandler([]);
 
         $methods = array_map(static function ($method) {
             return "{$method}Handler";


### PR DESCRIPTION
- The register callback of a feature should not try to use anything in the container, but just register things without taking in account configuration parameters since they may or may not be correctly available
- Cleanup the tests a bit by using the `@define-env` annotation
- Move the Log channel to a feature and add some tests
- Mark `BacktraceHelper` as `@internal` and make it lazy for the tracing service provider