### PR TITLE
Remove `"minimum-stability": "dev"`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -75,6 +75,5 @@
     "config": {
         "sort-packages": true
     },
-    "prefer-stable": true,
-    "minimum-stability": "dev"
+    "prefer-stable": true
 }


### PR DESCRIPTION
[`orchestral/testbench` version 9.0](https://github.com/orchestral/testbench/releases/tag/v9.0.0) is now released, we can remove `minimum-stability` again.

