### PR TITLE
Fix deprecation message for str_starts_with

### DIFF
--- a/src/Sentry/Laravel/Tracing/Integrations/LighthouseIntegration.php
+++ b/src/Sentry/Laravel/Tracing/Integrations/LighthouseIntegration.php
@@ -80,7 +80,7 @@ class LighthouseIntegration implements IntegrationInterface
     private function processEvent(Event $event, Options $options): void
     {
         // Detect if we are processing a GraphQL request, if not skip processing the event
-        if (!Str::startsWith($event->getTransaction() ?? '', 'lighthouse?')) {
+        if ($event->getTransaction() === null || !Str::startsWith($event->getTransaction(), 'lighthouse?')) {
             return;
         }
 

--- a/src/Sentry/Laravel/Tracing/Integrations/LighthouseIntegration.php
+++ b/src/Sentry/Laravel/Tracing/Integrations/LighthouseIntegration.php
@@ -80,7 +80,7 @@ class LighthouseIntegration implements IntegrationInterface
     private function processEvent(Event $event, Options $options): void
     {
         // Detect if we are processing a GraphQL request, if not skip processing the event
-        if (!Str::startsWith($event->getTransaction(), 'lighthouse?')) {
+        if (!Str::startsWith($event->getTransaction() ?? '', 'lighthouse?')) {
             return;
         }
 


### PR DESCRIPTION
str_starts_with(): passing null to parameter #1 ($haystack) of type string is deprecated in /var/www/vendor/laravel/framework/src/illuminate/support/str.php on line 1298