### PR TITLE
Auto configure our log channels

### DIFF
--- a/config/sentry.php
+++ b/config/sentry.php
@@ -35,6 +35,9 @@ return [
     // @see: https://docs.sentry.io/platforms/php/guides/laravel/configuration/options/#enable_logs
     'enable_logs' => env('SENTRY_ENABLE_LOGS', false),
 
+    // The minimum log level that will be sent to Sentry as logs using the `sentry_logs` logging channel
+    'logs_channel_level' => env('SENTRY_LOGS_LEVEL', env('LOG_LEVEL', 'debug')),
+
     // @see: https://docs.sentry.io/platforms/php/guides/laravel/configuration/options/#send_default_pii
     'send_default_pii' => env('SENTRY_SEND_DEFAULT_PII', false),
 


### PR DESCRIPTION
This should allow us to simplify the logging setup in modern Laravel applications.

Instead of adding the channel manually to the `logging.php` as the first step we can configure it using only these `.env` settings:

```
LOG_CHANNEL=stack
LOG_STACK=single,sentry_logs

# And we also need
SENTRY_ENABLE_LOGS=true

# Optional:
LOG_LEVEL=info # defaults to debug
# or:
SENTRY_LOGS_LEVEL=info # defaults to LOG_LEVEL
```

We should be careful with `SENTRY_LOGS_LEVEL` in the docs since users who manually added the `sentry_logs` channel will not have the boilerplate to allow `SENTRY_LOGS_LEVEL` to work so `LOG_LEVEL` should be prefereed, however since that usually sets the log level for the complete application it's nice to have the option to just set the Sentry version. Maybe you want `LOG_LEVEL=warning` and `SENTRY_LOGS_LEVEL=debug` for example.

The [troubleshooting steps](https://docs.sentry.io/platforms/php/guides/laravel/logs/#troubleshooting) still apply when the application doesn't have a stack channel which has been the default for many years but not everyone keeps up to date with their config changes.