### PR TITLE
Allow logging exceptions

### DIFF
--- a/src/Sentry/Laravel/Logs/LogsHandler.php
+++ b/src/Sentry/Laravel/Logs/LogsHandler.php
@@ -10,6 +10,8 @@ use Sentry\Monolog\CompatibilityProcessingHandlerTrait;
 use Sentry\Severity;
 use Throwable;
 
+use function Sentry\logger;
+
 class LogsHandler extends AbstractProcessingHandler
 {
     use CompatibilityProcessingHandlerTrait;
@@ -95,20 +97,22 @@ class LogsHandler extends AbstractProcessingHandler
      */
     protected function doWrite($record): void
     {
+        $context = $record['context'];
         $exception = $record['context']['exception'] ?? null;
 
         if ($exception instanceof Throwable) {
-            return;
+            // Unset the exception object from the log context
+            unset($context['exception']);
         }
 
-        \Sentry\logger()->aggregator()->add(
+        logger()->aggregator()->add(
             // This seems a little bit of a roundabout way to get the log level, but this is done for compatibility
             self::getLogLevelFromSeverity(
                 self::getSeverityFromLevel($record['level'])
             ),
             $record['message'],
             [],
-            array_merge($record['context'], $record['extra'])
+            array_merge($context, $record['extra'])
         );
     }
 

--- a/test/Sentry/Features/LogLogsIntegrationTest.php
+++ b/test/Sentry/Features/LogLogsIntegrationTest.php
@@ -77,7 +77,7 @@ class LogLogsIntegrationTest extends TestCase
         $this->assertEquals('Sentry Laravel error log message', $log->getBody());
     }
 
-    public function testLogChannelDoesntCaptureExceptions(): void
+    public function testLogChannelCapturesExceptions(): void
     {
         $logger = Log::channel('sentry_logs');
 
@@ -85,7 +85,13 @@ class LogLogsIntegrationTest extends TestCase
 
         $logs = $this->getAndFlushCapturedLogs();
 
-        $this->assertCount(0, $logs);
+        $this->assertCount(1, $logs);
+
+        $log = $logs[0];
+
+        $this->assertEquals(LogLevel::error(), $log->getLevel());
+        $this->assertEquals('Sentry Laravel error log message', $log->getBody());
+        $this->assertNull($log->attributes()->get('exception'));
     }
 
     public function testLogChannelAddsContextAsAttributes(): void


### PR DESCRIPTION
Instead of #1034, I decided to allow logging exceptions instead.
While we could emit logs for unhandled exceptions that bubble up to Laravel's error handler, we would miss all `captureException()` calls.

Attaching an `event_id` is not feasible either, as we don't know if the event id is a transaction or an error event. The trace correlation from the log to an error event must suffice for now.

Lastly, I had to create a copy of the context in order being able to mutate it, due to https://github.com/Seldaek/monolog/blob/main/src/Monolog/LogRecord.php#L35.
