### PR TITLE
Fix username not being a string resulting in exception

### DIFF
--- a/src/Sentry/Laravel/EventHandler.php
+++ b/src/Sentry/Laravel/EventHandler.php
@@ -274,12 +274,14 @@ class EventHandler
 
         // If the user is a Laravel Eloquent model we try to extract some common fields from it
         if ($authUser instanceof Model) {
+            $username = $authUser->getAttribute('username');
+
             $userData = [
                 'id' => $authUser instanceof Authenticatable
                     ? $authUser->getAuthIdentifier()
                     : $authUser->getKey(),
                 'email' => $authUser->getAttribute('email') ?? $authUser->getAttribute('mail'),
-                'username' => $authUser->getAttribute('username'),
+                'username' => $username === null ? $username : (string)$username,
             ];
         }
 

--- a/test/Sentry/EventHandler/AuthEventsTest.php
+++ b/test/Sentry/EventHandler/AuthEventsTest.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Sentry\EventHandler;
+
+use Illuminate\Auth\Events\Authenticated;
+use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Database\Eloquent\Model;
+use Sentry\Laravel\Tests\TestCase;
+
+class AuthEventsTest extends TestCase
+{
+    protected $setupConfig = [
+        'sentry.send_default_pii' => true,
+    ];
+
+    public function testAuthenticatedEventFillsUserOnScope(): void
+    {
+        $user = new AuthEventsTestUserModel();
+
+        $user->id = 123;
+        $user->username = 'username';
+        $user->email = 'foo@example.com';
+
+        $scope = $this->getCurrentSentryScope();
+
+        $this->assertNull($scope->getUser());
+
+        $this->dispatchLaravelEvent(new Authenticated('test', $user));
+
+        $this->assertNotNull($scope->getUser());
+
+        $this->assertEquals($scope->getUser()->getId(), 123);
+        $this->assertEquals($scope->getUser()->getUsername(), 'username');
+        $this->assertEquals($scope->getUser()->getEmail(), 'foo@example.com');
+    }
+
+    public function testAuthenticatedEventFillsUserOnScopeWhenUsernameIsNotAString(): void
+    {
+        $user = new AuthEventsTestUserModel();
+
+        $user->id = 123;
+        $user->username = 456;
+
+        $scope = $this->getCurrentSentryScope();
+
+        $this->assertNull($scope->getUser());
+
+        $this->dispatchLaravelEvent(new Authenticated('test', $user));
+
+        $this->assertNotNull($scope->getUser());
+
+        $this->assertEquals($scope->getUser()->getId(), 123);
+        $this->assertEquals($scope->getUser()->getUsername(), '456');
+    }
+
+    public function testAuthenticatedEventDoesNotFillUserOnScopeWhenPIIShouldNotBeSent(): void
+    {
+        $this->resetApplicationWithConfig([
+            'sentry.send_default_pii' => false,
+        ]);
+
+        $user = new AuthEventsTestUserModel();
+
+        $user->id = 123;
+
+        $scope = $this->getCurrentSentryScope();
+
+        $this->assertNull($scope->getUser());
+
+        $this->dispatchLaravelEvent(new Authenticated('test', $user));
+
+        $this->assertNull($scope->getUser());
+    }
+}
+
+class AuthEventsTestUserModel extends Model implements Authenticatable
+{
+    use \Illuminate\Auth\Authenticatable;
+}


### PR DESCRIPTION
This fixes:

> Sentry\UserDataBag::setUsername(): Argument #1 ($username) must be of type ?string, int given, called in /vendor/sentry/sentry/src/UserDataBag.php on line 104

Bit of a weird edge case where the username is not a string... but we should cover it!

Also added a few tests for this feature now.