### PR TITLE
Do not try to detect the session key on the CLI

### DIFF
--- a/test/Sentry/Features/CacheIntegrationTest.php
+++ b/test/Sentry/Features/CacheIntegrationTest.php
@@ -6,12 +6,21 @@ use Illuminate\Cache\Events\RetrievingKey;
 use Illuminate\Support\Facades\Cache;
 use Sentry\Laravel\Tests\TestCase;
 use Sentry\Tracing\Span;
+use Sentry\Laravel\Features\CacheIntegration;
 
 class CacheIntegrationTest extends TestCase
 {
     protected $defaultSetupConfig = [
         'session.driver' => 'array',
     ];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Ensure that session keys can be detected in the tests that are running from the console
+        CacheIntegration::$detectSessionKeyOnConsole = true;
+    }
 
     public function testCacheBreadcrumbForWriteAndHitIsRecorded(): void
     {


### PR DESCRIPTION
Getting the session store can result in opening a database connection, and since session keys are highly unlikely to exist on the CLI anyway I feel we can safely skip getting the session key in that situation. Since tests run in the CLI I've added a static property to skip that check which is not ideal but also not too bad 😄 

Fixes: #1057