### PR TITLE
Octane fixes

### DIFF
--- a/src/Sentry/Laravel/Tracing/Routing/TracingRoutingDispatcher.php
+++ b/src/Sentry/Laravel/Tracing/Routing/TracingRoutingDispatcher.php
@@ -2,6 +2,7 @@
 
 namespace Sentry\Laravel\Tracing\Routing;
 
+use Closure;
 use Illuminate\Routing\Route;
 use Sentry\SentrySdk;
 use Sentry\Tracing\SpanContext;
@@ -17,9 +18,13 @@ abstract class TracingRoutingDispatcher
             return $dispatch();
         }
 
+        // The action name can be a Closure curiously enough... so we guard againt that here
+        // @see: https://github.com/getsentry/sentry-laravel/issues/917
+        $action = $route->getActionName() instanceof Closure ? 'Closure' : $route->getActionName();
+
         $context = new SpanContext;
         $context->setOp('http.route');
-        $context->setDescription($route->getActionName());
+        $context->setDescription($action);
 
         $span = $parentSpan->startChild($context);
 

--- a/src/Sentry/Laravel/Tracing/ServiceProvider.php
+++ b/src/Sentry/Laravel/Tracing/ServiceProvider.php
@@ -68,7 +68,7 @@ class ServiceProvider extends BaseServiceProvider
                 $continueAfterResponse = false;
             }
 
-            return new Middleware($this->app, $continueAfterResponse);
+            return new Middleware($continueAfterResponse);
         });
     }
 


### PR DESCRIPTION
- Stop holding a reference to the container in our middleware, this prevents us from correctly registering a terminating callback causing the request to not be traced (or possibly traces to be extremely long since they span multiple requests). This is Octane specific, works fine in a normal Laravel/Lumen context
- As reported by #917 in some cases (not 100% clear what) the route name can be a Closure, add a preventitive guard against that