### PR TITLE
Flush metrics when events are being flushed and after each request

### DIFF
--- a/src/Sentry/Laravel/Http/FlushEventsMiddleware.php
+++ b/src/Sentry/Laravel/Http/FlushEventsMiddleware.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Sentry\Laravel\Http;
+
+use Closure;
+use Illuminate\Http\Request;
+use Sentry\Laravel\Integration;
+
+class FlushEventsMiddleware
+{
+    public function handle(Request $request, Closure $next)
+    {
+        return $next($request);
+    }
+
+    public function terminate(Request $request, $response): void
+    {
+        Integration::flushEvents();
+    }
+}

--- a/src/Sentry/Laravel/Integration.php
+++ b/src/Sentry/Laravel/Integration.php
@@ -23,6 +23,7 @@ use function Sentry\configureScope;
 use function Sentry\getBaggage;
 use function Sentry\getTraceparent;
 use function Sentry\getW3CTraceparent;
+use function Sentry\metrics;
 
 class Integration implements IntegrationInterface
 {
@@ -100,7 +101,7 @@ class Integration implements IntegrationInterface
     }
 
     /**
-     * Block until all async events are processed for the HTTP transport.
+     * Block until all events are processed by the PHP SDK client. Also flushes metrics.
      *
      * @internal This is not part of the public API and is here temporarily until
      *  the underlying issue can be resolved, this method will be removed.
@@ -112,6 +113,8 @@ class Integration implements IntegrationInterface
         if ($client !== null) {
             $client->flush();
         }
+
+        metrics()->flush();
     }
 
     /**

--- a/src/Sentry/Laravel/ServiceProvider.php
+++ b/src/Sentry/Laravel/ServiceProvider.php
@@ -19,6 +19,7 @@ use Sentry\Laravel\Console\AboutCommandIntegration;
 use Sentry\Laravel\Console\PublishCommand;
 use Sentry\Laravel\Console\TestCommand;
 use Sentry\Laravel\Features\Feature;
+use Sentry\Laravel\Http\FlushEventsMiddleware;
 use Sentry\Laravel\Http\LaravelRequestFetcher;
 use Sentry\Laravel\Http\SetRequestIpMiddleware;
 use Sentry\Laravel\Http\SetRequestMiddleware;
@@ -78,12 +79,14 @@ class ServiceProvider extends BaseServiceProvider
             if ($this->app instanceof Lumen) {
                 $this->app->middleware(SetRequestMiddleware::class);
                 $this->app->middleware(SetRequestIpMiddleware::class);
+                $this->app->middleware(FlushEventsMiddleware::class);
             } elseif ($this->app->bound(HttpKernelInterface::class)) {
                 $httpKernel = $this->app->make(HttpKernelInterface::class);
 
                 if ($httpKernel instanceof HttpKernel) {
                     $httpKernel->pushMiddleware(SetRequestMiddleware::class);
                     $httpKernel->pushMiddleware(SetRequestIpMiddleware::class);
+                    $httpKernel->pushMiddleware(FlushEventsMiddleware::class);
                 }
             }
         }


### PR DESCRIPTION
Adds a metrics flush to the current events flush (not renamed the because technically BC break, and don't see a need to cause pain when we don't have to even thought it's an internal method).

In addition this adds a terminable middleware flushing events after every request (after the response was sent).