### PR TITLE
LighthouseIntegration: Fix finding the operation definition node on the query

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -136,6 +136,11 @@ parameters:
 			path: src/Sentry/Laravel/Tracing/Integrations/LighthouseIntegration.php
 
 		-
+			message: "#^Method Sentry\\\\Laravel\\\\Tracing\\\\Integrations\\\\LighthouseIntegration\\:\\:extractOperationDefinitionNode\\(\\) has invalid return type GraphQL\\\\Language\\\\AST\\\\OperationDefinitionNode\\.$#"
+			count: 1
+			path: src/Sentry/Laravel/Tracing/Integrations/LighthouseIntegration.php
+
+		-
 			message: "#^Parameter \\$endExecution of method Sentry\\\\Laravel\\\\Tracing\\\\Integrations\\\\LighthouseIntegration\\:\\:handleEndExecution\\(\\) has invalid type Nuwave\\\\Lighthouse\\\\Events\\\\EndExecution\\.$#"
 			count: 1
 			path: src/Sentry/Laravel/Tracing/Integrations/LighthouseIntegration.php
@@ -147,6 +152,11 @@ parameters:
 
 		-
 			message: "#^Parameter \\$operation of method Sentry\\\\Laravel\\\\Tracing\\\\Integrations\\\\LighthouseIntegration\\:\\:extractOperationNames\\(\\) has invalid type GraphQL\\\\Language\\\\AST\\\\OperationDefinitionNode\\.$#"
+			count: 1
+			path: src/Sentry/Laravel/Tracing/Integrations/LighthouseIntegration.php
+
+		-
+			message: "#^Parameter \\$query of method Sentry\\\\Laravel\\\\Tracing\\\\Integrations\\\\LighthouseIntegration\\:\\:extractOperationDefinitionNode\\(\\) has invalid type GraphQL\\\\Language\\\\AST\\\\DocumentNode\\.$#"
 			count: 1
 			path: src/Sentry/Laravel/Tracing/Integrations/LighthouseIntegration.php
 

--- a/src/Sentry/Laravel/Tracing/Integrations/LighthouseIntegration.php
+++ b/src/Sentry/Laravel/Tracing/Integrations/LighthouseIntegration.php
@@ -125,10 +125,9 @@ class LighthouseIntegration implements IntegrationInterface
             return;
         }
 
-        /** @var \GraphQL\Language\AST\OperationDefinitionNode|null $operationDefinition */
-        $operationDefinition = $startExecution->query->definitions[0] ?? null;
+        $operationDefinition = $this->extractOperationDefinitionNode($startExecution->query);
 
-        if (!$operationDefinition instanceof OperationDefinitionNode) {
+        if ($operationDefinition === null) {
             return;
         }
 
@@ -237,6 +236,17 @@ class LighthouseIntegration implements IntegrationInterface
         sort($selectionSet, SORT_STRING);
 
         return $selectionSet;
+    }
+
+    private function extractOperationDefinitionNode(DocumentNode $query): ?OperationDefinitionNode
+    {
+        foreach ($query->definitions as $definition) {
+            if ($definition instanceof OperationDefinitionNode) {
+                return $definition;
+            }
+        }
+
+        return null;
     }
 
     private function isApplicable(): bool


### PR DESCRIPTION
We assumed the operation definition node was the first node of the query, but when using fragments this isn't true and we need to look further to find it. This looks at all definitions in the query to find the operation definition.

Fixes #882