### PR TITLE
Add support for W3C traceparent header

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     "require": {
         "php": "^7.2 | ^8.0",
         "illuminate/support": "^6.0 | ^7.0 | ^8.0 | ^9.0 | ^10.0",
-        "sentry/sentry": "^4.3",
+        "sentry/sentry": "^4.4",
         "symfony/psr-http-message-bridge": "^1.0 | ^2.0 | ^6.0 | ^7.0",
         "nyholm/psr7": "^1.0"
     },

--- a/src/Sentry/Laravel/Features/HttpClientIntegration.php
+++ b/src/Sentry/Laravel/Features/HttpClientIntegration.php
@@ -18,6 +18,7 @@ use Sentry\Tracing\SpanContext;
 use Sentry\Tracing\SpanStatus;
 use function Sentry\getBaggage;
 use function Sentry\getTraceparent;
+use function Sentry\getW3CTraceparent;
 
 class HttpClientIntegration extends Feature
 {
@@ -55,7 +56,8 @@ class HttpClientIntegration extends Feature
         if ($this->shouldAttachTracingHeaders($request)) {
             return $request
                 ->withHeader('baggage', getBaggage())
-                ->withHeader('sentry-trace', getTraceparent());
+                ->withHeader('sentry-trace', getTraceparent())
+                ->withHeader('traceparent', getW3CTraceparent());
         }
 
         return $request;

--- a/src/Sentry/Laravel/Integration.php
+++ b/src/Sentry/Laravel/Integration.php
@@ -22,6 +22,7 @@ use function Sentry\addBreadcrumb;
 use function Sentry\configureScope;
 use function Sentry\getBaggage;
 use function Sentry\getTraceparent;
+use function Sentry\getW3CTraceparent;
 
 class Integration implements IntegrationInterface
 {
@@ -168,7 +169,7 @@ class Integration implements IntegrationInterface
      */
     public static function sentryMeta(): string
     {
-        return self::sentryTracingMeta() . self::sentryBaggageMeta();
+        return self::sentryTracingMeta() . self::sentryW3CTracingMeta() . self::sentryBaggageMeta();
     }
 
     /**
@@ -179,6 +180,16 @@ class Integration implements IntegrationInterface
     public static function sentryTracingMeta(): string
     {
         return sprintf('<meta name="sentry-trace" content="%s"/>', getTraceparent());
+    }
+
+    /**
+     * Retrieve the `traceparent` meta tag with tracing information to link this request to front-end requests.
+     *
+     * @return string
+     */
+    public static function sentryW3CTracingMeta(): string
+    {
+        return sprintf('<meta name="traceparent" content="%s"/>', getW3CTraceparent());
     }
 
     /**

--- a/src/Sentry/Laravel/Tracing/Middleware.php
+++ b/src/Sentry/Laravel/Tracing/Middleware.php
@@ -175,7 +175,7 @@ class Middleware
         );
 
         $context = continueTrace(
-            $request->header('sentry-trace', ''),
+            $request->header('sentry-trace') ?? $request->header('traceparent', ''),
             $request->header('baggage', '')
         );
 


### PR DESCRIPTION
Requires https://github.com/getsentry/sentry-php/pull/1680 to be released first.