### PR TITLE
Prevent PHP 8.4 deprecation warning

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -9,6 +9,7 @@ $config = new PhpCsFixer\Config;
 $config
     ->setRules([
         '@PSR2' => true,
+        'nullable_type_declaration_for_default_null_value' => true,
     ])
     ->setFinder($finder)
 ;

--- a/src/Sentry/Laravel/Features/ConsoleSchedulingIntegration.php
+++ b/src/Sentry/Laravel/Features/ConsoleSchedulingIntegration.php
@@ -212,7 +212,7 @@ class ConsoleSchedulingIntegration extends Feature
         SentrySdk::getCurrentHub()->captureEvent($event);
     }
 
-    private function createCheckIn(string $slug, CheckInStatus $status, string $id = null): CheckIn
+    private function createCheckIn(string $slug, CheckInStatus $status, ?string $id = null): CheckIn
     {
         $options = SentrySdk::getCurrentHub()->getClient()->getOptions();
 


### PR DESCRIPTION
Prevent PHP 8.4 deprecation for default null value without nullable type declaration