### PR TITLE
Fix unable to parse string notifiable

### DIFF
--- a/src/Sentry/Laravel/Features/NotificationsIntegration.php
+++ b/src/Sentry/Laravel/Features/NotificationsIntegration.php
@@ -76,14 +76,22 @@ class NotificationsIntegration extends Feature
         }
     }
 
-    private function formatNotifiable(object $notifiable): string
+    private function formatNotifiable($notifiable): string
     {
-        $notifiable = get_class($notifiable);
-
-        if ($notifiable instanceof Model) {
-            $notifiable .= "({$notifiable->getKey()})";
+        if (is_string($notifiable) || is_numeric($notifiable)) {
+            return (string)$notifiable;
         }
 
-        return $notifiable;
+        if (is_object($notifiable)) {
+            $result = get_class($notifiable);
+
+            if ($notifiable instanceof Model) {
+                $result .= "({$notifiable->getKey()})";
+            }
+
+            return $result;
+        }
+
+        return 'unknown';
     }
 }


### PR DESCRIPTION
Apparently a notifiable can be a string and is not always an object (type hint is `mixed`).

Fix a bug that causes an exception when the notification is not an object and also fix a bug where the Eloquent model key was never appended to the notifiable class.

Related to #973