### PR TITLE
Fix missing `sentryMonitor` macro when command is called outside the CLI environment

### DIFF
--- a/src/Sentry/Laravel/Features/ConsoleIntegration.php
+++ b/src/Sentry/Laravel/Features/ConsoleIntegration.php
@@ -28,6 +28,11 @@ class ConsoleIntegration extends Feature
      */
     private $cache;
 
+    public function register(): void
+    {
+        $this->onBootInactive();
+    }
+    
     public function isApplicable(): bool
     {
         return $this->container()->make(Application::class)->runningInConsole();


### PR DESCRIPTION
This is a PR to fix the problem described by the #805 issue.

The problem is that whenever an artisan command is called when not running in console, the schedule method on the ConsoleKernel is executed. 

This happens on Laravel Vapor, for example, where the config is cached on the fly with `$app->make(ConsoleKernelContract::class)->call('config:cache');` in `vendor/laravel/vapor-core/stubs/fpmRuntime.php`


this can be replicated easily, by doing `Artisan::call('inspire');` in a controller.