### PR TITLE
Move delayed transaction finisher state out of middleware

### DIFF
--- a/src/Sentry/Laravel/Tracing/ServiceProvider.php
+++ b/src/Sentry/Laravel/Tracing/ServiceProvider.php
@@ -59,6 +59,8 @@ class ServiceProvider extends BaseServiceProvider
 
     public function register(): void
     {
+        $this->app->singleton(TransactionFinisher::class);
+
         $this->app->singleton(Middleware::class, function () {
             $continueAfterResponse = ($this->getTracingConfig()['continue_after_response'] ?? true) === true;
 

--- a/src/Sentry/Laravel/Tracing/TransactionFinisher.php
+++ b/src/Sentry/Laravel/Tracing/TransactionFinisher.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Sentry\Laravel\Tracing;
+
+/**
+ * @internal
+ */
+class TransactionFinisher
+{
+    public function __construct()
+    {
+        // We need to finish the transaction after the response has been sent to the client
+        // so we register a terminating callback to do so, this allows us to also capture
+        // spans that are created during the termination of the application like queue
+        // dispatched using dispatch(...)->afterResponse(). This middleware is called
+        // before the terminating callbacks so we are 99.9% sure to be the last one
+        // to run except if another terminating callback is registered after ours.
+        app()->terminating(function () {
+            app(Middleware::class)->finishTransaction();
+        });
+    }
+}

--- a/src/Sentry/Laravel/Tracing/TransactionFinisher.php
+++ b/src/Sentry/Laravel/Tracing/TransactionFinisher.php
@@ -12,9 +12,15 @@ class TransactionFinisher
         // We need to finish the transaction after the response has been sent to the client
         // so we register a terminating callback to do so, this allows us to also capture
         // spans that are created during the termination of the application like queue
-        // dispatched using dispatch(...)->afterResponse(). This middleware is called
-        // before the terminating callbacks so we are 99.9% sure to be the last one
-        // to run except if another terminating callback is registered after ours.
+        // dispatches using dispatch(...)->afterResponse() which are terminating
+        // callbacks themselfs just like we do below.
+        //
+        // This class is registered as a singleton in the container to ensure it's only
+        // instantiated once and the terminating callback is only registered once.
+        //
+        // It should be resolved from the container before the terminating callbacks are called.
+        // Good place is in the `terminate` callback of a middleware for example.
+        // This way we can be 99.9% sure to be the last ones to run.
         app()->terminating(function () {
             app(Middleware::class)->finishTransaction();
         });


### PR DESCRIPTION
Because out middleware is a singleton resolved in the boot of the framework it never get's detroyed so any state remains forever, this caused the terminating callback to only be registered for one request and subsequent requests did not get a new terminating callback registered. To fix this I moved the registering of the callback to a class we keep as a singleton so we know if the container was reset and this ensure the callback is only registered once per container lifecycle and re-registers it as needed for Octane.

Fixes #935

This also works fine on normal Laravel applications. Lumen never used this method anyway since `app()->terminating()` isn't a thing there.