### PR TITLE
Laravel 12 support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,12 +32,12 @@ jobs:
 
           # All versions below only support PHP ^8.2 (Laravel requirement)
           - { laravel: ^11.0,  testbench: ^9.0, phpunit: 10.5.* }
-          - { laravel: ^12.0,  testbench: ^10.0, phpunit: 10.5.* }
+          - { laravel: ^12.0,  testbench: ^10.0, phpunit: 11.5.* }
         exclude:
           - php: "8.1"
             packages: { laravel: ^11.0,  testbench: ^9.0, phpunit: 10.5.* }
           - php: "8.1"
-            packages: { laravel: ^12.0,  testbench: ^10.0, phpunit: 10.5.* }
+            packages: { laravel: ^12.0,  testbench: ^10.0, phpunit: 11.5.* }
 
     name: phpunit (PHP:${{ matrix.php }}, Laravel:${{ matrix.packages.laravel }})
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,9 +32,12 @@ jobs:
 
           # All versions below only support PHP ^8.2 (Laravel requirement)
           - { laravel: ^11.0,  testbench: ^9.0, phpunit: 10.5.* }
+          - { laravel: ^12.0,  testbench: ^10.0, phpunit: 10.5.* }
         exclude:
           - php: "8.1"
             packages: { laravel: ^11.0,  testbench: ^9.0, phpunit: 10.5.* }
+          - php: "8.1"
+            packages: { laravel: ^12.0,  testbench: ^10.0, phpunit: 10.5.* }
 
     name: phpunit (PHP:${{ matrix.php }}, Laravel:${{ matrix.packages.laravel }})
 

--- a/composer.json
+++ b/composer.json
@@ -37,6 +37,7 @@
     "require-dev": {
         "phpunit/phpunit": "^8.4 | ^9.3 | ^10.4 | ^11.5",
         "laravel/framework": "^6.0 | ^7.0 | ^8.0 | ^9.0 | ^10.0 | ^11.0 | ^12.0",
+        "livewire/livewire": "^2.0 | ^3.0",
         "orchestra/testbench": "^4.7 | ^5.1 | ^6.0 | ^7.0 | ^8.0 | ^9.0 | ^10.0",
         "friendsofphp/php-cs-fixer": "^3.11",
         "mockery/mockery": "^1.3",

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,6 @@
     "require-dev": {
         "phpunit/phpunit": "^8.4 | ^9.3 | ^10.4",
         "laravel/framework": "^6.0 | ^7.0 | ^8.0 | ^9.0 | ^10.0 | ^11.0 | ^12.0",
-        "livewire/livewire": "^2.0 | ^3.0",
         "orchestra/testbench": "^4.7 | ^5.1 | ^6.0 | ^7.0 | ^8.0 | ^9.0 | ^10.0",
         "friendsofphp/php-cs-fixer": "^3.11",
         "mockery/mockery": "^1.3",

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     ],
     "require": {
         "php": "^7.2 | ^8.0",
-        "illuminate/support": "^6.0 | ^7.0 | ^8.0 | ^9.0 | ^10.0 | ^11.0",
+        "illuminate/support": "^6.0 | ^7.0 | ^8.0 | ^9.0 | ^10.0 | ^11.0 | ^12.0",
         "sentry/sentry": "^4.10",
         "symfony/psr-http-message-bridge": "^1.0 | ^2.0 | ^6.0 | ^7.0",
         "nyholm/psr7": "^1.0"
@@ -36,9 +36,9 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^8.4 | ^9.3 | ^10.4",
-        "laravel/framework": "^6.0 | ^7.0 | ^8.0 | ^9.0 | ^10.0 | ^11.0",
+        "laravel/framework": "^6.0 | ^7.0 | ^8.0 | ^9.0 | ^10.0 | ^11.0 | ^12.0",
         "livewire/livewire": "^2.0 | ^3.0",
-        "orchestra/testbench": "^4.7 | ^5.1 | ^6.0 | ^7.0 | ^8.0 | ^9.0",
+        "orchestra/testbench": "^4.7 | ^5.1 | ^6.0 | ^7.0 | ^8.0 | ^9.0 | ^10.0",
         "friendsofphp/php-cs-fixer": "^3.11",
         "mockery/mockery": "^1.3",
         "phpstan/phpstan": "^1.10",
@@ -75,5 +75,6 @@
     "config": {
         "sort-packages": true
     },
+    "minimum-stability": "dev",
     "prefer-stable": true
 }

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         }
     },
     "require-dev": {
-        "phpunit/phpunit": "^8.4 | ^9.3 | ^10.4",
+        "phpunit/phpunit": "^8.4 | ^9.3 | ^10.4 | ^11.5",
         "laravel/framework": "^6.0 | ^7.0 | ^8.0 | ^9.0 | ^10.0 | ^11.0 | ^12.0",
         "orchestra/testbench": "^4.7 | ^5.1 | ^6.0 | ^7.0 | ^8.0 | ^9.0 | ^10.0",
         "friendsofphp/php-cs-fixer": "^3.11",


### PR DESCRIPTION
~~`livewire/livewire` had to be removed because it doesn't support L12 yet so we can't have it install. We are not using it except for phpstan and in development (to have autocomplete) so this is not a critical loss and we could release without it (since dev dependencies don't end up in the release anyway).~~

Another thing is the added `"minimum-stability": "dev"` we need because L12 is not out yet. This is also just a thing for local composer installs so can be released.

Release date is planned on February 24th, so we should aim for a release of the Sentry integration a few days before that.