### PR TITLE
Always remove XSRF-TOKEN cookie value before sending to Sentry

### DIFF
--- a/src/Sentry/Laravel/Http/LaravelRequestFetcher.php
+++ b/src/Sentry/Laravel/Http/LaravelRequestFetcher.php
@@ -40,7 +40,7 @@ class LaravelRequestFetcher implements RequestFetcherInterface
         $cookies = new Collection($request->getCookieParams());
 
         // We need to filter out the cookies that are not allowed to be sent to Sentry because they are very sensitive
-        $forbiddenCookies = [config('session.cookie'), 'remember_*'];
+        $forbiddenCookies = [config('session.cookie'), 'remember_*', 'XSRF-TOKEN'];
 
         return $request->withCookieParams(
             $cookies->map(function ($value, string $key) use ($forbiddenCookies) {


### PR DESCRIPTION
The CSRF protection cookie should probably be filtered away too like the session cookies. Less security sensitive but has no debugging purpose (except for seeing it's there). 

What do you think about filtering it by default like we do for session cookies?

(the name `XSRF-TOKEN` is hardcoded and not configurable by the user)