### PR TITLE
Fix test bootstrap

### DIFF
--- a/test/bootstrap.php
+++ b/test/bootstrap.php
@@ -1,6 +1,6 @@
 <?php
 
-error_reporting(E_ALL | E_STRICT);
+error_reporting(E_ALL | 2048);
 
 session_start();
 


### PR DESCRIPTION
`E_STRICT` was deprecated in PHP 8.4, substituting with [2048](https://www.php.net/manual/en/errorfunc.constants.php#constant.e-strict).