### PR TITLE
Spotlight improvements

### DIFF
--- a/config/sentry.php
+++ b/config/sentry.php
@@ -11,7 +11,7 @@ return [
     'dsn' => env('SENTRY_LARAVEL_DSN', env('SENTRY_DSN')),
 
     // @see https://spotlightjs.com/
-    'spotlight' => env('SENTRY_SPOTLIGHT', false),
+    // 'spotlight' => env('SENTRY_SPOTLIGHT', false),
 
     // @see: https://docs.sentry.io/platforms/php/guides/laravel/configuration/options/#logger
     // 'logger' => Sentry\Logger\DebugFileLogger::class, // By default this will log to `storage_path('logs/sentry.log')`

--- a/config/sentry.php
+++ b/config/sentry.php
@@ -10,6 +10,9 @@ return [
     // @see https://docs.sentry.io/product/sentry-basics/dsn-explainer/
     'dsn' => env('SENTRY_LARAVEL_DSN', env('SENTRY_DSN')),
 
+    // @see https://spotlightjs.com/
+    'spotlight' => env('SENTRY_SPOTLIGHT', false),
+
     // @see: https://docs.sentry.io/platforms/php/guides/laravel/configuration/options/#logger
     // 'logger' => Sentry\Logger\DebugFileLogger::class, // By default this will log to `storage_path('logs/sentry.log')`
 

--- a/src/Sentry/Laravel/BaseServiceProvider.php
+++ b/src/Sentry/Laravel/BaseServiceProvider.php
@@ -22,7 +22,7 @@ abstract class BaseServiceProvider extends ServiceProvider
     {
         $config = $this->getUserConfig();
 
-        return !empty($config['dsn']);
+        return !empty($config['dsn']) || ($config['spotlight'] ?? false) === true;
     }
 
     /**
@@ -42,12 +42,14 @@ abstract class BaseServiceProvider extends ServiceProvider
      *
      * Because of `traces_sampler` being dynamic we can never be 100% confident but that is also not important.
      *
+     * @deprecated This method is deprecated and will be removed in the next major release.
+     *
      * @return bool
      */
     protected function couldHavePerformanceTracingEnabled(): bool
     {
         $config = $this->getUserConfig();
 
-        return !empty($config['traces_sample_rate']) || !empty($config['traces_sampler']);
+        return !empty($config['traces_sample_rate']) || !empty($config['traces_sampler']) || ($config['spotlight'] ?? false) === true;
     }
 }

--- a/src/Sentry/Laravel/BaseServiceProvider.php
+++ b/src/Sentry/Laravel/BaseServiceProvider.php
@@ -22,7 +22,19 @@ abstract class BaseServiceProvider extends ServiceProvider
     {
         $config = $this->getUserConfig();
 
-        return !empty($config['dsn']) || ($config['spotlight'] ?? false) === true;
+        return !empty($config['dsn']);
+    }
+
+    /**
+     * Check if Spotlight was enabled in the config.
+     *
+     * @return bool
+     */
+    protected function hasSpotlightEnabled(): bool
+    {
+        $config = $this->getUserConfig();
+
+        return ($config['spotlight'] ?? false) === true;
     }
 
     /**
@@ -42,7 +54,7 @@ abstract class BaseServiceProvider extends ServiceProvider
      *
      * Because of `traces_sampler` being dynamic we can never be 100% confident but that is also not important.
      *
-     * @deprecated This method is deprecated and will be removed in the next major release.
+     * @deprecated since version 4.6. To be removed in version 5.0.
      *
      * @return bool
      */

--- a/src/Sentry/Laravel/ServiceProvider.php
+++ b/src/Sentry/Laravel/ServiceProvider.php
@@ -83,7 +83,7 @@ class ServiceProvider extends BaseServiceProvider
 
         $this->bootFeatures();
 
-        if ($this->hasDsnSet()) {
+        if ($this->hasDsnSet() || $this->hasSpotlightEnabled()) {
             $this->bindEvents();
 
             if ($this->app instanceof Lumen) {
@@ -188,7 +188,7 @@ class ServiceProvider extends BaseServiceProvider
      */
     protected function bootFeatures(): void
     {
-        $bootActive = $this->hasDsnSet();
+        $bootActive = $this->hasDsnSet() || $this->hasSpotlightEnabled();
 
         foreach (self::FEATURES as $feature) {
             try {

--- a/src/Sentry/Laravel/ServiceProvider.php
+++ b/src/Sentry/Laravel/ServiceProvider.php
@@ -83,6 +83,8 @@ class ServiceProvider extends BaseServiceProvider
 
         $this->bootFeatures();
 
+        // Only register if a DSN is set or Spotlight is enabled
+        // No events can be sent without a DSN set or Spotlight enabled
         if ($this->hasDsnSet() || $this->hasSpotlightEnabled()) {
             $this->bindEvents();
 
@@ -188,6 +190,8 @@ class ServiceProvider extends BaseServiceProvider
      */
     protected function bootFeatures(): void
     {
+        // Only register if a DSN is set or Spotlight is enabled
+        // No events can be sent without a DSN set or Spotlight enabled
         $bootActive = $this->hasDsnSet() || $this->hasSpotlightEnabled();
 
         foreach (self::FEATURES as $feature) {

--- a/src/Sentry/Laravel/Tracing/ServiceProvider.php
+++ b/src/Sentry/Laravel/Tracing/ServiceProvider.php
@@ -27,7 +27,7 @@ class ServiceProvider extends BaseServiceProvider
     public function boot(): void
     {
         // If there is no DSN set we register nothing since it's impossible for us to send traces without a DSN set
-        if (!$this->hasDsnSet()) {
+        if (!$this->hasDsnSet() && !$this->hasSpotlightEnabled()) {
             return;
         }
 

--- a/src/Sentry/Laravel/Tracing/ServiceProvider.php
+++ b/src/Sentry/Laravel/Tracing/ServiceProvider.php
@@ -26,7 +26,8 @@ class ServiceProvider extends BaseServiceProvider
 
     public function boot(): void
     {
-        // If there is no DSN set we register nothing since it's impossible for us to send traces without a DSN set
+        // Only register if a DSN is set or Spotlight is enabled
+        // No events can be sent without a DSN set or Spotlight enabled
         if (!$this->hasDsnSet() && !$this->hasSpotlightEnabled()) {
             return;
         }


### PR DESCRIPTION
Two things happening:

- When Spotlight was enabled you also needed to set a DSN for the SDK to be enabled, now only enabling Spotlight is enough
- You couldn't enable Spotlight without adding something to your `config/sentry.php` now you can enable it from your `.env` using `SENTRY_SPOTLIGHT=true`
- Deprecated `couldHavePerformanceTracingEnabled` since it's no longer in use since #600