### PR TITLE
ref(logs): add sentry.origin attribute to monolog handler

### DIFF
--- a/src/Sentry/Laravel/Logs/LogsHandler.php
+++ b/src/Sentry/Laravel/Logs/LogsHandler.php
@@ -112,7 +112,7 @@ class LogsHandler extends AbstractProcessingHandler
             ),
             $record['message'],
             [],
-            array_merge($context, $record['extra'])
+            array_merge($context, $record['extra'], ['sentry.origin' => 'auto.logger.monolog'])
         );
     }
 


### PR DESCRIPTION
Adds the `sentry.origin` tag for the Monolog logs integration. https://develop.sentry.dev/sdk/telemetry/logs/#sdk-integration-attributes