### PR TITLE
Allow embedding SQL query bindings (parameters) in SQL query breadcrumbs and spans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+### Features
+
+- Allow embedding SQL query bindings (parameters) in SQL query breadcrumbs and spans.
+
+  To enable this feature, update your `config/sentry.php` file or set the `SENTRY_TRACE_SQL_BINDINGS_ENABLED` and `SENTRY_BREADCRUMBS_SQL_BINDINGS_ENABLED` environment variables to `embed`.
+
+  ```php
+  'breadcrumbs' => [
+      'sql_bindings' => 'embed',
+  ],
+  'tracing' => [
+      'sql_bindings' => 'embed',
+  ],
+  ```
+
 ## 4.7.1
 
 The Sentry SDK team is happy to announce the immediate availability of Sentry Laravel SDK v4.7.1.

--- a/config/sentry.php
+++ b/config/sentry.php
@@ -58,7 +58,7 @@ return [
         // Capture SQL queries as breadcrumbs
         'sql_queries' => env('SENTRY_BREADCRUMBS_SQL_QUERIES_ENABLED', true),
 
-        // Capture SQL query bindings (parameters) in SQL query breadcrumbs
+        // Capture bindings in SQL query breadcrumbs. `true` or `append` shows them separate, `embed` inlines them
         'sql_bindings' => env('SENTRY_BREADCRUMBS_SQL_BINDINGS_ENABLED', false),
 
         // Capture queue job information as breadcrumbs
@@ -85,7 +85,7 @@ return [
         // Capture SQL queries as spans
         'sql_queries' => env('SENTRY_TRACE_SQL_QUERIES_ENABLED', true),
 
-        // Capture SQL query bindings (parameters) in SQL query spans
+        // Capture bindings in SQL query spans. `true` or `append` shows them separate, `embed` inlines them
         'sql_bindings' => env('SENTRY_TRACE_SQL_BINDINGS_ENABLED', false),
 
         // Capture where the SQL query originated from on the SQL query spans

--- a/src/Sentry/Laravel/ServiceProvider.php
+++ b/src/Sentry/Laravel/ServiceProvider.php
@@ -46,8 +46,7 @@ class ServiceProvider extends BaseServiceProvider
         'integrations',
         // This is kept for backwards compatibility and can be dropped in a future breaking release
         'breadcrumbs.sql_bindings',
-
-        // This config option is no longer in use but to prevent errors when upgrading we leave it here to be discarded
+        // This config option is no longer in use, but to prevent errors when upgrading we leave it here to be discarded
         'controllers_base_namespace',
     ];
 

--- a/test/Sentry/EventHandler/DatabaseEventsTest.php
+++ b/test/Sentry/EventHandler/DatabaseEventsTest.php
@@ -4,6 +4,8 @@ namespace Sentry\Laravel\Tests\EventHandler;
 
 use Illuminate\Database\Connection;
 use Illuminate\Database\Events\QueryExecuted;
+use Illuminate\Database\Grammar;
+use Illuminate\Database\Query\Builder;
 use Mockery;
 use Sentry\Laravel\Tests\TestCase;
 
@@ -46,11 +48,56 @@ class DatabaseEventsTest extends TestCase
 
         $lastBreadcrumb = $this->getLastSentryBreadcrumb();
 
-        $this->assertEquals($query, $lastBreadcrumb->getMessage());
-        $this->assertEquals($bindings, $lastBreadcrumb->getMetadata()['bindings']);
+        $this->assertSame($query, $lastBreadcrumb->getMessage());
+        $this->assertSame($bindings, $lastBreadcrumb->getMetadata()['bindings']);
     }
 
-    public function testSqlQueriesAreRecordedWhenDisabled(): void
+    public function testSqlBindingsAreInlined(): void
+    {
+        $this->resetApplicationWithConfig([
+            'sentry.breadcrumbs.sql_bindings' => 'embed',
+        ]);
+
+        $this->assertSame('embed', $this->app['config']->get('sentry.breadcrumbs.sql_bindings'));
+
+        $query = 'SELECT * FROM breadcrumbs WHERE bindings = ?;';
+        $bindings = ['1'];
+        $rawSQL = 'SELECT * FROM breadcrumbs WHERE bindings = 1;';
+
+        $grammar = Mockery::mock(Grammar::class);
+        $grammar
+            ->shouldReceive('substituteBindingsIntoRawSql')
+            ->with($query, $bindings)
+            ->andReturn($rawSQL);
+
+        $builder = Mockery::mock(Builder::class);
+        $builder
+            ->shouldReceive('getGrammar')
+            ->andReturn($grammar);
+
+        $connection = Mockery::mock(Connection::class);
+        $connection->shouldReceive('getName')
+            ->andReturn('test');
+        $connection->shouldReceive('query')
+            ->andReturn($builder);
+        $connection->shouldReceive('prepareBindings')
+            ->with($bindings)
+            ->andReturn($bindings);
+
+        $this->dispatchLaravelEvent(new QueryExecuted(
+            $query,
+            $bindings,
+            10,
+            $connection
+        ));
+
+        $lastBreadcrumb = $this->getLastSentryBreadcrumb();
+
+        $this->assertSame($rawSQL, $lastBreadcrumb->getMessage());
+        $this->assertArrayNotHasKey('bindings', $lastBreadcrumb->getMetadata());
+    }
+
+    public function testSqlQueriesAreNotRecordedWhenDisabled(): void
     {
         $this->resetApplicationWithConfig([
             'sentry.breadcrumbs.sql_queries' => false,
@@ -68,7 +115,7 @@ class DatabaseEventsTest extends TestCase
         $this->assertEmpty($this->getCurrentSentryBreadcrumbs());
     }
 
-    public function testSqlBindingsAreRecordedWhenDisabled(): void
+    public function testSqlBindingsAreNotRecordedWhenDisabled(): void
     {
         $this->resetApplicationWithConfig([
             'sentry.breadcrumbs.sql_bindings' => false,
@@ -85,13 +132,14 @@ class DatabaseEventsTest extends TestCase
 
         $lastBreadcrumb = $this->getLastSentryBreadcrumb();
 
-        $this->assertEquals($query, $lastBreadcrumb->getMessage());
-        $this->assertFalse(isset($lastBreadcrumb->getMetadata()['bindings']));
+        $this->assertSame($query, $lastBreadcrumb->getMessage());
+        $this->assertArrayNotHasKey('bindings', $lastBreadcrumb->getMetadata());
     }
 
     private function getMockedConnection()
     {
         return Mockery::mock(Connection::class)
-            ->shouldReceive('getName')->andReturn('test');
+            ->shouldReceive('getName')
+            ->andReturn('test');
     }
 }

--- a/test/Sentry/Features/DatabaseIntegrationTest.php
+++ b/test/Sentry/Features/DatabaseIntegrationTest.php
@@ -100,6 +100,18 @@ class DatabaseIntegrationTest extends TestCase
         $this->assertSame($bindings, $span->getData()['db.sql.bindings']);
     }
 
+    public function testSqlBindingsAreInlined(): void
+    {
+        $this->resetApplicationWithConfig([
+            'sentry.tracing.sql_bindings' => 'embed',
+        ]);
+
+        $span = $this->executeQueryAndRetrieveSpan('SELECT ?', [true]);
+
+        $this->assertSame('SELECT 1', $span->getDescription());
+        $this->assertArrayNotHasKey('db.sql.bindings', $span->getData());
+    }
+
     public function testSqlBindingsAreNotRecordedWhenDisabled(): void
     {
         $this->resetApplicationWithConfig([

--- a/test/Sentry/Features/DatabaseIntegrationTest.php
+++ b/test/Sentry/Features/DatabaseIntegrationTest.php
@@ -96,11 +96,11 @@ class DatabaseIntegrationTest extends TestCase
             $bindings = ['1']
         );
 
-        $this->assertEquals($query, $span->getDescription());
-        $this->assertEquals($bindings, $span->getData()['db.sql.bindings']);
+        $this->assertSame($query, $span->getDescription());
+        $this->assertSame($bindings, $span->getData()['db.sql.bindings']);
     }
 
-    public function testSqlBindingsAreRecordedWhenDisabled(): void
+    public function testSqlBindingsAreNotRecordedWhenDisabled(): void
     {
         $this->resetApplicationWithConfig([
             'sentry.tracing.sql_bindings' => false,
@@ -111,8 +111,8 @@ class DatabaseIntegrationTest extends TestCase
             ['1']
         );
 
-        $this->assertEquals($query, $span->getDescription());
-        $this->assertFalse(isset($span->getData()['db.sql.bindings']));
+        $this->assertSame($query, $span->getDescription());
+        $this->assertArrayNotHasKey('db.sql.bindings', $span->getData());
     }
 
     public function testSqlOriginIsResolvedWhenEnabledAndOverTreshold(): void


### PR DESCRIPTION
I added a similar feature to Laravel in https://github.com/laravel/framework/pull/52192.