### PR TITLE
chore(ci): Update PHPUnit versions in CI matrix

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -89,63 +89,63 @@ jobs:
         php: [ "8.5", "8.4", "8.3", "8.2", "8.1", "8.0", "7.4", "7.3", "7.2" ]
         packages:
           # All versions below should be test on PHP ^7.1 (Sentry SDK requirement) and PHP < 8.0 (PHPUnit requirement)
-          - { laravel: ^6.0,  testbench: 4.7.*, phpunit: 8.4.* }
-          - { laravel: ^7.0,  testbench: 5.1.*, phpunit: 8.4.* }
+          - { laravel: ^6.0,  testbench: 4.7.*, phpunit: 8.5.* }
+          - { laravel: ^7.0,  testbench: 5.1.*, phpunit: 8.5.* }
 
           # All versions below only support PHP ^7.3 (Laravel requirement)
-          - { laravel: ^8.0,  testbench: ^6.0, phpunit: 9.3.* }
+          - { laravel: ^8.0,  testbench: ^6.0, phpunit: 9.6.* }
 
           # All versions below only support PHP ^8.0 (Laravel requirement)
-          - { laravel: ^9.0,  testbench: ^7.0, phpunit: 9.5.* }
+          - { laravel: ^9.0,  testbench: ^7.0, phpunit: 9.6.* }
         exclude:
           - php: "7.2"
-            packages: { laravel: ^8.0,  testbench: ^6.0, phpunit: 9.3.* }
+            packages: { laravel: ^8.0,  testbench: ^6.0, phpunit: 9.6.* }
           - php: "7.2"
-            packages: { laravel: ^9.0,  testbench: ^7.0, phpunit: 9.5.* }
+            packages: { laravel: ^9.0,  testbench: ^7.0, phpunit: 9.6.* }
 
           - php: "7.3"
-            packages: { laravel: ^9.0,  testbench: ^7.0, phpunit: 9.5.* }
+            packages: { laravel: ^9.0,  testbench: ^7.0, phpunit: 9.6.* }
 
           - php: "7.4"
-            packages: { laravel: ^9.0,  testbench: ^7.0, phpunit: 9.5.* }
+            packages: { laravel: ^9.0,  testbench: ^7.0, phpunit: 9.6.* }
 
           - php: "8.0"
-            packages: { laravel: ^6.0,  testbench: 4.7.*, phpunit: 8.4.* }
+            packages: { laravel: ^6.0,  testbench: 4.7.*, phpunit: 8.5.* }
           - php: "8.0"
-            packages: { laravel: ^7.0,  testbench: 5.1.*, phpunit: 8.4.* }
+            packages: { laravel: ^7.0,  testbench: 5.1.*, phpunit: 8.5.* }
 
           - php: "8.1"
-            packages: { laravel: ^6.0,  testbench: 4.7.*, phpunit: 8.4.* }
+            packages: { laravel: ^6.0,  testbench: 4.7.*, phpunit: 8.5.* }
           - php: "8.1"
-            packages: { laravel: ^7.0,  testbench: 5.1.*, phpunit: 8.4.* }
+            packages: { laravel: ^7.0,  testbench: 5.1.*, phpunit: 8.5.* }
 
           - php: "8.2"
-            packages: { laravel: ^6.0,  testbench: 4.7.*, phpunit: 8.4.* }
+            packages: { laravel: ^6.0,  testbench: 4.7.*, phpunit: 8.5.* }
           - php: "8.2"
-            packages: { laravel: ^7.0,  testbench: 5.1.*, phpunit: 8.4.* }
+            packages: { laravel: ^7.0,  testbench: 5.1.*, phpunit: 8.5.* }
 
           - php: "8.3"
-            packages: { laravel: ^6.0,  testbench: 4.7.*, phpunit: 8.4.* }
+            packages: { laravel: ^6.0,  testbench: 4.7.*, phpunit: 8.5.* }
           - php: "8.3"
-            packages: { laravel: ^7.0,  testbench: 5.1.*, phpunit: 8.4.* }
+            packages: { laravel: ^7.0,  testbench: 5.1.*, phpunit: 8.5.* }
           - php: "8.3"
-            packages: { laravel: ^8.0,  testbench: ^6.0, phpunit: 9.3.* }
+            packages: { laravel: ^8.0,  testbench: ^6.0, phpunit: 9.6.* }
 
           - php: "8.4"
-            packages: { laravel: ^6.0,  testbench: 4.7.*, phpunit: 8.4.* }
+            packages: { laravel: ^6.0,  testbench: 4.7.*, phpunit: 8.5.* }
           - php: "8.4"
-            packages: { laravel: ^7.0,  testbench: 5.1.*, phpunit: 8.4.* }
+            packages: { laravel: ^7.0,  testbench: 5.1.*, phpunit: 8.5.* }
           - php: "8.4"
-            packages: { laravel: ^8.0,  testbench: ^6.0, phpunit: 9.3.* }
+            packages: { laravel: ^8.0,  testbench: ^6.0, phpunit: 9.6.* }
 
           - php: "8.5"
-            packages: { laravel: ^6.0,  testbench: 4.7.*, phpunit: 8.4.* }
+            packages: { laravel: ^6.0,  testbench: 4.7.*, phpunit: 8.5.* }
           - php: "8.5"
-            packages: { laravel: ^7.0,  testbench: 5.1.*, phpunit: 8.4.* }
+            packages: { laravel: ^7.0,  testbench: 5.1.*, phpunit: 8.5.* }
           - php: "8.5"
-            packages: { laravel: ^8.0,  testbench: ^6.0, phpunit: 9.3.* }
+            packages: { laravel: ^8.0,  testbench: ^6.0, phpunit: 9.6.* }
           - php: "8.5"
-            packages: { laravel: ^9.0,  testbench: ^7.0, phpunit: 9.5.* }
+            packages: { laravel: ^9.0,  testbench: ^7.0, phpunit: 9.6.* }
 
     name: phpunit (PHP:${{ matrix.php }}, Laravel:${{ matrix.packages.laravel }})
 

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
         "mockery/mockery": "^1.3",
         "orchestra/testbench": "^4.7 | ^5.1 | ^6.0 | ^7.0 | ^8.0 | ^9.0 | ^10.0",
         "phpstan/phpstan": "^1.10",
-        "phpunit/phpunit": "^8.4 | ^9.3 | ^10.4 | ^11.5"
+        "phpunit/phpunit": "^8.5 | ^9.6 | ^10.4 | ^11.5"
     },
     "autoload-dev": {
         "psr-4": {


### PR DESCRIPTION
Update PHPUnit version constraints in both the CI matrix and composer.json
to use more recent patch versions:

- PHPUnit 8.4.* → 8.5.* (for Laravel 6.x and 7.x)
- PHPUnit 9.3.* → 9.6.* (for Laravel 8.x)
- PHPUnit 9.5.* → 9.6.* (for Laravel 9.x)
- composer.json constraints: ^8.4 → ^8.5, ^9.3 → ^9.6