### PR TITLE
Add `ignore_exceptions` & `ignore_transactions` to the default config

### DIFF
--- a/config/sentry.php
+++ b/config/sentry.php
@@ -30,10 +30,10 @@ return [
     'send_default_pii' => env('SENTRY_SEND_DEFAULT_PII', false),
 
     // @see: https://docs.sentry.io/platforms/php/guides/laravel/configuration/options/#ignore-exceptions
-    'ignore_exceptions' => [],
+    // 'ignore_exceptions' => [],
 
     // @see: https://docs.sentry.io/platforms/php/guides/laravel/configuration/options/#ignore-transactions
-    'ignore_transactions' => [],
+    // 'ignore_transactions' => [],
 
     // Breadcrumb specific configuration
     'breadcrumbs' => [
@@ -101,4 +101,5 @@ return [
         // Enable the tracing integrations supplied by Sentry (recommended)
         'default_integrations' => env('SENTRY_TRACE_DEFAULT_INTEGRATIONS_ENABLED', true),
     ],
+
 ];

--- a/config/sentry.php
+++ b/config/sentry.php
@@ -29,6 +29,12 @@ return [
     // @see: https://docs.sentry.io/platforms/php/guides/laravel/configuration/options/#send-default-pii
     'send_default_pii' => env('SENTRY_SEND_DEFAULT_PII', false),
 
+    // @see: https://docs.sentry.io/platforms/php/guides/laravel/configuration/options/#ignore-exceptions
+    'ignore_exceptions' => [],
+
+    // @see: https://docs.sentry.io/platforms/php/guides/laravel/configuration/options/#ignore-transactions
+    'ignore_transactions' => [],
+
     // Breadcrumb specific configuration
     'breadcrumbs' => [
         // Capture Laravel logs as breadcrumbs
@@ -95,8 +101,4 @@ return [
         // Enable the tracing integrations supplied by Sentry (recommended)
         'default_integrations' => env('SENTRY_TRACE_DEFAULT_INTEGRATIONS_ENABLED', true),
     ],
-
-    'ignore_exceptions' => [],
-
-    'ignore_transactions' => [],
 ];

--- a/config/sentry.php
+++ b/config/sentry.php
@@ -96,4 +96,7 @@ return [
         'default_integrations' => env('SENTRY_TRACE_DEFAULT_INTEGRATIONS_ENABLED', true),
     ],
 
+    'ignore_exceptions' => [],
+
+    'ignore_transactions' => [],
 ];


### PR DESCRIPTION
Hello,

As https://github.com/getsentry/sentry-php/pull/1503 aimed to make ignoring exceptions "dead simple", I guess it should be included by default in the config file. Then it would be a lot easier to learn about the feature instead of searching into the doc (which is [incomplete at the moment](https://github.com/getsentry/sentry-php/issues/1643)).