### PR TITLE
Add support for Laravel 11

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -66,7 +66,7 @@ jobs:
           composer install --no-interaction --prefer-dist --no-progress
 
       - name: Run phpunit
-        run: vendor/bin/phpunit --coverage-clover=coverage.xml
+        run: vendor/bin/phpunit --coverage-clover=coverage.xml --coverage-filter=src/Sentry
 
       - name: Upload code coverage
         uses: codecov/codecov-action@v3
@@ -156,7 +156,7 @@ jobs:
           composer install --no-interaction --prefer-dist --no-progress
 
       - name: Run phpunit
-        run: vendor/bin/phpunit --coverage-clover=coverage.xml
+        run: vendor/bin/phpunit --coverage-clover=coverage.xml --coverage-filter=src/Sentry
 
       - name: Upload code coverage
         uses: codecov/codecov-action@v3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,6 +30,12 @@ jobs:
           # All versions below only support PHP ^8.1 (Laravel requirement)
           - { laravel: ^10.0,  testbench: ^8.0, phpunit: 9.6.* }
 
+          # All versions below only support PHP ^8.2 (Laravel requirement)
+          - { laravel: ^11.0,  testbench: ^9.0, phpunit: 10.5.* }
+        exclude:
+          - php: "8.1"
+            packages: { laravel: ^11.0,  testbench: ^9.0, phpunit: 10.5.* }
+
     name: phpunit (PHP:${{ matrix.php }}, Laravel:${{ matrix.packages.laravel }})
 
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -156,7 +156,7 @@ jobs:
           composer install --no-interaction --prefer-dist --no-progress
 
       - name: Run phpunit
-        run: vendor/bin/phpunit --coverage-clover=coverage.xml --coverage-filter=src/Sentry
+        run: vendor/bin/phpunit --coverage-clover=coverage.xml --whitelist=src/Sentry
 
       - name: Upload code coverage
         uses: codecov/codecov-action@v3

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ return Application::configure(basePath: dirname(__DIR__))
         //
     })
     ->withExceptions(function (Exceptions $exceptions) {
-        \Sentry\Laravel\Integration::handles($exceptions);
+        Integration::handles($exceptions);
     })->create();
 ```
 

--- a/README.md
+++ b/README.md
@@ -19,11 +19,12 @@ This is the official Laravel SDK for [Sentry](https://sentry.io).
 
 ## Getting Started
 
-The installation steps below work on versions 8.x, 9.x and 10.x of the Laravel framework.
+The installation steps below work on version 11.x of the Laravel framework.
 
 For older Laravel versions and Lumen see:
 
-- [Laravel 8.x & 9.x & 10.x](https://docs.sentry.io/platforms/php/guides/laravel/)
+- [Laravel 11.x](https://docs.sentry.io/platforms/php/guides/laravel/)
+- [Laravel 8.x & 9.x & 10.x](https://docs.sentry.io/platforms/php/guides/other-versions/laravel8-10)
 - [Laravel 6.x & 7.x](https://docs.sentry.io/platforms/php/guides/laravel/other-versions/laravel6-7/)
 - [Laravel 5.x](https://docs.sentry.io/platforms/php/guides/laravel/other-versions/laravel5/)
 - [Laravel 4.x](https://docs.sentry.io/platforms/php/guides/laravel/other-versions/laravel4/)
@@ -37,17 +38,28 @@ Install the `sentry/sentry-laravel` package:
 composer require sentry/sentry-laravel
 ```
 
-Enable capturing unhandled exception to report to Sentry by making the following change to your `app/Exceptions/Handler.php`:
+Enable capturing unhandled exception to report to Sentry by making the following change to your `bootstrap/app.php`:
 
-```php {filename:app/Exceptions/Handler.php}
+```php {filename:bootstrap/app.php}
+<?php
+
+use Illuminate\Foundation\Application;
+use Illuminate\Foundation\Configuration\Exceptions;
+use Illuminate\Foundation\Configuration\Middleware;
 use Sentry\Laravel\Integration;
 
-public function register(): void
-{
-    $this->reportable(function (Throwable $e) {
-        Integration::captureUnhandledException($e);
-    });
-}
+return Application::configure(basePath: dirname(__DIR__))
+    ->withRouting(
+        web: __DIR__.'/../routes/web.php',
+        commands: __DIR__.'/../routes/console.php',
+        health: '/up',
+    )
+    ->withMiddleware(function (Middleware $middleware) {
+        //
+    })
+    ->withExceptions(function (Exceptions $exceptions) {
+        \Sentry\Laravel\Integration::handles($exceptions);
+    })->create();
 ```
 
 > Alternatively, you can configure Sentry as a [Laravel Log Channel](https://docs.sentry.io/platforms/php/guides/laravel/usage/#log-channels), allowing you to capture `info` and `debug` logs as well.
@@ -84,6 +96,7 @@ To learn more about how to use the SDK [refer to our docs](https://docs.sentry.i
 
 The Laravel and Lumen versions listed below are all currently supported:
 
+- Laravel `>= 11.x.x` on PHP `>= 8.2` is supported starting from `4.3.0`
 - Laravel `>= 10.x.x` on PHP `>= 8.1` is supported starting from `3.2.0`
 - Laravel `>= 9.x.x` on PHP `>= 8.0` is supported starting from `2.11.0`
 - Laravel `>= 8.x.x` on PHP `>= 7.3` is supported starting from `1.9.0`

--- a/composer.json
+++ b/composer.json
@@ -75,5 +75,6 @@
     "config": {
         "sort-packages": true
     },
-    "prefer-stable": true
+    "prefer-stable": true,
+    "minimum-stability": "dev"
 }

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     ],
     "require": {
         "php": "^7.2 | ^8.0",
-        "illuminate/support": "^6.0 | ^7.0 | ^8.0 | ^9.0 | ^10.0",
+        "illuminate/support": "^6.0 | ^7.0 | ^8.0 | ^9.0 | ^10.0 | ^11.0",
         "sentry/sentry": "^4.5",
         "symfony/psr-http-message-bridge": "^1.0 | ^2.0 | ^6.0 | ^7.0",
         "nyholm/psr7": "^1.0"
@@ -36,7 +36,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^8.4 | ^9.3 | ^10.4",
-        "laravel/framework": "^6.0 | ^7.0 | ^8.0 | ^9.0 | ^10.0",
+        "laravel/framework": "^6.0 | ^7.0 | ^8.0 | ^9.0 | ^10.0 | ^11.0",
         "livewire/livewire": "^2.0 | ^3.0",
         "orchestra/testbench": "^4.7 | ^5.1 | ^6.0 | ^7.0 | ^8.0",
         "friendsofphp/php-cs-fixer": "^3.11",

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         "phpunit/phpunit": "^8.4 | ^9.3 | ^10.4",
         "laravel/framework": "^6.0 | ^7.0 | ^8.0 | ^9.0 | ^10.0 | ^11.0",
         "livewire/livewire": "^2.0 | ^3.0",
-        "orchestra/testbench": "^4.7 | ^5.1 | ^6.0 | ^7.0 | ^8.0",
+        "orchestra/testbench": "^4.7 | ^5.1 | ^6.0 | ^7.0 | ^8.0 | ^9.0",
         "friendsofphp/php-cs-fixer": "^3.11",
         "mockery/mockery": "^1.3",
         "phpstan/phpstan": "^1.10",

--- a/composer.json
+++ b/composer.json
@@ -75,6 +75,5 @@
     "config": {
         "sort-packages": true
     },
-    "prefer-stable": true,
-    "minimum-stability": "dev"
+    "prefer-stable": true
 }

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
         "friendsofphp/php-cs-fixer": "^3.11",
         "mockery/mockery": "^1.3",
         "phpstan/phpstan": "^1.10",
-        "laravel/folio": "^1.0",
+        "laravel/folio": "^1.1",
         "guzzlehttp/guzzle": "^7.2"
     },
     "autoload-dev": {

--- a/config/sentry.php
+++ b/config/sentry.php
@@ -34,7 +34,7 @@ return [
 
     // @see: https://docs.sentry.io/platforms/php/guides/laravel/configuration/options/#ignore-transactions
     'ignore_transactions' => [
-        // Ignore Laravel's health URL
+        // Ignore Laravel's default health URL
         '/up',
     ],
 

--- a/config/sentry.php
+++ b/config/sentry.php
@@ -33,7 +33,10 @@ return [
     // 'ignore_exceptions' => [],
 
     // @see: https://docs.sentry.io/platforms/php/guides/laravel/configuration/options/#ignore-transactions
-    // 'ignore_transactions' => [],
+    'ignore_transactions' => [
+        // Ignore Laravel's health URL
+        '/up',
+    ],
 
     // Breadcrumb specific configuration
     'breadcrumbs' => [

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -101,6 +101,11 @@ parameters:
 			path: src/Sentry/Laravel/Features/Storage/Integration.php
 
 		-
+			message: "#^Parameter \\$exceptions of method Sentry\\\\Laravel\\\\Integration\\:\\:handles\\(\\) has invalid type Illuminate\\\\Foundation\\\\Configuration\\\\Exceptions\\.$#"
+			count: 1
+			path: src/Sentry/Laravel/Integration.php
+
+		-
 			message: "#^Class Laravel\\\\Lumen\\\\Application not found\\.$#"
 			count: 3
 			path: src/Sentry/Laravel/ServiceProvider.php

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -12,16 +12,4 @@
             <directory>./test/Sentry/</directory>
         </testsuite>
     </testsuites>
-
-    <coverage>
-        <include>
-            <directory suffix=".php">./src/Sentry/</directory>
-        </include>
-    </coverage>
-
-    <filter>
-        <whitelist>
-            <directory suffix=".php">src</directory>
-        </whitelist>
-    </filter>
 </phpunit>

--- a/src/Sentry/Laravel/Integration.php
+++ b/src/Sentry/Laravel/Integration.php
@@ -54,7 +54,7 @@ class Integration implements IntegrationInterface
     }
 
     /**
-     * Convienence method to register the exception handler with Laravel 11+.
+     * Convienence method to register the exception handler with Laravel 11.0 and up.
      */
     public static function handles(Exceptions $exceptions): void
     {

--- a/src/Sentry/Laravel/Integration.php
+++ b/src/Sentry/Laravel/Integration.php
@@ -4,6 +4,7 @@ namespace Sentry\Laravel;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\LazyLoadingViolationException;
+use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Routing\Route;
 use Sentry\EventHint;
 use Sentry\EventId;
@@ -49,6 +50,16 @@ class Integration implements IntegrationInterface
             }
 
             return $event;
+        });
+    }
+
+    /**
+     * Convienence method to register the exception handler with Laravel 11+.
+     */
+    public static function handles(Exceptions $exceptions): void
+    {
+        $exceptions->reportable(static function (Throwable $exception) {
+            self::captureUnhandledException($exception);
         });
     }
 


### PR DESCRIPTION
New setup instructions:

`bootstrap/app.php`

```php
<?php

use Sentry\Laravel\Integration;

return Application::configure(basePath: dirname(__DIR__))
    ...
    ->withExceptions(function (Exceptions $exceptions) {
        Integration::handles($exceptions);
    })
    ->create();
```

- [x] Update https://docs.sentry.io/platforms/php/guides/laravel/ https://github.com/getsentry/sentry-docs/pull/9361
- [x] Update https://sentry.io/for/laravel/ https://github.com/getsentry/static-sites/pull/2363
- [x] Update https://sentry.io/welcome https://github.com/getsentry/static-sites/pull/2363
- [x] Ignore new health check (`/up`) by default?
- [x] Update onboarding https://github.com/getsentry/sentry/pull/66574
- [x] Update https://docs.sentry.io/platforms/php/guides/laravel/usage/#log-channels https://github.com/getsentry/sentry-docs/pull/9361