### PR TITLE
Fix filesystem `assertExists`/`assertMissing` not handling array as path argument

### DIFF
--- a/src/Sentry/Laravel/Features/Storage/FilesystemAdapterDecorator.php
+++ b/src/Sentry/Laravel/Features/Storage/FilesystemAdapterDecorator.php
@@ -8,12 +8,16 @@ trait FilesystemAdapterDecorator
 
     public function assertExists($path, $content = null)
     {
-        return $this->withSentry(__FUNCTION__, func_get_args(), $path, compact('path'));
+        [$description, $data] = $this->getDescriptionAndDataForPathOrPaths($path);
+
+        return $this->withSentry(__FUNCTION__, func_get_args(), $description, $data);
     }
 
     public function assertMissing($path)
     {
-        return $this->withSentry(__FUNCTION__, func_get_args(), $path, compact('path'));
+        [$description, $data] = $this->getDescriptionAndDataForPathOrPaths($path);
+
+        return $this->withSentry(__FUNCTION__, func_get_args(), $description, $data);
     }
 
     public function assertDirectoryEmpty($path)

--- a/src/Sentry/Laravel/Features/Storage/FilesystemDecorator.php
+++ b/src/Sentry/Laravel/Features/Storage/FilesystemDecorator.php
@@ -135,13 +135,7 @@ trait FilesystemDecorator
 
     public function delete($paths)
     {
-        if (is_array($paths)) {
-            $data = compact('paths');
-            $description = sprintf('%s paths', count($paths));
-        } else {
-            $data = ['path' => $paths];
-            $description = $paths;
-        }
+        [$description, $data] = $this->getDescriptionAndDataForPathOrPaths($paths);
 
         return $this->withSentry(__FUNCTION__, func_get_args(), $description, $data);
     }
@@ -199,5 +193,18 @@ trait FilesystemDecorator
     public function __call($name, $arguments)
     {
         return $this->filesystem->{$name}(...$arguments);
+    }
+
+    protected function getDescriptionAndDataForPathOrPaths($pathOrPaths): array
+    {
+        if (is_array($pathOrPaths)) {
+            $description = sprintf('%s paths', count($pathOrPaths));
+            $data = ['paths' => $pathOrPaths];
+        } else {
+            $description = $pathOrPaths;
+            $data = ['path' => $pathOrPaths];
+        }
+
+        return [$description, $data];
     }
 }

--- a/test/Sentry/Features/StorageIntegrationTest.php
+++ b/test/Sentry/Features/StorageIntegrationTest.php
@@ -22,6 +22,7 @@ class StorageIntegrationTest extends TestCase
         Storage::delete('foo');
         Storage::delete(['foo', 'bar']);
         Storage::files();
+        Storage::assertMissing(['foo', 'bar']);
 
         $spans = $transaction->getSpanRecorder()->getSpans();
 
@@ -61,6 +62,12 @@ class StorageIntegrationTest extends TestCase
         $this->assertSame('file.files', $span->getOp());
         $this->assertNull($span->getDescription());
         $this->assertSame(['directory' => null, 'recursive' => false, 'disk' => 'local', 'driver' => 'local'], $span->getData());
+
+        $this->assertArrayHasKey(7, $spans);
+        $span = $spans[7];
+        $this->assertSame('file.assertMissing', $span->getOp());
+        $this->assertSame('2 paths', $span->getDescription());
+        $this->assertSame(['paths' => ['foo', 'bar'], 'disk' => 'local', 'driver' => 'local'], $span->getData());
     }
 
     public function testDoesntCreateSpansWhenDisabled(): void


### PR DESCRIPTION
Fixes #876.

I also checked the interfaces again and it looks like these are the only 2 we are not handling correctly.