### PR TITLE
fix: Avoid manipulating config when resolving disks

### DIFF
--- a/src/Sentry/Laravel/Features/Storage/Integration.php
+++ b/src/Sentry/Laravel/Features/Storage/Integration.php
@@ -49,10 +49,14 @@ class Integration extends Feature
                     $diskResolver = (function (string $disk, array $config) {
                         // This is a "hack" to make sure that the original driver is resolved by the FilesystemManager
                         $oldConfig = config("filesystems.disks.{$disk}");
+
                         config(["filesystems.disks.{$disk}" => $config]);
+
                         /** @var FilesystemManager $this */
                         $resolved = $this->resolve($disk);
+
                         config(["filesystems.disks.{$disk}" => $oldConfig]);
+
                         return $resolved;
                     })->bindTo($filesystemManager, FilesystemManager::class);
 

--- a/src/Sentry/Laravel/Features/Storage/Integration.php
+++ b/src/Sentry/Laravel/Features/Storage/Integration.php
@@ -47,11 +47,8 @@ class Integration extends Feature
                     unset($config['sentry_original_driver']);
 
                     $diskResolver = (function (string $disk, array $config) {
-                        // This is a "hack" to make sure that the original driver is resolved by the FilesystemManager
-                        config(["filesystems.disks.{$disk}" => $config]);
-
                         /** @var FilesystemManager $this */
-                        return $this->resolve($disk);
+                        return $this->resolve($disk, $config);
                     })->bindTo($filesystemManager, FilesystemManager::class);
 
                     /** @var Filesystem $originalFilesystem */

--- a/src/Sentry/Laravel/Features/Storage/Integration.php
+++ b/src/Sentry/Laravel/Features/Storage/Integration.php
@@ -47,8 +47,12 @@ class Integration extends Feature
                     unset($config['sentry_original_driver']);
 
                     $diskResolver = (function (string $disk, array $config) {
-                        /** @var FilesystemManager $this */
-                        return $this->resolve($disk, $config);
+                        // This is a "hack" to make sure that the original driver is resolved by the FilesystemManager
+                        $oldConfig = config("filesystems.disks.{$disk}");
+                        config(["filesystems.disks.{$disk}" => $config]);
+                        $resolved = $this->resolve($disk);
+                        config(["filesystems.disks.{$disk}" => $oldConfig]);
+                        return $resolved;
                     })->bindTo($filesystemManager, FilesystemManager::class);
 
                     /** @var Filesystem $originalFilesystem */

--- a/src/Sentry/Laravel/Features/Storage/Integration.php
+++ b/src/Sentry/Laravel/Features/Storage/Integration.php
@@ -50,6 +50,7 @@ class Integration extends Feature
                         // This is a "hack" to make sure that the original driver is resolved by the FilesystemManager
                         $oldConfig = config("filesystems.disks.{$disk}");
                         config(["filesystems.disks.{$disk}" => $config]);
+                        /** @var FilesystemManager $this */
                         $resolved = $this->resolve($disk);
                         config(["filesystems.disks.{$disk}" => $oldConfig]);
                         return $resolved;

--- a/test/Sentry/Features/StorageIntegrationTest.php
+++ b/test/Sentry/Features/StorageIntegrationTest.php
@@ -164,6 +164,7 @@ class StorageIntegrationTest extends TestCase
         $this->resetApplicationWithConfig([
             'filesystems.disks' => Integration::configureDisks(config('filesystems.disks')),
         ]);
+
         $originalConfig = config('filesystems.disks.local');
 
         Storage::disk('local');

--- a/test/Sentry/Features/StorageIntegrationTest.php
+++ b/test/Sentry/Features/StorageIntegrationTest.php
@@ -159,6 +159,18 @@ class StorageIntegrationTest extends TestCase
         $this->expectNotToPerformAssertions();
     }
 
+    public function testResolvingDiskDoesNotModifyConfig(): void
+    {
+        $this->resetApplicationWithConfig([
+            'filesystems.disks' => Integration::configureDisks(config('filesystems.disks')),
+        ]);
+        $originalConfig = config('filesystems.disks.local');
+
+        Storage::disk('local');
+
+        $this->assertEquals($originalConfig, config('filesystems.disks.local'));
+    }
+
     public function testThrowsIfDiskConfigurationDoesntSpecifyDiskName(): void
     {
         $this->resetApplicationWithConfig([


### PR DESCRIPTION
This commit updates the storage integration such that it does not manipulate the filesystems config when a disk is resolved.
Doing so fixes an issue when using scoped disks where the disk's prefix property is injected into the parent disk's config, making the parent disk unusable from that point forward.

The added test doesn't replicate the issue with scoped disks specifically because the `league/flysystem-path-prefixing` package is required to use scoped disks. The best I could do was to assert that the config isn't being manipulated when a disk is resolved, which seems sensible in and of itself.

Tagging you here, @spawnia, as you may have some insight into why the "hack" this commit removes was added in the first place, and if it's still needed (ref https://github.com/getsentry/sentry-laravel/pull/726).