### PR TITLE
fix: SENTRY_LOG_LEVEL env naming

### DIFF
--- a/config/sentry.php
+++ b/config/sentry.php
@@ -36,7 +36,7 @@ return [
     'enable_logs' => env('SENTRY_ENABLE_LOGS', false),
 
     // The minimum log level that will be sent to Sentry as logs using the `sentry_logs` logging channel
-    'logs_channel_level' => env('SENTRY_LOG_LEVEL', env('LOG_LEVEL', 'debug')),
+    'logs_channel_level' => env('SENTRY_LOG_LEVEL', env('SENTRY_LOGS_LEVEL', env('LOG_LEVEL', 'debug'))),
 
     // @see: https://docs.sentry.io/platforms/php/guides/laravel/configuration/options/#send_default_pii
     'send_default_pii' => env('SENTRY_SEND_DEFAULT_PII', false),


### PR DESCRIPTION
### Description
Changelog states we are to use `SENTRY_LOG_LEVEL`, but the config is looking for `SENTRY_LOGS_LEVEL`, which doesn't appear to conform to the base `LOG_LEVEL` env variable.
