### PR TITLE
Disable scheduled task tracing for background tasks

### DIFF
--- a/src/Sentry/Laravel/Features/ConsoleSchedulingIntegration.php
+++ b/src/Sentry/Laravel/Features/ConsoleSchedulingIntegration.php
@@ -136,7 +136,8 @@ class ConsoleSchedulingIntegration extends Feature
 
     public function handleScheduledTaskStarting(ScheduledTaskStarting $event): void
     {
-        if (!$event->task) {
+        // There is nothing for us to track if it's a background task since it will be handled by a separate process
+        if (!$event->task || $event->task->runInBackground) {
             return;
         }
 


### PR DESCRIPTION
Introduced in #968 we now trace scheduled commands. However for backgrounded command we are tracing the framework starting the child process which has no meaningful data whatsoever. I am working on a solution for this but in the meantime I think it's better to disable the feature for backgrounded tasks to prevent a "flood" of 1ms transactions showing up in Sentry like so:

![image](https://github.com/user-attachments/assets/39828d77-df89-4da5-95fc-aa8f93daf822)

(in case it isn't obvious, only the `statview:*` commands are not running in the background)
