### PR TITLE
Queue tracing bugfixes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -56,7 +56,7 @@
             "@phpstan",
             "@tests"
         ],
-        "tests": "vendor/bin/phpunit --verbose",
+        "tests": "vendor/bin/phpunit",
         "cs-check": "vendor/bin/php-cs-fixer fix --verbose --diff --dry-run",
         "cs-fix": "vendor/bin/php-cs-fixer fix --verbose --diff",
         "phpstan": "vendor/bin/phpstan analyse"

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     "require": {
         "php": "^7.2 | ^8.0",
         "illuminate/support": "^6.0 | ^7.0 | ^8.0 | ^9.0 | ^10.0",
-        "sentry/sentry": "^4.0",
+        "sentry/sentry": "^4.3",
         "symfony/psr-http-message-bridge": "^1.0 | ^2.0",
         "nyholm/psr7": "^1.0"
     },

--- a/src/Sentry/Laravel/Features/Feature.php
+++ b/src/Sentry/Laravel/Features/Feature.php
@@ -23,16 +23,16 @@ abstract class Feature
     /**
      * In-memory cache for the tracing feature flag.
      *
-     * @var bool|null
+     * @var array<string, bool>
      */
-    private $isTracingFeatureEnabled;
+    private $isTracingFeatureEnabled = [];
 
     /**
      * In-memory cache for the breadcumb feature flag.
      *
-     * @var bool|null
+     * @var array<string, bool>
      */
-    private $isBreadcrumbFeatureEnabled;
+    private $isBreadcrumbFeatureEnabled = [];
 
     /**
      * @param Container $container The Laravel application container.
@@ -126,11 +126,11 @@ abstract class Feature
      */
     protected function isTracingFeatureEnabled(string $feature, bool $default = true): bool
     {
-        if ($this->isTracingFeatureEnabled === null) {
-            $this->isTracingFeatureEnabled = $this->isFeatureEnabled('tracing', $feature, $default);
+        if (!array_key_exists($feature, $this->isTracingFeatureEnabled)) {
+            $this->isTracingFeatureEnabled[$feature] = $this->isFeatureEnabled('tracing', $feature, $default);
         }
 
-        return $this->isTracingFeatureEnabled;
+        return $this->isTracingFeatureEnabled[$feature];
     }
 
     /**
@@ -138,11 +138,11 @@ abstract class Feature
      */
     protected function isBreadcrumbFeatureEnabled(string $feature, bool $default = true): bool
     {
-        if ($this->isBreadcrumbFeatureEnabled === null) {
-            $this->isBreadcrumbFeatureEnabled = $this->isFeatureEnabled('breadcrumbs', $feature, $default);
+        if (!array_key_exists($feature, $this->isBreadcrumbFeatureEnabled)) {
+            $this->isBreadcrumbFeatureEnabled[$feature] = $this->isFeatureEnabled('breadcrumbs', $feature, $default);
         }
 
-        return $this->isBreadcrumbFeatureEnabled;
+        return $this->isBreadcrumbFeatureEnabled[$feature];
     }
 
     /**

--- a/src/Sentry/Laravel/Features/HttpClientIntegration.php
+++ b/src/Sentry/Laravel/Features/HttpClientIntegration.php
@@ -94,13 +94,13 @@ class HttpClientIntegration extends Feature
         $span = $this->maybePopSpan();
 
         if ($span !== null) {
-            $span->finish();
             $span->setData(array_merge($span->getData(), [
                 // See: https://develop.sentry.dev/sdk/performance/span-data-conventions/#http
                 'http.response.status_code' => $event->response->status(),
                 'http.response.body.size' => $event->response->toPsrResponse()->getBody()->getSize(),
             ]));
             $span->setHttpStatus($event->response->status());
+            $span->finish();
         }
     }
 
@@ -109,8 +109,8 @@ class HttpClientIntegration extends Feature
         $span = $this->maybePopSpan();
 
         if ($span !== null) {
-            $span->finish();
             $span->setStatus(SpanStatus::internalError());
+            $span->finish();
         }
     }
 

--- a/src/Sentry/Laravel/Features/QueueIntegration.php
+++ b/src/Sentry/Laravel/Features/QueueIntegration.php
@@ -16,6 +16,7 @@ use Sentry\State\Scope;
 use Sentry\Tracing\PropagationContext;
 use Sentry\Tracing\SpanContext;
 use Sentry\Tracing\SpanStatus;
+use Sentry\Tracing\Transaction;
 use Sentry\Tracing\TransactionContext;
 use Sentry\Tracing\TransactionSource;
 
@@ -169,8 +170,20 @@ class QueueIntegration extends Feature
         $span = $this->maybePopSpan();
 
         if ($span !== null) {
-            $span->finish();
+            $hub = SentrySdk::getCurrentHub();
+
+            $currentSpan = $hub->getSpan();
+
+            if ($span instanceof Transaction) {
+                $hub->setSpan($span);
+            }
+
             $span->setStatus($status);
+            $span->finish();
+
+            if ($span instanceof Transaction) {
+                $hub->setSpan($currentSpan);
+            }
         }
     }
 

--- a/src/Sentry/Laravel/Features/QueueIntegration.php
+++ b/src/Sentry/Laravel/Features/QueueIntegration.php
@@ -169,8 +169,8 @@ class QueueIntegration extends Feature
         $span = $this->maybePopSpan();
 
         if ($span !== null) {
-            $span->finish();
             $span->setStatus($status);
+            $span->finish();
         }
     }
 

--- a/src/Sentry/Laravel/Features/QueueIntegration.php
+++ b/src/Sentry/Laravel/Features/QueueIntegration.php
@@ -16,7 +16,6 @@ use Sentry\State\Scope;
 use Sentry\Tracing\PropagationContext;
 use Sentry\Tracing\SpanContext;
 use Sentry\Tracing\SpanStatus;
-use Sentry\Tracing\Transaction;
 use Sentry\Tracing\TransactionContext;
 use Sentry\Tracing\TransactionSource;
 
@@ -170,20 +169,8 @@ class QueueIntegration extends Feature
         $span = $this->maybePopSpan();
 
         if ($span !== null) {
-            $hub = SentrySdk::getCurrentHub();
-
-            $currentSpan = $hub->getSpan();
-
-            if ($span instanceof Transaction) {
-                $hub->setSpan($span);
-            }
-
-            $span->setStatus($status);
             $span->finish();
-
-            if ($span instanceof Transaction) {
-                $hub->setSpan($currentSpan);
-            }
+            $span->setStatus($status);
         }
     }
 

--- a/src/Sentry/Laravel/Tracing/EventHandler.php
+++ b/src/Sentry/Laravel/Tracing/EventHandler.php
@@ -266,8 +266,8 @@ class EventHandler
         $span = $this->popSpan();
 
         if ($span !== null) {
-            $span->finish();
             $span->setStatus(SpanStatus::ok());
+            $span->finish();
         }
     }
 
@@ -276,8 +276,8 @@ class EventHandler
         $span = $this->popSpan();
 
         if ($span !== null) {
-            $span->finish();
             $span->setStatus(SpanStatus::internalError());
+            $span->finish();
         }
     }
 

--- a/test/Sentry/Features/HttpClientIntegrationTest.php
+++ b/test/Sentry/Features/HttpClientIntegrationTest.php
@@ -5,6 +5,7 @@ namespace Sentry\Laravel\Tests\Features;
 use GuzzleHttp\Psr7\Request as PsrRequest;
 use GuzzleHttp\Psr7\Response as PsrResponse;
 use Illuminate\Http\Client\Events\ResponseReceived;
+use Illuminate\Http\Client\Factory;
 use Illuminate\Http\Client\Request;
 use Illuminate\Http\Client\Response;
 use Illuminate\Support\Facades\Http;
@@ -128,7 +129,7 @@ class HttpClientIntegrationTest extends TestCase
 
     public function testHttpClientRequestTracingHeadersAreAttached(): void
     {
-        if (!method_exists(Http::class, 'globalRequestMiddleware')) {
+        if (!method_exists(Factory::class, 'globalRequestMiddleware')) {
             $this->markTestSkipped('The `globalRequestMiddleware` functionality we rely on was introduced in Laravel 10.14');
         }
 

--- a/test/Sentry/Features/QueueIntegrationTest.php
+++ b/test/Sentry/Features/QueueIntegrationTest.php
@@ -9,7 +9,7 @@ use Sentry\Laravel\Tests\TestCase;
 use function Sentry\addBreadcrumb;
 use function Sentry\captureException;
 
-class QueueEventsTest extends TestCase
+class QueueIntegrationTest extends TestCase
 {
     public function testQueueJobPushesAndPopsScopeWithBreadcrumbs(): void
     {

--- a/test/Sentry/Features/QueueIntegrationTest.php
+++ b/test/Sentry/Features/QueueIntegrationTest.php
@@ -123,6 +123,10 @@ class QueueIntegrationTest extends TestCase
 
         $this->assertEquals(EventType::transaction(), $transaction->getType());
         $this->assertEquals(QueueEventsTestJob::class, $transaction->getTransaction());
+
+        $traceContext = $transaction->getContexts()['trace'];
+
+        $this->assertEquals('queue.process', $traceContext['op']);
     }
 }
 
@@ -130,7 +134,6 @@ class QueueEventsTestJob implements ShouldQueue
 {
     public function handle(): void
     {
-        queueEventsTestAddTestBreadcrumb();
     }
 }
 


### PR DESCRIPTION
Fixes the following:

- Moves the queue tests to a more logical place, and adds tests for the queue job tracing feature flag
- Fixes bug where feature tests are incorrectly memoized in the feature class (this goes for all feature classes, not just the queue although it was only noticeable there since it had multiple options of the same category)
- ~~Fixes `trace` context being lost for `queue.process` transactions because the context was overwritten by the default context because there was no active span in the scope which is required for the correct context being added to the transaction event~~ (fixed in PHP SDK instead)

Especially the last point is important, this fixes data to get lost for queue job transactions, the before: 

![image](https://github.com/getsentry/sentry-laravel/assets/1090754/b213ba51-eedf-44d0-9838-ecbf89063bad)

and after the change:

![image](https://github.com/getsentry/sentry-laravel/assets/1090754/cc010de8-ea18-4049-a99b-eee177d3525f)

this also fixes the missing operation name in the performance dashboard (top one old, bottom one new) and missing data on the transaction itself (the queue job name and attempts and such):

![image](https://github.com/getsentry/sentry-laravel/assets/1090754/0b829374-42b0-4c20-a93f-c06e85e05248)