### PR TITLE
Fix retry count for queued jobs

### DIFF
--- a/src/Sentry/Laravel/Features/QueueIntegration.php
+++ b/src/Sentry/Laravel/Features/QueueIntegration.php
@@ -191,7 +191,7 @@ class QueueIntegration extends Feature
             'messaging.message.id' => $jobPayload['uuid'] ?? null,
             'messaging.message.envelope.size' => strlen($event->job->getRawBody()),
             'messaging.message.body.size' => strlen(json_encode($jobPayload['data'] ?? [])),
-            'messaging.message.retry.count' => $event->job->attempts(),
+            'messaging.message.retry.count' => $event->job->attempts() - 1,
             'messaging.message.receive.latency' => $jobPublishedAt !== null ? microtime(true) - $jobPublishedAt : null,
         ];
 


### PR DESCRIPTION
As correctly noted in #966 we are off by one for retries. This happened in the refactoring to the new attribute names for queue tracing. We used to call this field "attempts" in our Laravel specific field names and thus we are off by one since we should not consider the first attempt a retry, only subsequent attempts.