### PR TITLE
Unify backtrace origin

### DIFF
--- a/src/Sentry/Laravel/Tracing/EventHandler.php
+++ b/src/Sentry/Laravel/Tracing/EventHandler.php
@@ -170,9 +170,7 @@ class EventHandler
             $queryOrigin = $this->resolveQueryOriginFromBacktrace();
 
             if ($queryOrigin !== null) {
-                $context->setData(array_merge($context->getData(), [
-                    'db.sql.origin' => $queryOrigin
-                ]));
+                $context->setData(array_merge($context->getData(), $queryOrigin));
             }
         }
 
@@ -184,7 +182,7 @@ class EventHandler
      *
      * @return string|null
      */
-    private function resolveQueryOriginFromBacktrace(): ?string
+    private function resolveQueryOriginFromBacktrace(): ?array
     {
         $backtraceHelper = $this->makeBacktraceHelper();
 
@@ -196,7 +194,11 @@ class EventHandler
 
         $filePath = $backtraceHelper->getOriginalViewPathForFrameOfCompiledViewPath($firstAppFrame) ?? $firstAppFrame->getFile();
 
-        return "{$filePath}:{$firstAppFrame->getLine()}";
+        return [
+            'code.filepath' => $filePath,
+            'code.function' => $firstAppFrame->getFunctionName(),
+            'code.lineno' => $firstAppFrame->getLine(),
+        ];
     }
 
     protected function responsePreparedHandler(RoutingEvents\ResponsePrepared $event): void


### PR DESCRIPTION
We're turning this into a real feature in the Querries module.

![Screenshot 2023-11-20 at 12 42 10 PM](https://github.com/getsentry/sentry-laravel/assets/6617432/d0d4a60a-69ce-4e44-8a50-be8169000e9f)

This requires following some conventions, we'll use https://opentelemetry.io/docs/specs/semconv/attributes-registry/code/.

Will also update the other places we use this.