### PR TITLE
Improve stacktrace of test event

### DIFF
--- a/src/Sentry/Laravel/Console/TestCommand.php
+++ b/src/Sentry/Laravel/Console/TestCommand.php
@@ -89,7 +89,7 @@ class TestCommand extends Command
                     }
 
                     foreach ($stacktrace->getFrames() as $frame) {
-                        if (str_starts_with($frame->getAbsoluteFilePath(), __DIR__))  {
+                        if (str_starts_with($frame->getAbsoluteFilePath(), __DIR__)) {
                             $frame->setIsInApp(true);
                         }
                     }

--- a/src/Sentry/Laravel/ServiceProvider.php
+++ b/src/Sentry/Laravel/ServiceProvider.php
@@ -248,7 +248,10 @@ class ServiceProvider extends BaseServiceProvider
             $options = \array_merge(
                 [
                     'prefixes' => [$basePath],
-                    'in_app_exclude' => ["{$basePath}/vendor"],
+                    'in_app_exclude' => [
+                        "{$basePath}/vendor",
+                        "{$basePath}/artisan",
+                    ],
                 ],
                 $userConfig
             );


### PR DESCRIPTION
- Add "artisan" by default as not in-app since it should be considered a vendor file
- Make sure our test command frames are always detect as in-app so they look nicer

Before:

![afbeelding](https://github.com/user-attachments/assets/38ebcac1-06e6-4cc8-891e-728fbe19a4f0)

After:

![afbeelding](https://github.com/user-attachments/assets/3ae54a80-ea10-46f4-bc53-edc3697be7b3)

_note that in my screenshot my full path is shown, that is because of how my dev environment is setup, normally file paths would be shown from the project root instead of the system root._