### PR TITLE
Normalize array of key names before converting to string

### DIFF
--- a/test/Sentry/Features/CacheIntegrationTest.php
+++ b/test/Sentry/Features/CacheIntegrationTest.php
@@ -78,6 +78,19 @@ class CacheIntegrationTest extends TestCase
         $this->assertEquals(['foo', 'bar'], $span->getData()['cache.key']);
     }
 
+    public function testCacheGetSpanIsRecordedForMultipleOperation(): void
+    {
+        $this->markSkippedIfTracingEventsNotAvailable();
+
+        $span = $this->executeAndReturnMostRecentSpan(function () {
+            Cache::getMultiple(['foo', 'bar']);
+        });
+
+        $this->assertEquals('cache.get', $span->getOp());
+        $this->assertEquals('foo, bar', $span->getDescription());
+        $this->assertEquals(['foo', 'bar'], $span->getData()['cache.key']);
+    }
+
     public function testCacheGetSpanIsRecordedWithCorrectHitData(): void
     {
         $this->markSkippedIfTracingEventsNotAvailable();
@@ -107,7 +120,7 @@ class CacheIntegrationTest extends TestCase
         $this->assertEquals(99, $span->getData()['cache.ttl']);
     }
 
-    public function testCachePutSpanIsRecordedForBatchOperation(): void
+    public function testCachePutSpanIsRecordedForManyOperation(): void
     {
         $this->markSkippedIfTracingEventsNotAvailable();
 


### PR DESCRIPTION
As reported in #916, when retrieving multiple keys we could try and convert the values to a string for the keys instead of the actual keys. This was an oversight and is fixed by copying a bit from Laravel core to our codebase to correctly resolve the keys to an array of strings.

See: https://github.com/laravel/framework/blob/96712ba63e37b54ee8d0738eb613e13c9aff522f/src/Illuminate/Cache/Repository.php#L124-L126