### PR TITLE
Allow newer version of PSR HTTP message bridge

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "php": "^7.2 | ^8.0",
         "illuminate/support": "^6.0 | ^7.0 | ^8.0 | ^9.0 | ^10.0",
         "sentry/sentry": "^4.0",
-        "symfony/psr-http-message-bridge": "^1.0 | ^2.0",
+        "symfony/psr-http-message-bridge": "^1.0 | ^2.0 | ^6.0 | ^7.0",
         "nyholm/psr7": "^1.0"
     },
     "autoload": {

--- a/test/Sentry/Http/LaravelRequestFetcherTest.php
+++ b/test/Sentry/Http/LaravelRequestFetcherTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Sentry\Http;
+
+use Nyholm\Psr7\ServerRequest;
+use Sentry\Laravel\Http\LaravelRequestFetcher;
+use Sentry\Laravel\Tests\TestCase;
+
+class LaravelRequestFetcherTest extends TestCase
+{
+    protected function defineRoutes($router): void
+    {
+        $router->get('/', function () {
+            return 'Hello!';
+        });
+    }
+
+    public function testPsr7InstanceCanBeResolved(): void
+    {
+        // The request is only set on the container if we made a request (it is resolved by the SetRequestMiddleware)
+        $this->get('/');
+
+        $instance = $this->app->make(LaravelRequestFetcher::CONTAINER_PSR7_INSTANCE_KEY);
+
+        $this->assertInstanceOf(ServerRequest::class, $instance);
+    }
+}


### PR DESCRIPTION
Nothing changes in the package, and we include it to allow Laravel to use it. So we should also keep it up-to-date. Also added a test that it actually works (remove the `symfony/psr-http-message-bridge` dep and the test breaks).