### PR TITLE
Cache tracing

### DIFF
--- a/config/sentry.php
+++ b/config/sentry.php
@@ -103,6 +103,9 @@ return [
         // Capture HTTP client requests as spans
         'http_client_requests' => env('SENTRY_TRACE_HTTP_CLIENT_REQUESTS_ENABLED', true),
 
+        // Capture Laravel cache events (hits, writes etc.) as spans
+        'cache' => env('SENTRY_TRACE_CACHE_ENABLED', true),
+
         // Capture Redis operations as spans (this enables Redis events in Laravel)
         'redis_commands' => env('SENTRY_TRACE_REDIS_COMMANDS', false),
 

--- a/src/Sentry/Laravel/Features/Concerns/TracksPushedScopesAndSpans.php
+++ b/src/Sentry/Laravel/Features/Concerns/TracksPushedScopesAndSpans.php
@@ -5,6 +5,7 @@ namespace Sentry\Laravel\Features\Concerns;
 use Sentry\Laravel\Integration;
 use Sentry\SentrySdk;
 use Sentry\Tracing\Span;
+use Sentry\Tracing\SpanStatus;
 
 trait TracksPushedScopesAndSpans
 {
@@ -71,5 +72,22 @@ trait TracksPushedScopesAndSpans
         SentrySdk::getCurrentHub()->popScope();
 
         --$this->pushedScopeCount;
+    }
+
+    protected function maybeFinishSpan(?SpanStatus $status = null): ?Span
+    {
+        $span = $this->maybePopSpan();
+
+        if ($span === null) {
+            return null;
+        }
+
+        if ($status !== null) {
+            $span->setStatus($status);
+        }
+
+        $span->finish();
+
+        return $span;
     }
 }

--- a/src/Sentry/Laravel/Features/Concerns/WorksWithSpans.php
+++ b/src/Sentry/Laravel/Features/Concerns/WorksWithSpans.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Sentry\Laravel\Features\Concerns;
+
+use Sentry\SentrySdk;
+use Sentry\Tracing\Span;
+
+trait WorksWithSpans
+{
+    protected function getParentSpanIfSampled(): ?Span
+    {
+        $parentSpan = SentrySdk::getCurrentHub()->getSpan();
+
+        // If the span is not available or not sampled we don't need to do anything
+        if ($parentSpan === null || !$parentSpan->getSampled()) {
+            return null;
+        }
+
+        return $parentSpan;
+    }
+
+    /** @param callable(Span $parentSpan): void $callback */
+    protected function withParentSpanIfSampled(callable $callback): void
+    {
+        $parentSpan = $this->getParentSpanIfSampled();
+
+        if ($parentSpan === null) {
+            return;
+        }
+
+        $callback($parentSpan);
+    }
+}

--- a/src/Sentry/Laravel/Features/HttpClientIntegration.php
+++ b/src/Sentry/Laravel/Features/HttpClientIntegration.php
@@ -108,12 +108,7 @@ class HttpClientIntegration extends Feature
 
     public function handleConnectionFailedHandlerForTracing(ConnectionFailed $event): void
     {
-        $span = $this->maybePopSpan();
-
-        if ($span !== null) {
-            $span->setStatus(SpanStatus::internalError());
-            $span->finish();
-        }
+        $this->maybeFinishSpan(SpanStatus::internalError());
     }
 
     public function handleResponseReceivedHandlerForBreadcrumb(ResponseReceived $event): void

--- a/src/Sentry/Laravel/Features/LivewirePackageIntegration.php
+++ b/src/Sentry/Laravel/Features/LivewirePackageIntegration.php
@@ -168,11 +168,7 @@ class LivewirePackageIntegration extends Feature
 
     public function handleComponentDehydrate(Component $component): void
     {
-        $span = $this->maybePopSpan();
-
-        if ($span !== null) {
-            $span->finish();
-        }
+        $span = $this->maybeFinishSpan();
     }
 
     private function updateTransactionName(string $componentName): void

--- a/src/Sentry/Laravel/Features/NotificationsIntegration.php
+++ b/src/Sentry/Laravel/Features/NotificationsIntegration.php
@@ -58,7 +58,7 @@ class NotificationsIntegration extends Feature
 
     public function handleNotificationSent(NotificationSent $event): void
     {
-        $this->finishSpanWithStatus(SpanStatus::ok());
+        $this->maybeFinishSpan(SpanStatus::ok());
 
         if ($this->isBreadcrumbFeatureEnabled(self::FEATURE_KEY)) {
             Integration::addBreadcrumb(new Breadcrumb(
@@ -72,16 +72,6 @@ class NotificationsIntegration extends Feature
                     'notification' => get_class($event->notification),
                 ]
             ));
-        }
-    }
-
-    private function finishSpanWithStatus(SpanStatus $status): void
-    {
-        $span = $this->maybePopSpan();
-
-        if ($span !== null) {
-            $span->setStatus($status);
-            $span->finish();
         }
     }
 

--- a/src/Sentry/Laravel/Features/QueueIntegration.php
+++ b/src/Sentry/Laravel/Features/QueueIntegration.php
@@ -112,16 +112,12 @@ class QueueIntegration extends Feature
 
     public function handleJobQueuedEvent(JobQueued $event): void
     {
-        $span = $this->maybePopSpan();
-
-        if ($span !== null) {
-            $span->finish();
-        }
+        $this->maybeFinishSpan();
     }
 
     public function handleJobProcessedQueueEvent(JobProcessed $event): void
     {
-        $this->finishJobWithStatus(SpanStatus::ok());
+        $this->maybeFinishSpan(SpanStatus::ok());
 
         $this->maybePopScope();
     }
@@ -225,19 +221,9 @@ class QueueIntegration extends Feature
 
     public function handleJobExceptionOccurredQueueEvent(JobExceptionOccurred $event): void
     {
-        $this->finishJobWithStatus(SpanStatus::internalError());
+        $this->maybeFinishSpan(SpanStatus::internalError());
 
         Integration::flushEvents();
-    }
-
-    private function finishJobWithStatus(SpanStatus $status): void
-    {
-        $span = $this->maybePopSpan();
-
-        if ($span !== null) {
-            $span->setStatus($status);
-            $span->finish();
-        }
     }
 
     private function normalizeQueueName(?string $queue): string


### PR DESCRIPTION
With laravel/framework#51560 we are now able to trace cache operations.

Added the needed plumbing (enabled by default).