### PR TITLE
Use Context to pass check-in ID between processes

### DIFF
--- a/src/Sentry/Laravel/Features/ConsoleSchedulingIntegration.php
+++ b/src/Sentry/Laravel/Features/ConsoleSchedulingIntegration.php
@@ -322,7 +322,10 @@ class ConsoleSchedulingIntegration extends Feature
     /** @return CacheRepository|ContextRepository */
     private function resolveCache()
     {
-        if (class_exists(ContextRepository::class)) {
+        // Context is available since Laravel 11 but the hidden context is only
+        // passed to child processes since Laravel 12.40.2 which is required
+        // for this feature to work correctly for background scheduled tasks.
+        if (class_exists(ContextRepository::class) && version_compare(app()->version(), '12.40.2', '>=')) {
             return $this->container()->make(ContextRepository::class);
         }
 

--- a/test/Sentry/Features/ConsoleSchedulingIntegrationTest.php
+++ b/test/Sentry/Features/ConsoleSchedulingIntegrationTest.php
@@ -186,8 +186,8 @@ class ConsoleSchedulingIntegrationTest extends TestCase
 
     public function testBackgroundScheduledTaskUsesContextForCheckInId(): void
     {
-        if (!class_exists(ContextRepository::class)) {
-            $this->markTestSkipped('Laravel Context is not available in this Laravel version.');
+        if (!class_exists(ContextRepository::class) || version_compare(app()->version(), '12.40.2', '<')) {
+            $this->markTestSkipped('Laravel Context with hidden context passing to child processes requires Laravel 12.40.2+.');
         }
 
         /** @var Event $scheduledEvent */
@@ -248,8 +248,8 @@ class ConsoleSchedulingIntegrationTest extends TestCase
 
     public function testBackgroundScheduledTaskOverlappingExecutionsHaveDistinctCheckInIds(): void
     {
-        if (!class_exists(ContextRepository::class)) {
-            $this->markTestSkipped('Laravel Context is not available in this Laravel version.');
+        if (!class_exists(ContextRepository::class) || version_compare(app()->version(), '12.40.2', '<')) {
+            $this->markTestSkipped('Laravel Context with hidden context passing to child processes requires Laravel 12.40.2+.');
         }
 
         /** @var Event $scheduledEvent */


### PR DESCRIPTION
### Description

When using a compatible Laravel version we use Context to share the check-in ID between processes. This prevents a race condition where multiple scheduled tasks are running at the same time which are sharing the mutex key, see #1081. 

This only works on Laravel v12.40.2, see: laravel/framework#57918

#### Issues
* resolves: #1081
* resolves: LARAVEL-51