### PR TITLE
Add current Laravel context to event

### DIFF
--- a/src/Sentry/Laravel/Integration/LaravelContextIntegration.php
+++ b/src/Sentry/Laravel/Integration/LaravelContextIntegration.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Sentry\Laravel\Integration;
+
+use Illuminate\Support\Facades\Context;
+use Sentry\Event;
+use Sentry\EventHint;
+use Sentry\EventType;
+use Sentry\Integration\IntegrationInterface;
+use Sentry\SentrySdk;
+use Sentry\State\Scope;
+
+class LaravelContextIntegration implements IntegrationInterface
+{
+    public function setupOnce(): void
+    {
+        // Context was introduced in Laravel 11 so we need to check if we can use it otherwise we skip the event processor
+        if (!class_exists(Context::class)) {
+            return;
+        }
+
+        Scope::addGlobalEventProcessor(static function (Event $event, ?EventHint $hint = null): Event {
+            $self = SentrySdk::getCurrentHub()->getIntegration(self::class);
+
+            if (!$self instanceof self) {
+                return $event;
+            }
+
+            if (!in_array($event->getType(), [EventType::event(), EventType::transaction()], true)) {
+                return $event;
+            }
+
+            if (!Context::isEmpty()) {
+                $event->setContext('laravel', Context::all());
+            }
+
+            return $event;
+        });
+    }
+}

--- a/src/Sentry/Laravel/Integration/LaravelContextIntegration.php
+++ b/src/Sentry/Laravel/Integration/LaravelContextIntegration.php
@@ -30,9 +30,7 @@ class LaravelContextIntegration implements IntegrationInterface
                 return $event;
             }
 
-            if (!Context::isEmpty()) {
-                $event->setContext('laravel', Context::all());
-            }
+            $event->setContext('laravel', Context::all());
 
             return $event;
         });

--- a/src/Sentry/Laravel/ServiceProvider.php
+++ b/src/Sentry/Laravel/ServiceProvider.php
@@ -337,6 +337,7 @@ class ServiceProvider extends BaseServiceProvider
                     $integrations,
                     [
                         new Integration,
+                        new Integration\LaravelContextIntegration,
                         new Integration\ExceptionContextIntegration,
                     ],
                     $userIntegrations

--- a/test/Sentry/Integration/LaravelContextIntegrationTest.php
+++ b/test/Sentry/Integration/LaravelContextIntegrationTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Sentry\Integration;
+
+use Exception;
+use Illuminate\Support\Facades\Context;
+use Sentry\EventType;
+use Sentry\Laravel\Integration\LaravelContextIntegration;
+use Sentry\Laravel\Tests\TestCase;
+use function Sentry\captureException;
+
+class LaravelContextIntegrationTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        if (!class_exists(Context::class)) {
+            $this->markTestSkipped('Laravel introduced contexts in version 11.');
+        }
+
+        parent::setUp();
+    }
+
+    public function testLaravelContextIntegrationIsRegistered(): void
+    {
+        $integration = $this->getSentryHubFromContainer()->getIntegration(LaravelContextIntegration::class);
+
+        $this->assertInstanceOf(LaravelContextIntegration::class, $integration);
+    }
+
+    public function testExceptionIsCapturedWithLaravelContext(): void
+    {
+        $this->setupTestContext();
+
+        captureException(new Exception('Context test'));
+
+        $event = $this->getLastSentryEvent();
+
+        $this->assertNotNull($event);
+        $this->assertEquals($event->getType(), EventType::event());
+        $this->assertContextIsCaptured($event->getContexts());
+    }
+
+    public function testTransactionIsCapturedWithLaravelContext(): void
+    {
+        $this->setupTestContext();
+
+        $transaction = $this->startTransaction();
+        $transaction->setSampled(true);
+        $transaction->finish();
+
+        $event = $this->getLastSentryEvent();
+
+        $this->assertNotNull($event);
+        $this->assertEquals($event->getType(), EventType::transaction());
+        $this->assertContextIsCaptured($event->getContexts());
+    }
+
+    private function setupTestContext(): void
+    {
+        Context::flush();
+        Context::add('foo', 'bar');
+        Context::addHidden('hidden', 'value');
+    }
+
+    private function assertContextIsCaptured(array $context): void
+    {
+        $this->assertArrayHasKey('laravel', $context);
+        $this->assertArrayHasKey('foo', $context['laravel']);
+        $this->assertArrayNotHasKey('hidden', $context['laravel']);
+        $this->assertEquals('bar', $context['laravel']['foo']);
+    }
+}

--- a/test/Sentry/Integration/LaravelContextIntegrationTest.php
+++ b/test/Sentry/Integration/LaravelContextIntegrationTest.php
@@ -40,6 +40,30 @@ class LaravelContextIntegrationTest extends TestCase
         $this->assertContextIsCaptured($event->getContexts());
     }
 
+    public function testExceptionIsCapturedWithoutLaravelContextIfEmpty(): void
+    {
+        captureException(new Exception('Context test'));
+
+        $event = $this->getLastSentryEvent();
+
+        $this->assertNotNull($event);
+        $this->assertEquals($event->getType(), EventType::event());
+        $this->assertArrayNotHasKey('laravel', $event->getContexts());
+    }
+
+    public function testExceptionIsCapturedWithoutLaravelContextIfOnlyHidden(): void
+    {
+        Context::addHidden('hidden', 'value');
+
+        captureException(new Exception('Context test'));
+
+        $event = $this->getLastSentryEvent();
+
+        $this->assertNotNull($event);
+        $this->assertEquals($event->getType(), EventType::event());
+        $this->assertArrayNotHasKey('laravel', $event->getContexts());
+    }
+
     public function testTransactionIsCapturedWithLaravelContext(): void
     {
         $this->setupTestContext();


### PR DESCRIPTION
Laravel introduces [context](https://laravel.com/docs/11.x/context) which is similar to how our scopes work, this introduces a new integration that adds (if present) the current context to the event/transaction data so they become visible in Sentry.

This can look something like this in the Sentry UI:

![afbeelding](https://github.com/getsentry/sentry-laravel/assets/1090754/a81d3acb-28b2-49cc-acca-b5edff6798aa)

Fixes #862.