### PR TITLE
Allow cache store used by console scheduling integration to be overridden

### DIFF
--- a/src/Sentry/Laravel/Features/ConsoleSchedulingIntegration.php
+++ b/src/Sentry/Laravel/Features/ConsoleSchedulingIntegration.php
@@ -18,6 +18,9 @@ use Sentry\SentrySdk;
 
 class ConsoleSchedulingIntegration extends Feature
 {
+    /**
+     * @var string|null
+     */
     private $cacheStore = null;
 
     /**


### PR DESCRIPTION
An initial discussion about the implementation of this change can be found [here](https://discord.com/channels/621778831602221064/1268962575098449921).

- Allows the cache store used by `ConsoleSchedulingIntegration` to be overridden in a user-defined service provider
- Uses that cache store for storing state when a job is run in the background