### PR TITLE
Send span origin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     "require": {
         "php": "^7.2 | ^8.0",
         "illuminate/support": "^6.0 | ^7.0 | ^8.0 | ^9.0 | ^10.0 | ^11.0",
-        "sentry/sentry": "^4.7",
+        "sentry/sentry": "^4.9",
         "symfony/psr-http-message-bridge": "^1.0 | ^2.0 | ^6.0 | ^7.0",
         "nyholm/psr7": "^1.0"
     },

--- a/src/Sentry/Laravel/Console/TestCommand.php
+++ b/src/Sentry/Laravel/Console/TestCommand.php
@@ -176,18 +176,20 @@ class TestCommand extends Command
         if ($this->option('transaction')) {
             $this->clearErrorMessagesFromSDK();
 
-            $transactionContext = new TransactionContext();
-            $transactionContext->setSampled(true);
-            $transactionContext->setName('Sentry Test Transaction');
-            $transactionContext->setSource(TransactionSource::custom());
-            $transactionContext->setOp('sentry.test');
+            $transaction = $hub->startTransaction(
+                TransactionContext::make()
+                    ->setOp('sentry.test')
+                    ->setName('Sentry Test Transaction')
+                    ->setOrigin('auto.test.transaction')
+                    ->setSource(TransactionSource::custom())
+                    ->setSampled(true)
+            );
 
-            $transaction = $hub->startTransaction($transactionContext);
-
-            $spanContext = new SpanContext();
-            $spanContext->setOp('sentry.sent');
-
-            $span = $transaction->startChild($spanContext);
+            $span = $transaction->startChild(
+                SpanContext::make()
+                    ->setOp('sentry.sent')
+                    ->setOrigin('auto.test.span')
+            );
 
             $this->info('Sending transaction...');
 

--- a/src/Sentry/Laravel/Features/CacheIntegration.php
+++ b/src/Sentry/Laravel/Features/CacheIntegration.php
@@ -116,6 +116,7 @@ class CacheIntegration extends Feature
                             ->setData([
                                 'cache.key' => $keys,
                             ])
+                            ->setOrigin('auto.cache')
                             ->setDescription(implode(', ', $keys))
                     )
                 );
@@ -136,6 +137,7 @@ class CacheIntegration extends Feature
                                 'cache.key' => $keys,
                                 'cache.ttl' => $event->seconds,
                             ])
+                            ->setOrigin('auto.cache')
                             ->setDescription(implode(', ', $keys))
                     )
                 );
@@ -149,6 +151,7 @@ class CacheIntegration extends Feature
                             ->setData([
                                 'cache.key' => [$event->key],
                             ])
+                            ->setOrigin('auto.cache')
                             ->setDescription($event->key)
                     )
                 );
@@ -165,8 +168,9 @@ class CacheIntegration extends Feature
             return;
         }
 
-        $context = new SpanContext();
-        $context->setOp('db.redis');
+        $context = SpanContext::make()
+            ->setOp('db.redis')
+            ->setOrigin('auto.cache.redis');
 
         $keyForDescription = '';
 

--- a/src/Sentry/Laravel/Features/LivewirePackageIntegration.php
+++ b/src/Sentry/Laravel/Features/LivewirePackageIntegration.php
@@ -112,15 +112,18 @@ class LivewirePackageIntegration extends Feature
             return;
         }
 
-        $context = new SpanContext;
-        $context->setOp('ui.livewire.component');
-        $context->setDescription(
-            empty($method)
-                ? $component->getName()
-                : "{$component->getName()}::{$method}"
+        $this->pushSpan(
+            $parentSpan->startChild(
+                SpanContext::make()
+                    ->setOp('ui.livewire.component')
+                    ->setOrigin('auto.laravel.livewire')
+                    ->setDescription(
+                        empty($method)
+                            ? $component->getName()
+                            : "{$component->getName()}::{$method}"
+                    )
+            )
         );
-
-        $this->pushSpan($parentSpan->startChild($context));
     }
 
     public function handleComponentMount(Component $component, array $data): void

--- a/src/Sentry/Laravel/Features/NotificationsIntegration.php
+++ b/src/Sentry/Laravel/Features/NotificationsIntegration.php
@@ -43,7 +43,7 @@ class NotificationsIntegration extends Feature
             return;
         }
 
-        $context = (new SpanContext)
+        $context = SpanContext::make()
             ->setOp('notification.send')
             ->setData([
                 'id' => $event->notification->id,
@@ -51,6 +51,7 @@ class NotificationsIntegration extends Feature
                 'notifiable' => $this->formatNotifiable($event->notifiable),
                 'notification' => get_class($event->notification),
             ])
+            ->setOrigin('auto.laravel.notifications')
             ->setDescription($event->channel);
 
         $this->pushSpan($parentSpan->startChild($context));

--- a/src/Sentry/Laravel/Features/QueueIntegration.php
+++ b/src/Sentry/Laravel/Features/QueueIntegration.php
@@ -202,6 +202,7 @@ class QueueIntegration extends Feature
 
         $context->setOp('queue.process');
         $context->setData($job);
+        $context->setOrigin('auto.queue');
         $context->setStartTimestamp(microtime(true));
 
         // When the parent span is null we start a new transaction otherwise we start a child of the current span

--- a/src/Sentry/Laravel/Features/Storage/FilesystemDecorator.php
+++ b/src/Sentry/Laravel/Features/Storage/FilesystemDecorator.php
@@ -54,14 +54,16 @@ trait FilesystemDecorator
         }
 
         if ($this->recordSpans) {
-            $spanContext = new SpanContext;
-            $spanContext->setOp($op);
-            $spanContext->setData($data);
-            $spanContext->setDescription($description);
-
-            return trace(function () use ($method, $args) {
-                return $this->filesystem->{$method}(...$args);
-            }, $spanContext);
+            return trace(
+                function () use ($method, $args) {
+                    return $this->filesystem->{$method}(...$args);
+                },
+                SpanContext::make()
+                    ->setOp($op)
+                    ->setData($data)
+                    ->setOrigin('auto.filesystem')
+                    ->setDescription($description)
+            );
         }
 
         return $this->filesystem->{$method}(...$args);

--- a/src/Sentry/Laravel/Tracing/Integrations/LighthouseIntegration.php
+++ b/src/Sentry/Laravel/Tracing/Integrations/LighthouseIntegration.php
@@ -45,7 +45,7 @@ class LighthouseIntegration implements IntegrationInterface
 
     public function __construct(EventDispatcher $eventDispatcher, bool $ignoreOperationName = false)
     {
-        $this->eventDispatcher     = $eventDispatcher;
+        $this->eventDispatcher = $eventDispatcher;
         $this->ignoreOperationName = $ignoreOperationName;
     }
 
@@ -106,11 +106,12 @@ class LighthouseIntegration implements IntegrationInterface
             return;
         }
 
-        $context = new SpanContext;
-        $context->setOp('graphql.request');
+        $context = SpanContext::make()
+            ->setOp('graphql.request')
+            ->setOrigin('auto.graphql.server');
 
-        $this->operations    = [];
-        $this->requestSpan   = $this->previousSpan->startChild($context);
+        $this->operations = [];
+        $this->requestSpan = $this->previousSpan->startChild($context);
         $this->operationSpan = null;
 
         SentrySdk::getCurrentHub()->setSpan($this->requestSpan);
@@ -136,8 +137,9 @@ class LighthouseIntegration implements IntegrationInterface
 
         $this->updateTransactionName();
 
-        $context = new SpanContext;
-        $context->setOp("graphql.{$operationDefinition->operation}");
+        $context = SpanContext::make()
+            ->setOp("graphql.{$operationDefinition->operation}")
+            ->setOrigin('auto.graphql.server');
 
         $this->operationSpan = $this->requestSpan->startChild($context);
 

--- a/src/Sentry/Laravel/Tracing/Routing/TracingRoutingDispatcher.php
+++ b/src/Sentry/Laravel/Tracing/Routing/TracingRoutingDispatcher.php
@@ -22,11 +22,12 @@ abstract class TracingRoutingDispatcher
         // @see: https://github.com/getsentry/sentry-laravel/issues/917
         $action = $route->getActionName() instanceof Closure ? 'Closure' : $route->getActionName();
 
-        $context = new SpanContext;
-        $context->setOp('http.route');
-        $context->setDescription($action);
-
-        $span = $parentSpan->startChild($context);
+        $span = $parentSpan->startChild(
+            SpanContext::make()
+                ->setOp('http.route')
+                ->setOrigin('auto.http.server')
+                ->setDescription($action)
+        );
 
         SentrySdk::getCurrentHub()->setSpan($span);
 

--- a/src/Sentry/Laravel/Tracing/ViewEngineDecorator.php
+++ b/src/Sentry/Laravel/Tracing/ViewEngineDecorator.php
@@ -35,11 +35,12 @@ final class ViewEngineDecorator implements Engine
             return $this->engine->get($path, $data);
         }
 
-        $context = new SpanContext();
-        $context->setOp('view.render');
-        $context->setDescription($this->viewFactory->shared(self::SHARED_KEY, basename($path)));
-
-        $span = $parentSpan->startChild($context);
+        $span = $parentSpan->startChild(
+            SpanContext::make()
+                ->setOp('view.render')
+                ->setOrigin('auto.view')
+                ->setDescription($this->viewFactory->shared(self::SHARED_KEY, basename($path)))
+        );
 
         SentrySdk::getCurrentHub()->setSpan($span);
 


### PR DESCRIPTION
- Bumps SDK requirement for getsentry/sentry-php#1566
- Add span origins to all SDK generated spans
- Refactor context creation where possible to use `Context::make()` to cleanup code

Fixes #729