### PR TITLE
Always register the about command integration

### DIFF
--- a/src/Sentry/Laravel/ServiceProvider.php
+++ b/src/Sentry/Laravel/ServiceProvider.php
@@ -95,9 +95,9 @@ class ServiceProvider extends BaseServiceProvider
             }
 
             $this->registerArtisanCommands();
-
-            $this->registerAboutCommandIntegration();
         }
+
+        $this->registerAboutCommandIntegration();
     }
 
     /**


### PR DESCRIPTION
The allows `Artisan::call('about')` to function, since it's just a simple registration and no actual work is performed there is no performance panelty to doing it like this.