### PR TITLE
Remove support for `traceparent`

### DIFF
--- a/src/Sentry/Laravel/Features/HttpClientIntegration.php
+++ b/src/Sentry/Laravel/Features/HttpClientIntegration.php
@@ -18,7 +18,6 @@ use Sentry\Tracing\SpanContext;
 use Sentry\Tracing\SpanStatus;
 use function Sentry\getBaggage;
 use function Sentry\getTraceparent;
-use function Sentry\getW3CTraceparent;
 
 class HttpClientIntegration extends Feature
 {
@@ -56,8 +55,7 @@ class HttpClientIntegration extends Feature
         if ($this->shouldAttachTracingHeaders($request)) {
             return $request
                 ->withHeader('baggage', getBaggage())
-                ->withHeader('sentry-trace', getTraceparent())
-                ->withHeader('traceparent', getW3CTraceparent());
+                ->withHeader('sentry-trace', getTraceparent());
         }
 
         return $request;

--- a/src/Sentry/Laravel/Features/QueueIntegration.php
+++ b/src/Sentry/Laravel/Features/QueueIntegration.php
@@ -80,7 +80,6 @@ class QueueIntegration extends Feature
 
                 if ($payload !== null) {
                     $payload[self::QUEUE_PAYLOAD_BAGGAGE_DATA] = getBaggage();
-                    $payload[self::QUEUE_PAYLOAD_TRACE_PARENT_DATA] = getTraceparent();
                     $payload[self::QUEUE_PAYLOAD_PUBLISH_TIME] = microtime(true);
                 }
 

--- a/src/Sentry/Laravel/Integration.php
+++ b/src/Sentry/Laravel/Integration.php
@@ -194,11 +194,12 @@ class Integration implements IntegrationInterface
     /**
      * Retrieve the `traceparent` meta tag with tracing information to link this request to front-end requests.
      *
+     * @deprecated since version 4.14. To be removed in version 5.0.
      * @return string
      */
     public static function sentryW3CTracingMeta(): string
     {
-        return sprintf('<meta name="traceparent" content="%s"/>', getW3CTraceparent());
+        return '';
     }
 
     /**

--- a/src/Sentry/Laravel/Tracing/Middleware.php
+++ b/src/Sentry/Laravel/Tracing/Middleware.php
@@ -151,7 +151,7 @@ class Middleware
         );
 
         $context = continueTrace(
-            $request->header('sentry-trace') ?? $request->header('traceparent', ''),
+            $request->header('sentry-trace', ''),
             $request->header('baggage', '')
         );
 


### PR DESCRIPTION
Adding support for W3C's `traceparent` header was a mistake on our end. This mainly causes surprises for users, that get spammed by 3rd parties sending this header.
We made the decision to remove support from the SDK.