### PR TITLE
First class callable helper for integrating Sentry with Laravel 11

### DIFF
--- a/src/Sentry/Laravel/Integration.php
+++ b/src/Sentry/Laravel/Integration.php
@@ -59,7 +59,7 @@ class Integration implements IntegrationInterface
     public static function handles(Exceptions $exceptions): void
     {
         $exceptions->reportable(static function (Throwable $exception) {
-            self::captureUnhandledException($throwable);
+            self::captureUnhandledException($exception);
         });
     }
 

--- a/src/Sentry/Laravel/Integration.php
+++ b/src/Sentry/Laravel/Integration.php
@@ -58,7 +58,7 @@ class Integration implements IntegrationInterface
      */
     public static function handles(Exceptions $exceptions): void
     {
-        $exceptions->reportable(static function (Throwable $throwable) {
+        $exceptions->reportable(static function (Throwable $exception) {
             self::captureUnhandledException($throwable);
         });
     }

--- a/src/Sentry/Laravel/Integration.php
+++ b/src/Sentry/Laravel/Integration.php
@@ -4,6 +4,7 @@ namespace Sentry\Laravel;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\LazyLoadingViolationException;
+use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Routing\Route;
 use Sentry\EventHint;
 use Sentry\EventId;
@@ -49,6 +50,16 @@ class Integration implements IntegrationInterface
             }
 
             return $event;
+        });
+    }
+
+    /**
+     * Convienence method to register the exception handler with Laravel 11+.
+     */
+    public static function handles(Exceptions $exceptions): void
+    {
+        $exceptions->reportable(static function (Throwable $throwable) {
+            self::captureUnhandledException($throwable);
         });
     }
 


### PR DESCRIPTION
Using: https://www.php.net/manual/en/functions.first_class_callable_syntax.php new in 8.1+ which we can recommend to use because Laravel 11 is PHP 8.1+ 🥳 

**Not tested yet!**