### PR TITLE
fix: add preg_quote for env variables

### DIFF
--- a/src/Sentry/Laravel/Console/PublishCommand.php
+++ b/src/Sentry/Laravel/Console/PublishCommand.php
@@ -101,7 +101,7 @@ COMMAND;
         if (count($values) > 0) {
             foreach ($values as $envKey => $envValue) {
                 if ($this->isEnvKeySet($envKey, $envFileContents)) {
-                    $envFileContents = preg_replace("/^{$envKey}=\"?.*?\"?(\s|$)/m", "{$envKey}={$envValue}\n", $envFileContents);
+                    $envFileContents = preg_replace($this->getEnvKeyPattern($envKey), "{$envKey}={$envValue}\n", $envFileContents);
 
                     $this->info("Updated {$envKey} with new value in your `.env` file.");
                 } else {
@@ -129,7 +129,12 @@ COMMAND;
     {
         $envFileContents = $envFileContents ?? file_get_contents(app()->environmentFilePath());
 
-        return (bool)preg_match("/^{$envKey}=\"?.*?\"?(\s|$)/m", $envFileContents);
+        return (bool)preg_match($this->getEnvKeyPattern($envKey), $envFileContents);
+    }
+
+    private function getEnvKeyPattern(string $envKey): string
+    {
+        return '/^' . preg_quote($envKey, '/') . '="?.*?"?(\s|$)/m';
     }
 
     private function askForDsnInput(): string

--- a/test/Sentry/Console/PublishCommandTest.php
+++ b/test/Sentry/Console/PublishCommandTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Sentry\Laravel\Tests\Console;
+
+use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+use Sentry\Laravel\Console\PublishCommand;
+
+class PublishCommandTest extends TestCase
+{
+    public function testIsEnvKeySetTreatsRegexMetacharactersAsLiterals(): void
+    {
+        $command = new PublishCommand();
+
+        $isEnvKeySetMethod = new ReflectionMethod($command, 'isEnvKeySet');
+        if (\PHP_VERSION_ID < 80100) {
+            $isEnvKeySetMethod->setAccessible(true);
+        }
+
+        $this->assertFalse((bool)$isEnvKeySetMethod->invoke(
+            $command,
+            'SENTRY.*KEY',
+            "SENTRYAKEY=true\n"
+        ));
+
+        $this->assertTrue((bool)$isEnvKeySetMethod->invoke(
+            $command,
+            'SENTRY.*KEY',
+            "SENTRY.*KEY=true\n"
+        ));
+    }
+
+    public function testEnvKeyPatternEscapesRegexMetacharactersForReplacement(): void
+    {
+        $command = new PublishCommand();
+
+        $getEnvKeyPatternMethod = new ReflectionMethod($command, 'getEnvKeyPattern');
+        if (\PHP_VERSION_ID < 80100) {
+            $getEnvKeyPatternMethod->setAccessible(true);
+        }
+
+        $pattern = $getEnvKeyPatternMethod->invoke($command, 'SENTRY.*KEY');
+
+        $updatedContents = preg_replace(
+            $pattern,
+            "SENTRY.*KEY=new\n",
+            "SENTRYAKEY=old\nSENTRY.*KEY=old\n"
+        );
+
+        $this->assertSame("SENTRYAKEY=old\nSENTRY.*KEY=new\n", $updatedContents);
+    }
+}


### PR DESCRIPTION
This PR adds `preg_quote` around environment variables for extra hardening. This is currently not an issue because we are only using a hardcoded list of environment variables, adding it will provide additional safety in case this changes in the future

closes LARAVEL-56