### PR TITLE
Update `sentry/sdk` dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "php": "^7.2 | ^8.0",
         "illuminate/support": "^6.0 | ^7.0 | ^8.0 | ^9.0 | ^10.0",
         "sentry/sentry": "^3.20.1",
-        "sentry/sdk": "^3.4",
+        "sentry/sdk": "^4.0",
         "symfony/psr-http-message-bridge": "^1.0 | ^2.0",
         "nyholm/psr7": "^1.0"
     },


### PR DESCRIPTION
By updating `sentry/sdk` to `v4.0` which uses [`sentry/sentry` now removed `php-http/message-factory` dependency](https://github.com/getsentry/sentry-php/blob/df4c078a349f588fc7c704d66f3c46c26487d9e2/CHANGELOG.md#misc). Therefore, we can get rid of this dependency issue when installing this package.
```
Package `php-http/message-factory` is abandoned, you should avoid using it. Use psr/http-factory instead.
```