### PR TITLE
feat: Added sentryMonitor macro support for specifying environments, updated CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,8 +67,10 @@ composer phpstan
 The code is automatically formatted through [php-cs-fixer](https://cs.symfony.com).
 
 ```bash
-composer phpcs
+composer cs-fix
 ```
+
+**Note**: there is a dry run option `composer cs-check`
 
 ## Releasing a new version
 

--- a/src/Sentry/Laravel/Features/ConsoleIntegration.php
+++ b/src/Sentry/Laravel/Features/ConsoleIntegration.php
@@ -37,6 +37,8 @@ class ConsoleIntegration extends Feature
     {
         $this->cache = $cache;
 
+        $container = $this->container();
+
         $startCheckIn = function (?string $slug, SchedulingEvent $scheduled, ?int $checkInMargin, ?int $maxRuntime, bool $updateMonitorConfig) {
             $this->startCheckIn($slug, $scheduled, $checkInMargin, $maxRuntime, $updateMonitorConfig);
         };
@@ -49,9 +51,13 @@ class ConsoleIntegration extends Feature
             ?int $checkInMargin = null,
             ?int $maxRuntime = null,
             bool $updateMonitorConfig = true,
-            array $runOnEnvironments = []
-        ) use ($startCheckIn, $finishCheckIn) {
-            if (! empty($runOnEnvironments) && ! in_array(config('app.env'), $runOnEnvironments)) {
+            array $onlyOnEnvironments = []
+        ) use ($container, $startCheckIn, $finishCheckIn) {
+            $environment = $container instanceof Application
+                ? $container->environment()
+                : null;
+
+            if (!empty($onlyOnEnvironments) && !in_array($environment, $onlyOnEnvironments)) {
                 return $this;
             }
 
@@ -84,7 +90,7 @@ class ConsoleIntegration extends Feature
             ?int $checkInMargin = null,
             ?int $maxRuntime = null,
             bool $updateMonitorConfig = true,
-            array $runOnEnvironments = []
+            array $onlyOnEnvironments = []
         ) {
             return $this;
         });

--- a/src/Sentry/Laravel/Features/ConsoleIntegration.php
+++ b/src/Sentry/Laravel/Features/ConsoleIntegration.php
@@ -19,7 +19,7 @@ use Sentry\SentrySdk;
 class ConsoleIntegration extends Feature
 {
     /**
-     * @var array<string, CheckIn> The list of checkins that are currently in progress.
+     * @var array<string, CheckIn> The list of check-ins that are currently in progress.
      */
     private $checkInStore = [];
 
@@ -48,8 +48,13 @@ class ConsoleIntegration extends Feature
             ?string $monitorSlug = null,
             ?int $checkInMargin = null,
             ?int $maxRuntime = null,
-            bool $updateMonitorConfig = true
+            bool $updateMonitorConfig = true,
+            array $runOnEnvironments = []
         ) use ($startCheckIn, $finishCheckIn) {
+            if (! empty($runOnEnvironments) && ! in_array(config('app.env'), $runOnEnvironments)) {
+                return $this;
+            }
+
             /** @var SchedulingEvent $this */
             if ($monitorSlug === null && $this->command === null) {
                 throw new RuntimeException('The command string is null, please set a slug manually for this scheduled command using the `sentryMonitor(\'your-monitor-slug\')` macro.');
@@ -78,7 +83,8 @@ class ConsoleIntegration extends Feature
             ?string $monitorSlug = null,
             ?int $checkInMargin = null,
             ?int $maxRuntime = null,
-            bool $updateMonitorConfig = true
+            bool $updateMonitorConfig = true,
+            array $runOnEnvironments = []
         ) {
             return $this;
         });

--- a/test/Sentry/Features/ConsoleIntegrationTest.php
+++ b/test/Sentry/Features/ConsoleIntegrationTest.php
@@ -85,7 +85,9 @@ class ConsoleIntegrationTest extends TestCase
 
     public function testScheduledMacroWithSpecifiedEnvironmentsMatching(): void
     {
-        $this->app['config']->set('app.env', 'production');
+        $this->app->detectEnvironment(static function () {
+            return 'production';
+        });
 
         /** @var Event $scheduledEvent */
         $scheduledEvent = $this->getScheduler()
@@ -107,7 +109,9 @@ class ConsoleIntegrationTest extends TestCase
 
     public function testScheduledMacroWithSpecifiedEnvironmentsNotMatching(): void
     {
-        $this->app['config']->set('app.env', 'production');
+        $this->app->detectEnvironment(static function () {
+            return 'production';
+        });
 
         /** @var Event $scheduledEvent */
         $scheduledEvent = $this->getScheduler()
@@ -122,28 +126,6 @@ class ConsoleIntegrationTest extends TestCase
         $finishCheckInEvent = $this->getLastSentryEvent();
 
         $this->assertNull($finishCheckInEvent);
-    }
-
-    public function testScheduledMacroWithSpecifiedEnvironmentsEmpty(): void
-    {
-        $this->app['config']->set('app.env', 'production');
-
-        /** @var Event $scheduledEvent */
-        $scheduledEvent = $this->getScheduler()
-            ->call(function () {})
-            ->sentryMonitor('test-monitor', null, null, true, []);
-
-        $scheduledEvent->run($this->app);
-
-        // We expect a total of 2 events to be sent to Sentry:
-        // 1. The start check-in event
-        // 2. The finish check-in event
-        $this->assertSentryCheckInCount(2);
-
-        $finishCheckInEvent = $this->getLastSentryEvent();
-
-        $this->assertNotNull($finishCheckInEvent->getCheckIn());
-        $this->assertEquals('test-monitor', $finishCheckInEvent->getCheckIn()->getMonitorSlug());
     }
 
     /** @define-env envWithoutDsnSet */


### PR DESCRIPTION
## Feature
- Added the new parameter to specify an array of environments that you would like the `sentryMonitor()` logic to run in
     - If nothing is specified, then the macro will run like normal
     - If one or more environments are specified and one matches it will run like normal
     - If one or more environments are specified and nothing matches it will run not run and return `$this`
- Updated the contribution guide as there is no longer a Composer `phpcs` command. I did try running cs-fix/cs-check and there was a ton of changes (looks like mainly LF -> CRLF changes) but I didn't commit any of those changes.

## References
- https://github.com/getsentry/sentry/discussions/42283#discussioncomment-7802861