### PR TITLE
Set `http` breadcrumb level based on response code

### DIFF
--- a/src/Sentry/Laravel/Features/HttpClientIntegration.php
+++ b/src/Sentry/Laravel/Features/HttpClientIntegration.php
@@ -115,7 +115,9 @@ class HttpClientIntegration extends Feature
     {
         $level = Breadcrumb::LEVEL_INFO;
 
-        if ($event->response->failed()) {
+        if ($event->response->clientError()) {
+            $level = Breadcrumb::LEVEL_WARNING;
+        } elseif ($event->response->serverError()) {
             $level = Breadcrumb::LEVEL_ERROR;
         }
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/35d60b02-faed-42cb-9bbb-cd794f688dbb)

I think it makes sense to set 4XX response codes to `warning` instead of `error`.

Part of https://github.com/getsentry/team-sdks/issues/100