### PR TITLE
Specify 'sentry-laravel' on publish tag

### DIFF
--- a/src/Sentry/Laravel/ServiceProvider.php
+++ b/src/Sentry/Laravel/ServiceProvider.php
@@ -107,7 +107,7 @@ class ServiceProvider extends BaseServiceProvider
             if ($this->app instanceof Laravel) {
                 $this->publishes([
                     __DIR__ . '/../../../config/sentry.php' => config_path(static::$abstract . '.php'),
-                ], 'config');
+                ], 'sentry-laravel.config');
             }
 
             $this->registerArtisanCommands();


### PR DESCRIPTION
It's a confusing name since there might be other things named `config` and it specifies that config name is related to the exact library.