### PR TITLE
feat(ai): add invoke_agent tracing baseline

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -63,9 +63,11 @@ jobs:
       - name: Install Composer dependencies
         run: |
           # friendsofphp/php-cs-fixer: No need for this package to run phpunit and it conflicts with older Laravel versions
+          # laravel/ai: Only supports PHP 8.4+ and Laravel 12, remove globally and re-add below where supported
+          composer remove friendsofphp/php-cs-fixer laravel/ai --dev --no-interaction --no-update
+
           # laravel/pennant: Does not yet support Laravel 13
           # laravel/octane: Does not yet support Laravel 13
-          composer remove friendsofphp/php-cs-fixer --dev --no-interaction --no-update
           [[ "${{ matrix.packages.laravel }}" == "^13.0" ]] && composer remove laravel/pennant laravel/octane --dev --no-interaction --no-update || true
 
           # Require the correct versions we want to run phpunit for
@@ -76,11 +78,20 @@ jobs:
             "orchestra/testbench:${{ matrix.packages.testbench }}" \
             --no-interaction --no-update
 
+          # Re-require laravel/ai for supported combinations (PHP 8.4+ and Laravel 12)
+          if [ "${{ matrix.packages.laravel }}" == "^12.0" ] && ([ "${{ matrix.php }}" == "8.4" ] || [ "${{ matrix.php }}" == "8.5" ]); then
+            composer require "laravel/ai:^0.1.5" --dev --no-interaction --no-update
+          fi
+
           # Actually run the composer installation
           composer install --no-interaction --prefer-dist --no-progress
 
       - name: Run phpunit
         run: vendor/bin/phpunit --coverage-clover=coverage.xml --coverage-filter=src/Sentry
+
+      - name: Run AI integration tests
+        if: matrix.packages.laravel == '^12.0' && (matrix.php == '8.4' || matrix.php == '8.5')
+        run: vendor/bin/phpunit test/Sentry/Features/AiIntegrationTest.php
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
@@ -177,7 +188,8 @@ jobs:
           # laravel/folio: Only supported on PHP 8.1 + Laravel 10.0 and above
           # laravel/pennant: Only supported on PHP 8.1 + Laravel 10.0 and above
           # laravel/octane: Only supported on PHP 8.1 + Laravel 10.10.1 and above
-          composer remove friendsofphp/php-cs-fixer livewire/livewire laravel/folio laravel/pennant laravel/octane --dev --no-interaction --no-update
+          # laravel/ai: Only supported on PHP 8.4+ and Laravel 12
+          composer remove friendsofphp/php-cs-fixer livewire/livewire laravel/folio laravel/pennant laravel/octane laravel/ai --dev --no-interaction --no-update
 
           # Require the correct versions we want to run phpunit for
           composer require \

--- a/.github/workflows/cs.yaml
+++ b/.github/workflows/cs.yaml
@@ -24,7 +24,10 @@ jobs:
           php-version: '8.3'
 
       - name: Install dependencies
-        run: composer update --no-progress --no-interaction --prefer-dist
+        run: |
+          # laravel/ai: Only supported on PHP 8.4+
+          composer remove laravel/ai --dev --no-interaction --no-update
+          composer update --no-progress --no-interaction --prefer-dist
 
       - name: Run script
         run: vendor/bin/php-cs-fixer fix --verbose --diff --dry-run
@@ -42,7 +45,10 @@ jobs:
           php-version: '8.3'
 
       - name: Install dependencies
-        run: composer update --no-progress --no-interaction --prefer-dist
+        run: |
+          # laravel/ai: Only supported on PHP 8.4+
+          composer remove laravel/ai --dev --no-interaction --no-update
+          composer update --no-progress --no-interaction --prefer-dist
 
       - name: Run script
         run: vendor/bin/phpstan analyse

--- a/composer.json
+++ b/composer.json
@@ -37,6 +37,7 @@
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.11",
         "guzzlehttp/guzzle": "^7.2",
+        "laravel/ai": "^0.1.5",
         "laravel/folio": "^1.1",
         "laravel/framework": "^6.0 | ^7.0 | ^8.0 | ^9.0 | ^10.0 | ^11.0 | ^12.0 | ^13.0",
         "laravel/octane": "^2.15",

--- a/config/sentry.php
+++ b/config/sentry.php
@@ -128,6 +128,12 @@ return [
         // This is required to capture any spans that are created after the response has been sent like queue jobs dispatched using `dispatch(...)->afterResponse()` for example
         'continue_after_response' => env('SENTRY_TRACE_CONTINUE_AFTER_RESPONSE', true),
 
+        // Capture AI agent interactions as spans (requires laravel/ai)
+        'gen_ai' => env('SENTRY_TRACE_GEN_AI_ENABLED', true),
+
+        // Capture AI invoke_agent spans
+        'gen_ai_invoke_agent' => env('SENTRY_TRACE_GEN_AI_INVOKE_AGENT_ENABLED', true),
+
         // Enable the tracing integrations supplied by Sentry (recommended)
         'default_integrations' => env('SENTRY_TRACE_DEFAULT_INTEGRATIONS_ENABLED', true),
     ],

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -99,3 +99,23 @@ parameters:
 			message: "#^Class Laravel\\\\Lumen\\\\Application not found\\.$#"
 			count: 2
 			path: src/Sentry/Laravel/Tracing/ServiceProvider.php
+
+		-
+			message: "#^Parameter \\$event of method Sentry\\\\Laravel\\\\Features\\\\AiIntegration\\:\\:handlePromptingAgentForTracing\\(\\) has invalid type Laravel\\\\Ai\\\\Events\\\\PromptingAgent\\.$#"
+			count: 1
+			path: src/Sentry/Laravel/Features/AiIntegration.php
+
+		-
+			message: "#^Parameter \\$event of method Sentry\\\\Laravel\\\\Features\\\\AiIntegration\\:\\:handleAgentPromptedForTracing\\(\\) has invalid type Laravel\\\\Ai\\\\Events\\\\AgentPrompted\\.$#"
+			count: 1
+			path: src/Sentry/Laravel/Features/AiIntegration.php
+
+		-
+			message: "#^Parameter \\$agent of method Sentry\\\\Laravel\\\\Features\\\\AiIntegration\\:\\:resolveAgentAttribute\\(\\) has invalid type Laravel\\\\Ai\\\\Contracts\\\\Agent\\.$#"
+			count: 1
+			path: src/Sentry/Laravel/Features/AiIntegration.php
+
+		-
+			message: "#^Parameter \\$usage of method Sentry\\\\Laravel\\\\Features\\\\AiIntegration\\:\\:setTokenUsage\\(\\) has invalid type Laravel\\\\Ai\\\\Responses\\\\Data\\\\Usage\\.$#"
+			count: 1
+			path: src/Sentry/Laravel/Features/AiIntegration.php

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -10,6 +10,7 @@
     <testsuites>
         <testsuite name="Sentry Laravel Test Suite">
             <directory>./test/Sentry/</directory>
+            <exclude>./test/Sentry/Features/AiIntegrationTest.php</exclude>
         </testsuite>
     </testsuites>
 </phpunit>

--- a/src/Sentry/Laravel/Features/AiIntegration.php
+++ b/src/Sentry/Laravel/Features/AiIntegration.php
@@ -1,0 +1,240 @@
+<?php
+
+namespace Sentry\Laravel\Features;
+
+use Illuminate\Contracts\Events\Dispatcher;
+use Sentry\SentrySdk;
+use Sentry\Tracing\Span;
+use Sentry\Tracing\SpanContext;
+use Sentry\Tracing\SpanStatus;
+
+class AiIntegration extends Feature
+{
+    private const FEATURE_KEY = 'gen_ai';
+    private const MAX_TRACKED_INVOCATIONS = 100;
+
+    /** @var array<string, AiInvocationData> */
+    private $invocations = [];
+
+    public function isApplicable(): bool
+    {
+        if (!class_exists('Laravel\Ai\Events\PromptingAgent')) {
+            return false;
+        }
+
+        return $this->isTracingFeatureEnabled(self::FEATURE_KEY);
+    }
+
+    public function onBoot(Dispatcher $events): void
+    {
+        $events->listen('Laravel\Ai\Events\PromptingAgent', [$this, 'handlePromptingAgentForTracing']);
+        $events->listen('Laravel\Ai\Events\AgentPrompted', [$this, 'handleAgentPromptedForTracing']);
+        $events->listen('Laravel\Ai\Events\StreamingAgent', [$this, 'handlePromptingAgentForTracing']);
+        $events->listen('Laravel\Ai\Events\AgentStreamed', [$this, 'handleAgentPromptedForTracing']);
+    }
+
+    public function handlePromptingAgentForTracing(\Laravel\Ai\Events\PromptingAgent $event): void
+    {
+        if (!$this->isTracingFeatureEnabled('gen_ai_invoke_agent')) {
+            return;
+        }
+
+        $parentSpan = SentrySdk::getCurrentHub()->getSpan();
+        if ($parentSpan === null || !$parentSpan->getSampled()) {
+            return;
+        }
+
+        $agentName = $this->shortClassName($event->prompt->agent);
+        $model = $event->prompt->model ?? null;
+        $isStreaming = is_a($event, 'Laravel\Ai\Events\StreamingAgent');
+
+        $data = [
+            'gen_ai.operation.name' => 'invoke_agent',
+            'gen_ai.agent.name' => $agentName,
+        ];
+
+        if ($isStreaming) {
+            $data['gen_ai.response.streaming'] = true;
+        }
+
+        if ($model !== null) {
+            $data['gen_ai.request.model'] = $model;
+        }
+
+        $provider = $event->prompt->provider ?? null;
+        $providerName = $provider !== null ? $provider->name() : null;
+        if ($providerName !== null) {
+            $data['gen_ai.provider.name'] = $providerName;
+        }
+
+        $temperature = $this->resolveAgentAttribute($event->prompt->agent, 'Laravel\Ai\Attributes\Temperature');
+        if ($temperature !== null) {
+            $data['gen_ai.request.temperature'] = $temperature;
+        }
+
+        $maxTokens = $this->resolveAgentAttribute($event->prompt->agent, 'Laravel\Ai\Attributes\MaxTokens');
+        if ($maxTokens !== null) {
+            $data['gen_ai.request.max_tokens'] = $maxTokens;
+        }
+
+        $agentSpan = $parentSpan->startChild(
+            SpanContext::make()
+                ->setOp('gen_ai.invoke_agent')
+                ->setData($data)
+                ->setOrigin('auto.ai.laravel')
+                ->setDescription('invoke_agent ' . ($model ?? 'unknown'))
+        );
+
+        $this->evictOldestIfNeeded($this->invocations);
+
+        $this->invocations[$event->invocationId] = new AiInvocationData($agentSpan, $parentSpan);
+        SentrySdk::getCurrentHub()->setSpan($agentSpan);
+    }
+
+    public function handleAgentPromptedForTracing(\Laravel\Ai\Events\AgentPrompted $event): void
+    {
+        $invocationId = $event->invocationId;
+        if (!isset($this->invocations[$invocationId])) {
+            return;
+        }
+
+        $invocation = $this->invocations[$invocationId];
+        $agentSpan = $invocation->span;
+        $parentSpan = $invocation->parentSpan;
+
+        $data = $agentSpan->getData();
+
+        $responseModel = $event->response->meta->model ?? null;
+        if ($responseModel !== null) {
+            $data['gen_ai.response.model'] = $responseModel;
+        }
+
+        $responseProvider = $event->response->meta->provider ?? null;
+        if ($responseProvider !== null && !isset($data['gen_ai.provider.name'])) {
+            $data['gen_ai.provider.name'] = strtolower($responseProvider);
+        }
+
+        $usage = $event->response->usage ?? null;
+        if ($usage !== null) {
+            $this->setTokenUsage($data, $usage);
+        }
+
+        $conversationId = $event->response->conversationId ?? null;
+        if ($conversationId !== null) {
+            $data['gen_ai.conversation.id'] = $conversationId;
+        }
+
+        $agentSpan->setData($data);
+        $agentSpan->setStatus(SpanStatus::ok());
+        $agentSpan->finish();
+
+        unset($this->invocations[$invocationId]);
+
+        if ($parentSpan !== null) {
+            SentrySdk::getCurrentHub()->setSpan($parentSpan);
+        }
+    }
+
+    /**
+     * @return int|float|string|null
+     */
+    private function resolveAgentAttribute(\Laravel\Ai\Contracts\Agent $agent, string $attributeClass)
+    {
+        if (!class_exists($attributeClass) || PHP_VERSION_ID < 80000) {
+            return null;
+        }
+
+        try {
+            $reflection = new \ReflectionClass($agent);
+            $attributes = $reflection->getAttributes($attributeClass);
+            if (empty($attributes)) {
+                return null;
+            }
+
+            $instance = $attributes[0]->newInstance();
+            return $instance->value ?? null;
+        } catch (\Throwable $e) {
+            return null;
+        }
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    private function setTokenUsage(array &$data, \Laravel\Ai\Responses\Data\Usage $usage): void
+    {
+        $inputTokens = $usage->promptTokens ?? 0;
+        if ($inputTokens > 0) {
+            $data['gen_ai.usage.input_tokens'] = $inputTokens;
+        }
+
+        $outputTokens = $usage->completionTokens ?? 0;
+        if ($outputTokens > 0) {
+            $data['gen_ai.usage.output_tokens'] = $outputTokens;
+        }
+
+        $totalTokens = $inputTokens + $outputTokens;
+        if ($totalTokens > 0) {
+            $data['gen_ai.usage.total_tokens'] = $totalTokens;
+        }
+
+        $cachedTokens = $usage->cacheReadInputTokens ?? 0;
+        if ($cachedTokens > 0) {
+            $data['gen_ai.usage.input_tokens.cached'] = $cachedTokens;
+        }
+
+        $cacheWriteTokens = $usage->cacheWriteInputTokens ?? 0;
+        if ($cacheWriteTokens > 0) {
+            $data['gen_ai.usage.input_tokens.cache_write'] = $cacheWriteTokens;
+        }
+
+        $reasoningTokens = $usage->reasoningTokens ?? 0;
+        if ($reasoningTokens > 0) {
+            $data['gen_ai.usage.output_tokens.reasoning'] = $reasoningTokens;
+        }
+    }
+
+    private function shortClassName(object $obj): string
+    {
+        $parts = explode('\\', \get_class($obj));
+
+        return end($parts);
+    }
+
+    /**
+     * @param array<string, mixed> $map
+     */
+    private function evictOldestIfNeeded(array &$map): void
+    {
+        while (\count($map) >= self::MAX_TRACKED_INVOCATIONS) {
+            reset($map);
+            $oldestKey = key($map);
+            if ($oldestKey === null) {
+                break;
+            }
+
+            $oldest = $map[$oldestKey];
+            if ($oldest instanceof AiInvocationData) {
+                $oldest->span->setStatus(SpanStatus::deadlineExceeded());
+                $oldest->span->finish();
+            }
+
+            unset($map[$oldestKey]);
+        }
+    }
+}
+
+class AiInvocationData
+{
+    /** @var Span */
+    public $span;
+
+    /** @var Span|null */
+    public $parentSpan;
+
+    public function __construct(Span $span, ?Span $parentSpan)
+    {
+        $this->span = $span;
+        $this->parentSpan = $parentSpan;
+    }
+}

--- a/src/Sentry/Laravel/Features/AiIntegration.php
+++ b/src/Sentry/Laravel/Features/AiIntegration.php
@@ -11,6 +11,7 @@ use Sentry\Tracing\SpanStatus;
 class AiIntegration extends Feature
 {
     private const FEATURE_KEY = 'gen_ai';
+    private const FEATURE_KEY_INVOKE_AGENT = 'gen_ai_invoke_agent';
     private const MAX_TRACKED_INVOCATIONS = 100;
 
     /** @var array<string, AiInvocationData> */
@@ -35,7 +36,7 @@ class AiIntegration extends Feature
 
     public function handlePromptingAgentForTracing(\Laravel\Ai\Events\PromptingAgent $event): void
     {
-        if (!$this->isTracingFeatureEnabled('gen_ai_invoke_agent')) {
+        if (!$this->isTracingFeatureEnabled(self::FEATURE_KEY_INVOKE_AGENT)) {
             return;
         }
 
@@ -44,7 +45,7 @@ class AiIntegration extends Feature
             return;
         }
 
-        $agentName = $this->shortClassName($event->prompt->agent);
+        $agentName = class_basename($event->prompt->agent);
         $model = $event->prompt->model ?? null;
         $isStreaming = is_a($event, 'Laravel\Ai\Events\StreamingAgent');
 
@@ -111,7 +112,7 @@ class AiIntegration extends Feature
 
         $responseProvider = $event->response->meta->provider ?? null;
         if ($responseProvider !== null && !isset($data['gen_ai.provider.name'])) {
-            $data['gen_ai.provider.name'] = strtolower($responseProvider);
+            $data['gen_ai.provider.name'] = $responseProvider;
         }
 
         $usage = $event->response->usage ?? null;
@@ -192,13 +193,6 @@ class AiIntegration extends Feature
         if ($reasoningTokens > 0) {
             $data['gen_ai.usage.output_tokens.reasoning'] = $reasoningTokens;
         }
-    }
-
-    private function shortClassName(object $obj): string
-    {
-        $parts = explode('\\', \get_class($obj));
-
-        return end($parts);
     }
 
     /**

--- a/src/Sentry/Laravel/ServiceProvider.php
+++ b/src/Sentry/Laravel/ServiceProvider.php
@@ -77,6 +77,7 @@ class ServiceProvider extends BaseServiceProvider
         Features\PennantPackageIntegration::class,
         Features\LivewirePackageIntegration::class,
         Features\ConsoleSchedulingIntegration::class,
+        Features\AiIntegration::class,
     ];
 
     /**

--- a/test/Sentry/Features/AiIntegrationTest.php
+++ b/test/Sentry/Features/AiIntegrationTest.php
@@ -1,0 +1,990 @@
+<?php
+// Stub interfaces and classes so the test works without laravel/ai installed
+namespace Laravel\Ai\Contracts;
+
+if (!interface_exists(Agent::class)) {
+    interface Agent
+    {
+    }
+}
+
+if (!interface_exists(Tool::class)) {
+    interface Tool
+    {
+    }
+}
+
+namespace Laravel\Ai\Providers;
+
+if (!class_exists(Provider::class)) {
+    abstract class Provider
+    {
+    }
+}
+
+namespace Laravel\Ai\Contracts\Providers;
+
+if (!interface_exists(TextProvider::class)) {
+    interface TextProvider
+    {
+    }
+}
+
+if (!interface_exists(EmbeddingProvider::class)) {
+    interface EmbeddingProvider
+    {
+    }
+}
+
+namespace Laravel\Ai\Gateway;
+
+if (!class_exists(TextGenerationOptions::class)) {
+    class TextGenerationOptions
+    {
+    }
+}
+
+namespace Laravel\Ai\Contracts\Gateway;
+
+if (!interface_exists(TextGateway::class)) {
+    interface TextGateway
+    {
+    }
+}
+
+if (!interface_exists(EmbeddingGateway::class)) {
+    interface EmbeddingGateway
+    {
+    }
+}
+
+if (!class_exists(StubEmbeddingGateway::class)) {
+    class StubEmbeddingGateway implements EmbeddingGateway
+    {
+        public function generateEmbeddings($provider, string $model, array $inputs, int $dimensions): \Laravel\Ai\Responses\EmbeddingsResponse
+        {
+            return new \Laravel\Ai\Responses\EmbeddingsResponse();
+        }
+    }
+}
+
+if (!class_exists(StubTextGateway::class)) {
+    class StubTextGateway implements TextGateway
+    {
+        public function generateText(\Laravel\Ai\Contracts\Providers\TextProvider $provider, string $model, ?string $instructions, array $messages = [], array $tools = [], ?array $schema = null, ?\Laravel\Ai\Gateway\TextGenerationOptions $options = null, ?int $timeout = null): \Laravel\Ai\Responses\TextResponse
+        {
+            return new \Laravel\Ai\Responses\TextResponse();
+        }
+        public function streamText(string $invocationId, \Laravel\Ai\Contracts\Providers\TextProvider $provider, string $model, ?string $instructions, array $messages = [], array $tools = [], ?array $schema = null, ?\Laravel\Ai\Gateway\TextGenerationOptions $options = null, ?int $timeout = null): \Generator
+        {
+            yield from [];
+        }
+        public function onToolInvocation(\Closure $invoking, \Closure $invoked): self
+        {
+            return $this;
+        }
+    }
+}
+
+namespace Laravel\Ai\Responses\Data;
+
+if (!class_exists(Usage::class)) {
+    class Usage
+    {
+        public function __construct(public int $promptTokens = 0, public int $completionTokens = 0, public int $cacheWriteInputTokens = 0, public int $cacheReadInputTokens = 0, public int $reasoningTokens = 0)
+        {
+        }
+    }
+}
+
+if (!class_exists(Meta::class)) {
+    class Meta
+    {
+        public function __construct(public ?string $provider = null, public ?string $model = null)
+        {
+        }
+    }
+}
+
+namespace Laravel\Ai\Responses;
+
+if (!class_exists(TextResponse::class)) {
+    class TextResponse
+    {
+        public $messages;
+        public $toolCalls;
+        public $toolResults;
+        public $steps;
+
+        public function __construct(public string $text, public object $usage, public object $meta)
+        {
+        }
+    }
+}
+
+if (!class_exists(AgentResponse::class)) {
+    class AgentResponse extends TextResponse
+    {
+        public ?string $conversationId = null;
+
+        public function __construct(public string $invocationId, string $text, object $usage, object $meta)
+        {
+            parent::__construct($text, $usage, $meta);
+        }
+    }
+}
+
+if (!class_exists(StreamableAgentResponse::class)) {
+    class StreamableAgentResponse
+    {
+    }
+}
+
+if (!class_exists(QueuedAgentResponse::class)) {
+    class QueuedAgentResponse
+    {
+    }
+}
+
+if (!class_exists(TextResponse::class)) {
+    class TextResponse
+    {
+    }
+}
+
+if (!class_exists(EmbeddingsResponse::class)) {
+    class EmbeddingsResponse
+    {
+    }
+}
+
+namespace Laravel\Ai\Prompts;
+
+if (!class_exists(AgentPrompt::class)) {
+    class AgentPrompt
+    {
+        public function __construct(public object $agent, public string $prompt, public array $attachments = [], public ?object $provider = null, public ?string $model = null)
+        {
+        }
+    }
+}
+
+if (!class_exists(EmbeddingsPrompt::class)) {
+    class EmbeddingsPrompt
+    {
+        public function __construct(public array $inputs = [], public ?int $dimensions = null, public ?object $provider = null, public ?string $model = null)
+        {
+        }
+    }
+}
+
+namespace Laravel\Ai\Events;
+
+if (!class_exists(PromptingAgent::class)) {
+    class PromptingAgent
+    {
+        public function __construct(public string $invocationId, public object $prompt)
+        {
+        }
+    }
+}
+if (!class_exists(AgentPrompted::class)) {
+    class AgentPrompted
+    {
+        public function __construct(public string $invocationId, public object $prompt, public object $response)
+        {
+        }
+    }
+}
+if (!class_exists(InvokingTool::class)) {
+    class InvokingTool
+    {
+        public function __construct(public string $invocationId, public string $toolInvocationId, public object $agent, public object $tool, public array $arguments)
+        {
+        }
+    }
+}
+if (!class_exists(ToolInvoked::class)) {
+    class ToolInvoked
+    {
+        public function __construct(public string $invocationId, public string $toolInvocationId, public object $agent, public object $tool, public array $arguments, public $result)
+        {
+        }
+    }
+}
+if (!class_exists(StreamingAgent::class)) {
+    class StreamingAgent extends PromptingAgent
+    {
+    }
+}
+if (!class_exists(AgentStreamed::class)) {
+    class AgentStreamed extends AgentPrompted
+    {
+    }
+}
+if (!class_exists(GeneratingEmbeddings::class)) {
+    class GeneratingEmbeddings
+    {
+        public function __construct(public string $invocationId, public object $provider, public string $model, public object $prompt)
+        {
+        }
+    }
+}
+if (!class_exists(EmbeddingsGenerated::class)) {
+    class EmbeddingsGenerated
+    {
+        public function __construct(public string $invocationId, public object $provider, public string $model, public object $prompt, public object $response)
+        {
+        }
+    }
+}
+
+namespace Laravel\Ai\Attributes;
+
+if (!class_exists(Temperature::class)) {
+    #[\Attribute(\Attribute::TARGET_CLASS)] class Temperature
+    {
+        public function __construct(public float $value)
+        {
+        }
+    }
+}
+if (!class_exists(MaxTokens::class)) {
+    #[\Attribute(\Attribute::TARGET_CLASS)] class MaxTokens
+    {
+        public function __construct(public int $value)
+        {
+        }
+    }
+}
+
+namespace Laravel\Ai\Files;
+
+if (!class_exists(File::class)) {
+    abstract class File
+    {
+        public ?string $name = null;
+        public function name(): ?string
+        {
+            return $this->name;
+        } public function as(?string $name): static
+        {
+            $this->name = $name;
+            return $this;
+        }
+    }
+}
+if (!class_exists(Image::class)) {
+    abstract class Image extends File
+    {
+    }
+}
+if (!class_exists(Document::class)) {
+    abstract class Document extends File
+    {
+    }
+}
+
+namespace Sentry\Laravel\Tests\Features\AiStubs;
+
+use Laravel\Ai\Attributes\MaxTokens;
+use Laravel\Ai\Attributes\Temperature;
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Contracts\Providers\EmbeddingProvider;
+use Laravel\Ai\Contracts\Providers\TextProvider;
+use Laravel\Ai\Contracts\Tool;
+use Laravel\Ai\Responses\AgentResponse;
+use Laravel\Ai\Responses\QueuedAgentResponse;
+use Laravel\Ai\Responses\StreamableAgentResponse;
+
+class TestAgent implements Agent
+{
+    public function instructions(): string
+    {
+        return 'You are a helpful assistant.';
+    }
+    public function tools(): array
+    {
+        return [new WeatherLookup()];
+    }
+    public function prompt(string $prompt, array $attachments = [], array|string|null $provider = null, ?string $model = null): AgentResponse
+    {
+        return new AgentResponse();
+    }
+    public function stream(string $prompt, array $attachments = [], array|string|null $provider = null, ?string $model = null): StreamableAgentResponse
+    {
+        return new StreamableAgentResponse();
+    }
+    public function queue(string $prompt, array $attachments = [], array|string|null $provider = null, ?string $model = null): QueuedAgentResponse
+    {
+        return new QueuedAgentResponse();
+    }
+    public function respond(...$args)
+    {
+        return null;
+    }
+    public function streamRespond(...$args)
+    {
+        return null;
+    }
+    public function queueRespond(...$args)
+    {
+        return null;
+    }
+    public function broadcast(string $prompt, $channels, array $attachments = [], bool $now = false, array|string|null $provider = null, ?string $model = null): StreamableAgentResponse
+    {
+        return new StreamableAgentResponse();
+    }
+    public function broadcastNow(string $prompt, $channels, array $attachments = [], array|string|null $provider = null, ?string $model = null): StreamableAgentResponse
+    {
+        return new StreamableAgentResponse();
+    }
+    public function broadcastOnQueue(string $prompt, $channels, array $attachments = [], array|string|null $provider = null, ?string $model = null): QueuedAgentResponse
+    {
+        return new QueuedAgentResponse();
+    }
+}
+#[Temperature(0.7)] #[MaxTokens(4096)]
+class TestAgentWithConfig implements Agent
+{
+    public function instructions(): string
+    {
+        return 'You are a configured assistant.';
+    }
+    public function tools(): array
+    {
+        return [];
+    }
+    public function prompt(string $prompt, array $attachments = [], array|string|null $provider = null, ?string $model = null): AgentResponse
+    {
+        return new AgentResponse();
+    }
+    public function stream(string $prompt, array $attachments = [], array|string|null $provider = null, ?string $model = null): StreamableAgentResponse
+    {
+        return new StreamableAgentResponse();
+    }
+    public function queue(string $prompt, array $attachments = [], array|string|null $provider = null, ?string $model = null): QueuedAgentResponse
+    {
+        return new QueuedAgentResponse();
+    }
+    public function respond(...$args)
+    {
+        return null;
+    }
+    public function streamRespond(...$args)
+    {
+        return null;
+    }
+    public function queueRespond(...$args)
+    {
+        return null;
+    }
+    public function broadcast(string $prompt, $channels, array $attachments = [], bool $now = false, array|string|null $provider = null, ?string $model = null): StreamableAgentResponse
+    {
+        return new StreamableAgentResponse();
+    }
+    public function broadcastNow(string $prompt, $channels, array $attachments = [], array|string|null $provider = null, ?string $model = null): StreamableAgentResponse
+    {
+        return new StreamableAgentResponse();
+    }
+    public function broadcastOnQueue(string $prompt, $channels, array $attachments = [], array|string|null $provider = null, ?string $model = null): QueuedAgentResponse
+    {
+        return new QueuedAgentResponse();
+    }
+}
+class WeatherLookup implements Tool
+{
+    public function name(): string
+    {
+        return 'WeatherLookup';
+    }
+    public function description(): string
+    {
+        return 'Looks up the current weather for a given location.';
+    }
+    public function schema(\Illuminate\Contracts\JsonSchema\JsonSchema $schema): array
+    {
+        return ['location' => $schema->string()->description('The city and state, e.g. San Francisco, CA')->required(), 'unit' => $schema->string()->enum(['celsius', 'fahrenheit'])];
+    }
+    public function handle($request): string
+    {
+        return 'Sunny, 22°C';
+    }
+}
+class TestProvider extends \Laravel\Ai\Providers\Provider implements TextProvider, EmbeddingProvider
+{
+    public function __construct()
+    {
+        // Override parent constructor to allow no-arg instantiation
+    }
+
+    public function driver(): string
+    {
+        return 'openai';
+    }
+    public function name(): string
+    {
+        return 'openai';
+    }
+    public function prompt(\Laravel\Ai\Prompts\AgentPrompt $prompt): \Laravel\Ai\Responses\AgentResponse
+    {
+        return new \Laravel\Ai\Responses\AgentResponse();
+    }
+    public function stream(\Laravel\Ai\Prompts\AgentPrompt $prompt): \Laravel\Ai\Responses\StreamableAgentResponse
+    {
+        return new \Laravel\Ai\Responses\StreamableAgentResponse();
+    }
+    public function textGateway(): \Laravel\Ai\Contracts\Gateway\TextGateway
+    {
+        return new \Laravel\Ai\Contracts\Gateway\StubTextGateway();
+    }
+    public function chat(...$args)
+    {
+        return null;
+    }
+    public function promptStreamed(...$args)
+    {
+        return null;
+    }
+    public function chatStreamed(...$args)
+    {
+        return null;
+    }
+    public function textModel()
+    {
+        return null;
+    }
+    public function useTextGateway(\Laravel\Ai\Contracts\Gateway\TextGateway $gateway): self
+    {
+        return $this;
+    }
+    public function defaultTextModel(): string
+    {
+        return 'gpt-4o';
+    }
+    public function cheapestTextModel(): string
+    {
+        return 'gpt-4o-mini';
+    }
+    public function smartestTextModel(): string
+    {
+        return 'gpt-4o';
+    }
+    public function embeddings(array $inputs, ?int $dimensions = null, ?string $model = null): \Laravel\Ai\Responses\EmbeddingsResponse
+    {
+        return new \Laravel\Ai\Responses\EmbeddingsResponse();
+    }
+    public function embeddingGateway(): \Laravel\Ai\Contracts\Gateway\EmbeddingGateway
+    {
+        return new \Laravel\Ai\Contracts\Gateway\StubEmbeddingGateway();
+    }
+    public function useEmbeddingGateway($gateway): self
+    {
+        return $this;
+    }
+    public function defaultEmbeddingModel(): string
+    {
+        return 'text-embedding-3-small';
+    }
+    public function cheapestEmbeddingModel(): string
+    {
+        return 'text-embedding-3-small';
+    }
+    public function defaultEmbeddingsDimensions(): int
+    {
+        return 1536;
+    }
+    public function defaultEmbeddingsModel(): string
+    {
+        return 'text-embedding-3-small';
+    }
+}
+class TestToolCall
+{
+    public function __construct(public string $name, public array $arguments = [])
+    {
+    }
+}
+class TestToolResult
+{
+    public function __construct(public string $name, public $result)
+    {
+    }
+}
+class TestLocalImage extends \Laravel\Ai\Files\Image
+{
+    public function __construct(public string $path, public ?string $mime = null)
+    {
+    }
+    public function mimeType(): ?string
+    {
+        return $this->mime;
+    }
+    public function name(): ?string
+    {
+        return $this->name ?? basename($this->path);
+    }
+    public function toArray(): array
+    {
+        return ['type' => 'local-image', 'name' => $this->name(), 'path' => $this->path, 'mime' => $this->mime];
+    }
+}
+class TestRemoteImage extends \Laravel\Ai\Files\RemoteImage
+{
+}
+namespace Sentry\Laravel\Tests\Features;
+
+use Illuminate\Http\Client\Events\ConnectionFailed;
+use Illuminate\Http\Client\Events\RequestSending;
+use Illuminate\Http\Client\Events\ResponseReceived;
+use Illuminate\Http\Client\Request as HttpRequest;
+use Illuminate\Http\Client\Response as HttpResponse;
+use Laravel\Ai\Events\PromptingAgent;
+use Laravel\Ai\Events\AgentPrompted;
+use Laravel\Ai\Events\StreamingAgent;
+use Laravel\Ai\Events\AgentStreamed;
+use Laravel\Ai\Events\InvokingTool;
+use Laravel\Ai\Events\ToolInvoked;
+use Laravel\Ai\Events\GeneratingEmbeddings;
+use Laravel\Ai\Events\EmbeddingsGenerated;
+use Sentry\Laravel\Tests\Features\AiStubs\TestAgent;
+use Sentry\Laravel\Tests\Features\AiStubs\TestAgentWithConfig;
+use Sentry\Laravel\Tests\Features\AiStubs\TestProvider;
+use Sentry\Laravel\Tests\Features\AiStubs\TestToolCall;
+use Sentry\Laravel\Tests\Features\AiStubs\TestToolResult;
+use Laravel\Ai\Responses\Data\Usage;
+use Sentry\Laravel\Tests\Features\AiStubs\WeatherLookup;
+use Sentry\Laravel\Tests\Features\AiStubs\TestLocalImage;
+use Sentry\Laravel\Tests\Features\AiStubs\TestRemoteImage;
+use Sentry\Laravel\Tests\TestCase;
+use Sentry\Tracing\Span;
+use Sentry\Tracing\SpanStatus;
+
+class AiIntegrationTest extends TestCase
+{
+    private const PROVIDER_URL = 'https://api.openai.com/v1';
+    protected $defaultSetupConfig = ['sentry.tracing.http_client_requests' => false];
+    protected function setUp(): void
+    {
+        if (\PHP_VERSION_ID < 80400) {
+            $this->markTestSkipped('Laravel AI requires PHP 8.4+.');
+        }
+        if (version_compare(\Illuminate\Foundation\Application::VERSION, '12', '<')) {
+            $this->markTestSkipped('Laravel AI requires Laravel 12+.');
+        }
+        parent::setUp();
+        config(['prism.providers.openai.url' => self::PROVIDER_URL]);
+    }
+
+    public function testAgentSpanIsRecorded(): void
+    {
+        $spans = $this->runAgentFlow($this->makePromptAndResponse());
+        $this->assertCount(2, $spans); // transaction + invoke_agent
+        $agentSpan = $spans[1];
+        $this->assertEquals('gen_ai.invoke_agent', $agentSpan->getOp());
+        $this->assertEquals('invoke_agent gpt-4o', $agentSpan->getDescription());
+        $this->assertEquals(SpanStatus::ok(), $agentSpan->getStatus());
+        $this->assertEquals('auto.ai.laravel', $agentSpan->getOrigin());
+        $data = $agentSpan->getData();
+        $this->assertEquals('invoke_agent', $data['gen_ai.operation.name']);
+        $this->assertEquals('TestAgent', $data['gen_ai.agent.name']);
+        $this->assertEquals('gpt-4o', $data['gen_ai.request.model']);
+        $this->assertEquals('gpt-4o-2024-08-06', $data['gen_ai.response.model']);
+        $this->assertEquals('conv-abc-123', $data['gen_ai.conversation.id']);
+    }
+
+    public function testAgentSpanCapturesTokenUsageAndRequestParams(): void
+    {
+        // Token usage
+        $spans = $this->runAgentFlow($this->makePromptAndResponse(promptTokens: 100, completionTokens: 50, cacheReadInputTokens: 20, reasoningTokens: 15));
+        $data = $spans[1]->getData();
+        $this->assertEquals(100, $data['gen_ai.usage.input_tokens']);
+        $this->assertEquals(50, $data['gen_ai.usage.output_tokens']);
+        $this->assertEquals(150, $data['gen_ai.usage.total_tokens']);
+        $this->assertEquals(20, $data['gen_ai.usage.input_tokens.cached']);
+        $this->assertEquals(15, $data['gen_ai.usage.output_tokens.reasoning']);
+        // Request parameters from attributes
+        $spans = $this->runAgentFlow($this->makePromptAndResponse(agentClass: TestAgentWithConfig::class));
+        $data = $spans[1]->getData();
+        $this->assertEquals(0.7, $data['gen_ai.request.temperature']);
+        $this->assertEquals(4096, $data['gen_ai.request.max_tokens']);
+    }
+
+    public function testPiiControlsMessageCapture(): void
+    {
+        $this->markTestSkipped('Covered in stacked PR4 (messages + redaction).');
+
+        // PII enabled: messages captured
+        $this->resetApplicationWithConfig(['sentry.send_default_pii' => true, 'prism.providers.openai.url' => self::PROVIDER_URL]);
+        $spans = $this->runAgentFlow($this->makePromptAndResponse());
+        $data = $spans[1]->getData();
+        $input = json_decode($data['gen_ai.input.messages'], true);
+        $this->assertEquals('user', $input[0]['role']);
+        $this->assertStringContainsString('Analyze this', $input[0]['parts'][0]['content']);
+        $this->assertEquals('You are a helpful assistant.', $data['gen_ai.system_instructions']);
+        $output = json_decode($data['gen_ai.output.messages'], true);
+        $this->assertEquals('assistant', $output[0]['role']);
+        // PII disabled: messages omitted
+        $this->resetApplicationWithConfig(['sentry.send_default_pii' => false, 'prism.providers.openai.url' => self::PROVIDER_URL]);
+        $spans = $this->runAgentFlow($this->makePromptAndResponse());
+        $data = $spans[1]->getData();
+        $this->assertArrayNotHasKey('gen_ai.input.messages', $data);
+        $this->assertArrayNotHasKey('gen_ai.system_instructions', $data);
+        $this->assertArrayNotHasKey('gen_ai.output.messages', $data);
+    }
+
+    public function testTracingDisabledRecordsNoSpans(): void
+    {
+        $this->resetApplicationWithConfig(['sentry.tracing.gen_ai' => false, 'prism.providers.openai.url' => self::PROVIDER_URL]);
+        $spans = $this->runAgentFlow($this->makePromptAndResponse());
+        $this->assertCount(1, $spans);
+    }
+
+    public function testChatSpanIsCreatedWithStepData(): void
+    {
+        $this->markTestSkipped('Covered in stacked PR2 (chat spans).');
+
+        $transaction = $this->startTransaction();
+        [$prompt, $response] = $this->makePromptAndResponse(promptTokens: 100, completionTokens: 50);
+        $this->dispatchAgentFlow('inv-c', $prompt, $response);
+        $chatSpans = $this->findAllSpansByOp($transaction, 'gen_ai.chat');
+        $this->assertCount(1, $chatSpans);
+        $data = $chatSpans[0]->getData();
+        $this->assertEquals('chat', $data['gen_ai.operation.name']);
+        $this->assertEquals('gpt-4o', $data['gen_ai.request.model']);
+        $this->assertEquals('gpt-4o-2024-08-06', $data['gen_ai.response.model']);
+        $this->assertEquals('stop', $data['gen_ai.response.finish_reasons']);
+        $this->assertEquals(100, $data['gen_ai.usage.input_tokens']);
+        $this->assertEquals('conv-abc-123', $data['gen_ai.conversation.id']);
+    }
+
+    public function testMultiStepFlowWithToolCalls(): void
+    {
+        $this->markTestSkipped('Covered in stacked PR3 (tool spans).');
+
+        $transaction = $this->startTransaction();
+        [$prompt, $response] = $this->makeMultiStepPromptAndResponse();
+        $agent = new TestAgent();
+        $tool = new WeatherLookup();
+        $this->dispatchLaravelEvent(new PromptingAgent('inv-m', $prompt));
+        $this->dispatchLlmHttpEvents();
+        $this->dispatchLaravelEvent(new InvokingTool('inv-m', 'tool-1', $agent, $tool, ['city' => 'Paris']));
+        $this->dispatchLaravelEvent(new ToolInvoked('inv-m', 'tool-1', $agent, $tool, ['city' => 'Paris'], 'Sunny, 22C'));
+        $this->dispatchLlmHttpEvents();
+        $this->dispatchLaravelEvent(new AgentPrompted('inv-m', $prompt, $this->wrapResponse($response)));
+        $spans = $transaction->getSpanRecorder()->getSpans();
+        $this->assertCount(5, $spans); // transaction + invoke_agent + chat#0 + tool + chat#1
+        $this->assertEquals('gen_ai.invoke_agent', $spans[1]->getOp());
+        $this->assertEquals('gen_ai.chat', $spans[2]->getOp());
+        $this->assertEquals('gen_ai.execute_tool', $spans[3]->getOp());
+        $this->assertEquals('gen_ai.chat', $spans[4]->getOp());
+        $chatSpans = $this->findAllSpansByOp($transaction, 'gen_ai.chat');
+        $this->assertEquals('tool_calls', $chatSpans[0]->getData()['gen_ai.response.finish_reasons']);
+        $this->assertEquals('stop', $chatSpans[1]->getData()['gen_ai.response.finish_reasons']);
+    }
+
+    public function testToolSpanCapturesMetadataAndPiiControl(): void
+    {
+        $this->markTestSkipped('Covered in stacked PR3 (tool spans).');
+
+        // With PII: arguments and result captured
+        $this->resetApplicationWithConfig(['sentry.send_default_pii' => true, 'prism.providers.openai.url' => self::PROVIDER_URL]);
+        $transaction = $this->startTransaction();
+        [$prompt, $response] = $this->makePromptAndResponse();
+        $agent = new TestAgent();
+        $tool = new WeatherLookup();
+        $this->dispatchLaravelEvent(new PromptingAgent('inv-t1', $prompt));
+        $this->dispatchLlmHttpEvents();
+        $this->dispatchLaravelEvent(new InvokingTool('inv-t1', 'tool-1', $agent, $tool, ['query' => 'weather in Paris']));
+        $this->dispatchLaravelEvent(new ToolInvoked('inv-t1', 'tool-1', $agent, $tool, ['query' => 'weather in Paris'], 'Sunny, 22C'));
+        $this->dispatchLlmHttpEvents();
+        $this->dispatchLaravelEvent(new AgentPrompted('inv-t1', $prompt, $this->wrapResponse($response)));
+        $toolSpan = $this->findSpanByOp($transaction, 'gen_ai.execute_tool');
+        $this->assertEquals('execute_tool WeatherLookup', $toolSpan->getDescription());
+        $data = $toolSpan->getData();
+        $this->assertEquals('WeatherLookup', $data['gen_ai.tool.name']);
+        $this->assertEquals('function', $data['gen_ai.tool.type']);
+        $this->assertEquals('TestAgent', $data['gen_ai.agent.name']);
+        $this->assertEquals('{"query":"weather in Paris"}', $data['gen_ai.tool.call.arguments']);
+        $this->assertEquals('Sunny, 22C', $data['gen_ai.tool.call.result']);
+        // Without PII: arguments and result omitted
+        $this->resetApplicationWithConfig(['sentry.send_default_pii' => false, 'prism.providers.openai.url' => self::PROVIDER_URL]);
+        $transaction = $this->startTransaction();
+        [$prompt, $response] = $this->makePromptAndResponse();
+        $this->dispatchLaravelEvent(new PromptingAgent('inv-t2', $prompt));
+        $this->dispatchLlmHttpEvents();
+        $this->dispatchLaravelEvent(new InvokingTool('inv-t2', 'tool-2', $agent, $tool, ['q' => 'secret']));
+        $this->dispatchLaravelEvent(new ToolInvoked('inv-t2', 'tool-2', $agent, $tool, ['q' => 'secret'], 'secret'));
+        $this->dispatchLlmHttpEvents();
+        $this->dispatchLaravelEvent(new AgentPrompted('inv-t2', $prompt, $this->wrapResponse($response)));
+        $data = $this->findSpanByOp($transaction, 'gen_ai.execute_tool')->getData();
+        $this->assertArrayNotHasKey('gen_ai.tool.call.arguments', $data);
+        $this->assertArrayNotHasKey('gen_ai.tool.call.result', $data);
+    }
+
+    public function testStreamingAgentHasStreamingFlag(): void
+    {
+        $transaction = $this->startTransaction();
+        [$prompt, $response] = $this->makeStreamingPromptAndResponse();
+        $this->dispatchLaravelEvent(new StreamingAgent('inv-s', $prompt));
+        $this->dispatchLlmHttpEvents();
+        $this->dispatchLaravelEvent(new AgentStreamed('inv-s', $prompt, $this->wrapResponse($response)));
+        $this->assertTrue($transaction->getSpanRecorder()->getSpans()[1]->getData()['gen_ai.response.streaming']);
+    }
+
+    public function testEmbeddingsSpanIsRecorded(): void
+    {
+        $this->markTestSkipped('Covered in stacked PR5 (embeddings).');
+
+        $transaction = $this->startTransaction();
+        [$provider, $prompt, $response] = $this->makeEmbeddingsPromptAndResponse();
+        $this->dispatchLaravelEvent(new GeneratingEmbeddings('emb-1', $provider, 'text-embedding-3-small', $prompt));
+        $this->dispatchLaravelEvent(new EmbeddingsGenerated('emb-1', $provider, 'text-embedding-3-small', $prompt, $this->wrapEmbeddingsResponse($response)));
+        $span = $transaction->getSpanRecorder()->getSpans()[1];
+        $this->assertEquals('gen_ai.embeddings', $span->getOp());
+        $this->assertEquals('embeddings text-embedding-3-small', $span->getDescription());
+        $data = $span->getData();
+        $this->assertEquals('text-embedding-3-small', $data['gen_ai.request.model']);
+        $this->assertEquals('text-embedding-3-small-2024', $data['gen_ai.response.model']);
+        $this->assertEquals('openai', $data['gen_ai.provider.name']);
+        $this->assertEquals(25, $data['gen_ai.usage.input_tokens']);
+    }
+
+    public function testEmbeddingsPiiControl(): void
+    {
+        $this->markTestSkipped('Covered in stacked PR5 (embeddings).');
+
+        // With PII: inputs captured
+        $this->resetApplicationWithConfig(['sentry.send_default_pii' => true, 'sentry.tracing.http_client_requests' => false, 'prism.providers.openai.url' => self::PROVIDER_URL]);
+        $transaction = $this->startTransaction();
+        [$provider, $prompt, $response] = $this->makeEmbeddingsPromptAndResponse();
+        $this->dispatchLaravelEvent(new GeneratingEmbeddings('emb-2', $provider, 'text-embedding-3-small', $prompt));
+        $this->dispatchLaravelEvent(new EmbeddingsGenerated('emb-2', $provider, 'text-embedding-3-small', $prompt, $this->wrapEmbeddingsResponse($response)));
+        $inputs = json_decode($transaction->getSpanRecorder()->getSpans()[1]->getData()['gen_ai.embeddings.input'], true);
+        $this->assertCount(2, $inputs);
+        $this->assertEquals('Napa Valley has great wine.', $inputs[0]);
+        // Without PII: inputs omitted
+        $this->resetApplicationWithConfig(['sentry.send_default_pii' => false, 'sentry.tracing.http_client_requests' => false, 'prism.providers.openai.url' => self::PROVIDER_URL]);
+        $transaction = $this->startTransaction();
+        [$provider, $prompt, $response] = $this->makeEmbeddingsPromptAndResponse();
+        $this->dispatchLaravelEvent(new GeneratingEmbeddings('emb-3', $provider, 'text-embedding-3-small', $prompt));
+        $this->dispatchLaravelEvent(new EmbeddingsGenerated('emb-3', $provider, 'text-embedding-3-small', $prompt, $this->wrapEmbeddingsResponse($response)));
+        $this->assertArrayNotHasKey('gen_ai.embeddings.input', $transaction->getSpanRecorder()->getSpans()[1]->getData());
+    }
+
+    public function testBinaryContentIsRedacted(): void
+    {
+        $this->markTestSkipped('Covered in stacked PR4 (messages + redaction).');
+
+        $this->resetApplicationWithConfig(['sentry.send_default_pii' => true, 'prism.providers.openai.url' => self::PROVIDER_URL]);
+        $dataUri = 'data:image/png;base64,' . str_repeat('iVBORw0KGgoAAAANSUhEUgAA', 100);
+        $spans = $this->runAgentFlow($this->makePromptAndResponse(promptText: $dataUri));
+        $input = json_decode($this->findSpanByOpInSpans($spans, 'gen_ai.invoke_agent')->getData()['gen_ai.input.messages'], true);
+        $this->assertEquals('[Blob substitute]', $input[0]['parts'][0]['content']);
+    }
+
+    public function testAttachmentHandling(): void
+    {
+        $this->markTestSkipped('Covered in stacked PR4 (attachments).');
+
+        $this->resetApplicationWithConfig(['sentry.send_default_pii' => true, 'prism.providers.openai.url' => self::PROVIDER_URL]);
+        $transaction = $this->startTransaction();
+        $agent = new TestAgent();
+        $provider = new TestProvider();
+        $prompt = new \Laravel\Ai\Prompts\AgentPrompt($agent, 'Compare images.', collect([new TestLocalImage('/tmp/photo.png', 'image/png'), new TestRemoteImage('https://example.com/photo.jpg', 'image/jpeg')]), $provider, 'gpt-4o');
+        $step = (object)['text' => 'Done.', 'toolCalls' => [], 'toolResults' => [], 'finishReason' => (object)['value' => 'stop'],
+            'usage' => new Usage(100, 20), 'meta' => (object)['provider' => 'openai', 'model' => 'gpt-4o-2024-08-06']];
+        $response = (object)['text' => 'Done.', 'toolCalls' => [], 'toolResults' => [], 'steps' => [$step],
+            'usage' => new Usage(100, 20), 'meta' => (object)['provider' => 'openai', 'model' => 'gpt-4o-2024-08-06'], 'conversationId' => 'conv-img'];
+        $this->dispatchAgentFlow('inv-a', $prompt, $response);
+        $parts = json_decode($this->findSpanByOp($transaction, 'gen_ai.invoke_agent')->getData()['gen_ai.input.messages'], true)[0]['parts'];
+        $this->assertCount(3, $parts); // text + local blob + remote uri
+        $this->assertEquals('text', $parts[0]['type']);
+        $this->assertEquals('blob', $parts[1]['type']);
+        $this->assertEquals('[Blob substitute]', $parts[1]['content']);
+        $this->assertEquals('image', $parts[1]['modality']);
+        $this->assertEquals('uri', $parts[2]['type']);
+        $this->assertEquals('https://example.com/photo.jpg', $parts[2]['content']);
+    }
+
+    public function testGranularSpanTypeDisabling(): void
+    {
+        $this->markTestSkipped('Covered across stacked PR2/PR3/PR5.');
+
+        // Disable invoke_agent -> no agent or chat spans
+        $this->resetApplicationWithConfig(['sentry.tracing.gen_ai_invoke_agent' => false, 'prism.providers.openai.url' => self::PROVIDER_URL]);
+        $spans = $this->runAgentFlow($this->makePromptAndResponse());
+        $this->assertEmpty(array_filter($spans, fn ($s) => $s->getOp() === 'gen_ai.invoke_agent'));
+        $this->assertEmpty(array_filter($spans, fn ($s) => $s->getOp() === 'gen_ai.chat'));
+        // Disable chat -> agent span still created, no chat
+        $this->resetApplicationWithConfig(['sentry.tracing.gen_ai_chat' => false, 'prism.providers.openai.url' => self::PROVIDER_URL]);
+        $transaction = $this->startTransaction();
+        [$prompt, $response] = $this->makePromptAndResponse();
+        $this->dispatchAgentFlow('inv-gc', $prompt, $response);
+        $this->assertCount(1, $this->findAllSpansByOp($transaction, 'gen_ai.invoke_agent'));
+        $this->assertCount(0, $this->findAllSpansByOp($transaction, 'gen_ai.chat'));
+    }
+
+    public function testEdgeCases(): void
+    {
+        $this->markTestSkipped('Covered in stacked PR2 (chat edge cases).');
+
+        // Orphaned events don't crash
+        $transaction = $this->startTransaction();
+        [$prompt, $response] = $this->makePromptAndResponse();
+        $this->dispatchLaravelEvent(new AgentPrompted('inv-orphan', $prompt, $this->wrapResponse($response)));
+        $this->dispatchLaravelEvent(new ToolInvoked('inv-orphan', 'tool-orphan', new TestAgent(), new WeatherLookup(), [], 'result'));
+        $this->assertCount(1, $transaction->getSpanRecorder()->getSpans());
+        // Connection failure finishes chat span with error
+        $transaction = $this->startTransaction();
+        [$prompt] = $this->makePromptAndResponse();
+        $this->dispatchLaravelEvent(new PromptingAgent('inv-f', $prompt));
+        $this->dispatchLlmRequestSending();
+        $httpReq = new HttpRequest(new \GuzzleHttp\Psr7\Request('POST', self::PROVIDER_URL . '/responses', [], '{}'));
+        $this->dispatchLaravelEvent(new ConnectionFailed($httpReq, new \Illuminate\Http\Client\ConnectionException('timeout')));
+        $chatSpans = $this->findAllSpansByOp($transaction, 'gen_ai.chat');
+        $this->assertCount(1, $chatSpans);
+        $this->assertEquals(SpanStatus::internalError(), $chatSpans[0]->getStatus());
+    }
+
+    // ---- Helpers ----
+
+    private function runAgentFlow(array $pr, string $id = 'inv-x'): array
+    {
+        $t = $this->startTransaction();
+        $this->dispatchAgentFlow($id, $pr[0], $pr[1]);
+        return $t->getSpanRecorder()->getSpans();
+    }
+    private function dispatchAgentFlow(string $id, object $prompt, object $response): void
+    {
+        $this->dispatchLaravelEvent(new PromptingAgent($id, $prompt));
+        $this->dispatchLlmHttpEvents();
+        $wrappedResponse = $this->wrapResponse($response);
+        $this->dispatchLaravelEvent(new AgentPrompted($id, $prompt, $wrappedResponse));
+    }
+
+    private function wrapResponse(object $response): object
+    {
+        if ($response instanceof \Laravel\Ai\Responses\AgentResponse) {
+            return $response;
+        }
+        $usage = new Usage(
+            $response->usage->promptTokens ?? 0,
+            $response->usage->completionTokens ?? 0,
+            $response->usage->cacheWriteInputTokens ?? 0,
+            $response->usage->cacheReadInputTokens ?? 0,
+            $response->usage->reasoningTokens ?? 0
+        );
+        $meta = new \Laravel\Ai\Responses\Data\Meta(
+            $response->meta->provider ?? null,
+            $response->meta->model ?? null
+        );
+        $wrapped = new \Laravel\Ai\Responses\AgentResponse(
+            $response->conversationId ?? 'test-inv',
+            $response->text ?? '',
+            $usage,
+            $meta
+        );
+        $wrapped->conversationId = $response->conversationId ?? null;
+        if (isset($response->steps)) {
+            $wrapped->steps = collect($response->steps);
+        }
+        if (isset($response->toolCalls)) {
+            $wrapped->toolCalls = collect($response->toolCalls);
+        }
+        if (isset($response->toolResults)) {
+            $wrapped->toolResults = collect($response->toolResults);
+        }
+        return $wrapped;
+    }
+
+    private function wrapEmbeddingsResponse(object $response): \Laravel\Ai\Responses\EmbeddingsResponse
+    {
+        $meta = new \Laravel\Ai\Responses\Data\Meta(
+            $response->meta->provider ?? null,
+            $response->meta->model ?? null
+        );
+        return new \Laravel\Ai\Responses\EmbeddingsResponse(
+            $response->embeddings ?? [],
+            $response->tokens ?? 0,
+            $meta
+        );
+    }
+    private function makePromptAndResponse(int $promptTokens = 60, int $completionTokens = 130, int $cacheReadInputTokens = 0, int $reasoningTokens = 0, string $agentClass = TestAgent::class, string $promptText = 'Analyze this transcript'): array
+    {
+        $agent = new $agentClass();
+        $provider = new TestProvider();
+        $usage = new Usage($promptTokens, $completionTokens, 0, $cacheReadInputTokens, $reasoningTokens);
+        $meta = (object)['provider' => 'openai', 'model' => 'gpt-4o-2024-08-06'];
+        $prompt = new \Laravel\Ai\Prompts\AgentPrompt($agent, $promptText, [], $provider, 'gpt-4o');
+        $step = (object)['text' => 'The analysis shows positive trends.', 'toolCalls' => [], 'toolResults' => [], 'finishReason' => (object)['value' => 'stop'], 'usage' => $usage, 'meta' => $meta];
+        $response = (object)['text' => 'The analysis shows positive trends.', 'toolCalls' => [], 'toolResults' => [], 'steps' => [$step], 'usage' => $usage, 'meta' => $meta, 'conversationId' => 'conv-abc-123'];
+        return [$prompt, $response];
+    }
+
+    private function makeMultiStepPromptAndResponse(): array
+    {
+        $agent = new TestAgent();
+        $provider = new TestProvider();
+        $meta = (object)['provider' => 'openai', 'model' => 'gpt-4o-2024-08-06'];
+        $prompt = new \Laravel\Ai\Prompts\AgentPrompt($agent, 'What is the weather in Paris?', [], $provider, 'gpt-4o');
+        $tc = new TestToolCall('WeatherLookup', ['city' => 'Paris']);
+        $tr = new TestToolResult('WeatherLookup', 'Sunny, 22C');
+        $step1 = (object)['text' => '', 'toolCalls' => [$tc], 'toolResults' => [$tr], 'finishReason' => (object)['value' => 'tool_calls'], 'usage' => new Usage(60, 20), 'meta' => $meta];
+        $step2 = (object)['text' => 'Sunny and 22 degrees.', 'toolCalls' => [], 'toolResults' => [], 'finishReason' => (object)['value' => 'stop'], 'usage' => new Usage(80, 30), 'meta' => $meta];
+        $response = (object)['text' => 'Sunny and 22 degrees.', 'toolCalls' => [$tc], 'toolResults' => [$tr], 'steps' => [$step1, $step2], 'usage' => new Usage(140, 50), 'meta' => $meta, 'conversationId' => 'conv-abc-123'];
+        return [$prompt, $response];
+    }
+
+    private function makeStreamingPromptAndResponse(): array
+    {
+        $agent = new TestAgent();
+        $provider = new TestProvider();
+        $prompt = new \Laravel\Ai\Prompts\AgentPrompt($agent, 'Analyze this transcript', [], $provider, 'gpt-4o');
+        $response = (object)['text' => 'Streamed analysis.', 'toolCalls' => [], 'toolResults' => [], 'steps' => [], 'usage' => new Usage(60, 130), 'meta' => (object)['provider' => 'openai', 'model' => 'gpt-4o-2024-08-06'], 'conversationId' => 'conv-stream-123'];
+        return [$prompt, $response];
+    }
+
+    private function makeEmbeddingsPromptAndResponse(): array
+    {
+        $p = new TestProvider();
+        $prompt = new \Laravel\Ai\Prompts\EmbeddingsPrompt(['Napa Valley has great wine.', 'Laravel is a PHP framework.'], 1536, $p, 'text-embedding-3-small');
+        $response = (object)['embeddings' => [[0.1, 0.2], [0.4, 0.5]], 'tokens' => 25, 'meta' => (object)['provider' => 'openai', 'model' => 'text-embedding-3-small-2024']];
+        return [$p, $prompt, $response];
+    }
+
+    private function findSpanByOp(object $t, string $op): ?Span
+    {
+        return $this->findSpanByOpInSpans($t->getSpanRecorder()->getSpans(), $op);
+    }
+
+    private function findSpanByOpInSpans(array $spans, string $op): ?Span
+    {
+        foreach ($spans as $s) {
+            if ($s->getOp() === $op) {
+                return $s;
+            }
+        }
+        return null;
+    }
+
+    private function findAllSpansByOp(object $t, string $op): array
+    {
+        return array_values(array_filter($t->getSpanRecorder()->getSpans(), fn (Span $s) => $s->getOp() === $op));
+    }
+
+    private function dispatchLlmHttpEvents(): void
+    {
+        $this->dispatchLlmRequestSending();
+        $this->dispatchLlmResponseReceived();
+    }
+    private function dispatchLlmRequestSending(): void
+    {
+        $this->dispatchLaravelEvent(new RequestSending(new HttpRequest(new \GuzzleHttp\Psr7\Request('POST', self::PROVIDER_URL . '/responses', [], '{}'))));
+    }
+    private function dispatchLlmResponseReceived(): void
+    {
+        $r = new HttpRequest(new \GuzzleHttp\Psr7\Request('POST', self::PROVIDER_URL . '/responses', [], '{}'));
+        $this->dispatchLaravelEvent(new ResponseReceived($r, new HttpResponse(new \GuzzleHttp\Psr7\Response(200, [], '{}'))));
+    }
+}

--- a/test/Sentry/Features/AiIntegrationTest.php
+++ b/test/Sentry/Features/AiIntegrationTest.php
@@ -1,443 +1,4 @@
 <?php
-// Stub interfaces and classes so the test works without laravel/ai installed
-namespace Laravel\Ai\Contracts;
-
-if (!interface_exists(Agent::class)) {
-    interface Agent
-    {
-    }
-}
-
-if (!interface_exists(Tool::class)) {
-    interface Tool
-    {
-    }
-}
-
-namespace Laravel\Ai\Providers;
-
-if (!class_exists(Provider::class)) {
-    abstract class Provider
-    {
-    }
-}
-
-namespace Laravel\Ai\Contracts\Providers;
-
-if (!interface_exists(TextProvider::class)) {
-    interface TextProvider
-    {
-    }
-}
-
-if (!interface_exists(EmbeddingProvider::class)) {
-    interface EmbeddingProvider
-    {
-    }
-}
-
-namespace Laravel\Ai\Gateway;
-
-if (!class_exists(TextGenerationOptions::class)) {
-    class TextGenerationOptions
-    {
-    }
-}
-
-namespace Laravel\Ai\Contracts\Gateway;
-
-if (!interface_exists(TextGateway::class)) {
-    interface TextGateway
-    {
-    }
-}
-
-if (!interface_exists(EmbeddingGateway::class)) {
-    interface EmbeddingGateway
-    {
-    }
-}
-
-if (!class_exists(StubEmbeddingGateway::class)) {
-    class StubEmbeddingGateway implements EmbeddingGateway
-    {
-        public function generateEmbeddings($provider, string $model, array $inputs, int $dimensions): \Laravel\Ai\Responses\EmbeddingsResponse
-        {
-            return new \Laravel\Ai\Responses\EmbeddingsResponse();
-        }
-    }
-}
-
-if (!class_exists(StubTextGateway::class)) {
-    class StubTextGateway implements TextGateway
-    {
-        public function generateText(\Laravel\Ai\Contracts\Providers\TextProvider $provider, string $model, ?string $instructions, array $messages = [], array $tools = [], ?array $schema = null, ?\Laravel\Ai\Gateway\TextGenerationOptions $options = null, ?int $timeout = null): \Laravel\Ai\Responses\TextResponse
-        {
-            return new \Laravel\Ai\Responses\TextResponse();
-        }
-        public function streamText(string $invocationId, \Laravel\Ai\Contracts\Providers\TextProvider $provider, string $model, ?string $instructions, array $messages = [], array $tools = [], ?array $schema = null, ?\Laravel\Ai\Gateway\TextGenerationOptions $options = null, ?int $timeout = null): \Generator
-        {
-            yield from [];
-        }
-        public function onToolInvocation(\Closure $invoking, \Closure $invoked): self
-        {
-            return $this;
-        }
-    }
-}
-
-namespace Laravel\Ai\Responses\Data;
-
-if (!class_exists(Usage::class)) {
-    class Usage
-    {
-        public $promptTokens;
-        public $completionTokens;
-        public $cacheWriteInputTokens;
-        public $cacheReadInputTokens;
-        public $reasoningTokens;
-
-        public function __construct($promptTokens = 0, $completionTokens = 0, $cacheWriteInputTokens = 0, $cacheReadInputTokens = 0, $reasoningTokens = 0)
-        {
-            $this->promptTokens = $promptTokens;
-            $this->completionTokens = $completionTokens;
-            $this->cacheWriteInputTokens = $cacheWriteInputTokens;
-            $this->cacheReadInputTokens = $cacheReadInputTokens;
-            $this->reasoningTokens = $reasoningTokens;
-        }
-    }
-}
-
-if (!class_exists(Meta::class)) {
-    class Meta
-    {
-        public $provider;
-        public $model;
-
-        public function __construct($provider = null, $model = null)
-        {
-            $this->provider = $provider;
-            $this->model = $model;
-        }
-    }
-}
-
-namespace Laravel\Ai\Responses;
-
-if (!class_exists(TextResponse::class)) {
-    class TextResponse
-    {
-        public $text;
-        public $usage;
-        public $meta;
-        public $messages;
-        public $toolCalls;
-        public $toolResults;
-        public $steps;
-
-        public function __construct($text = '', $usage = null, $meta = null)
-        {
-            $this->text = $text;
-            $this->usage = $usage;
-            $this->meta = $meta;
-        }
-    }
-}
-
-if (!class_exists(AgentResponse::class)) {
-    class AgentResponse extends TextResponse
-    {
-        public $conversationId;
-        public $invocationId;
-
-        public function __construct($invocationId = '', $text = '', $usage = null, $meta = null)
-        {
-            $this->invocationId = $invocationId;
-            parent::__construct($text, $usage, $meta);
-        }
-    }
-}
-
-if (!class_exists(StreamableAgentResponse::class)) {
-    class StreamableAgentResponse
-    {
-    }
-}
-
-if (!class_exists(QueuedAgentResponse::class)) {
-    class QueuedAgentResponse
-    {
-    }
-}
-
-if (!class_exists(TextResponse::class)) {
-    class TextResponse
-    {
-    }
-}
-
-if (!class_exists(EmbeddingsResponse::class)) {
-    class EmbeddingsResponse
-    {
-    }
-}
-
-namespace Laravel\Ai\Prompts;
-
-if (!class_exists(AgentPrompt::class)) {
-    class AgentPrompt
-    {
-        public $agent;
-        public $prompt;
-        public $attachments;
-        public $provider;
-        public $model;
-
-        public function __construct($agent, $prompt, array $attachments = [], $provider = null, $model = null)
-        {
-            $this->agent = $agent;
-            $this->prompt = $prompt;
-            $this->attachments = $attachments;
-            $this->provider = $provider;
-            $this->model = $model;
-        }
-    }
-}
-
-if (!class_exists(EmbeddingsPrompt::class)) {
-    class EmbeddingsPrompt
-    {
-        public $inputs;
-        public $dimensions;
-        public $provider;
-        public $model;
-
-        public function __construct(array $inputs = [], $dimensions = null, $provider = null, $model = null)
-        {
-            $this->inputs = $inputs;
-            $this->dimensions = $dimensions;
-            $this->provider = $provider;
-            $this->model = $model;
-        }
-    }
-}
-
-namespace Laravel\Ai\Events;
-
-if (!class_exists(PromptingAgent::class)) {
-    class PromptingAgent
-    {
-        public $invocationId;
-        public $prompt;
-
-        public function __construct($invocationId, $prompt)
-        {
-            $this->invocationId = $invocationId;
-            $this->prompt = $prompt;
-        }
-    }
-}
-if (!class_exists(AgentPrompted::class)) {
-    class AgentPrompted
-    {
-        public $invocationId;
-        public $prompt;
-        public $response;
-
-        public function __construct($invocationId, $prompt, $response)
-        {
-            $this->invocationId = $invocationId;
-            $this->prompt = $prompt;
-            $this->response = $response;
-        }
-    }
-}
-if (!class_exists(InvokingTool::class)) {
-    class InvokingTool
-    {
-        public $invocationId;
-        public $toolInvocationId;
-        public $agent;
-        public $tool;
-        public $arguments;
-
-        public function __construct($invocationId, $toolInvocationId, $agent, $tool, array $arguments)
-        {
-            $this->invocationId = $invocationId;
-            $this->toolInvocationId = $toolInvocationId;
-            $this->agent = $agent;
-            $this->tool = $tool;
-            $this->arguments = $arguments;
-        }
-    }
-}
-if (!class_exists(ToolInvoked::class)) {
-    class ToolInvoked
-    {
-        public $invocationId;
-        public $toolInvocationId;
-        public $agent;
-        public $tool;
-        public $arguments;
-        public $result;
-
-        public function __construct($invocationId, $toolInvocationId, $agent, $tool, array $arguments, $result)
-        {
-            $this->invocationId = $invocationId;
-            $this->toolInvocationId = $toolInvocationId;
-            $this->agent = $agent;
-            $this->tool = $tool;
-            $this->arguments = $arguments;
-            $this->result = $result;
-        }
-    }
-}
-if (!class_exists(StreamingAgent::class)) {
-    class StreamingAgent extends PromptingAgent
-    {
-    }
-}
-if (!class_exists(AgentStreamed::class)) {
-    class AgentStreamed extends AgentPrompted
-    {
-    }
-}
-if (!class_exists(GeneratingEmbeddings::class)) {
-    class GeneratingEmbeddings
-    {
-        public $invocationId;
-        public $provider;
-        public $model;
-        public $prompt;
-
-        public function __construct($invocationId, $provider, $model, $prompt)
-        {
-            $this->invocationId = $invocationId;
-            $this->provider = $provider;
-            $this->model = $model;
-            $this->prompt = $prompt;
-        }
-    }
-}
-if (!class_exists(EmbeddingsGenerated::class)) {
-    class EmbeddingsGenerated
-    {
-        public $invocationId;
-        public $provider;
-        public $model;
-        public $prompt;
-        public $response;
-
-        public function __construct($invocationId, $provider, $model, $prompt, $response)
-        {
-            $this->invocationId = $invocationId;
-            $this->provider = $provider;
-            $this->model = $model;
-            $this->prompt = $prompt;
-            $this->response = $response;
-        }
-    }
-}
-
-namespace Laravel\Ai\Attributes;
-
-if (!class_exists(Temperature::class)) {
-    if (\PHP_VERSION_ID >= 80000) {
-        eval('
-            #[\Attribute(\Attribute::TARGET_CLASS)]
-            class Temperature
-            {
-                public $value;
-
-                public function __construct($value)
-                {
-                    $this->value = $value;
-                }
-            }
-        ');
-    } else {
-        class Temperature
-        {
-            public $value;
-
-            public function __construct($value)
-            {
-                $this->value = $value;
-            }
-        }
-    }
-}
-if (!class_exists(MaxTokens::class)) {
-    if (\PHP_VERSION_ID >= 80000) {
-        eval('
-            #[\Attribute(\Attribute::TARGET_CLASS)]
-            class MaxTokens
-            {
-                public $value;
-
-                public function __construct($value)
-                {
-                    $this->value = $value;
-                }
-            }
-        ');
-    } else {
-        class MaxTokens
-        {
-            public $value;
-
-            public function __construct($value)
-            {
-                $this->value = $value;
-            }
-        }
-    }
-}
-
-namespace Laravel\Ai\Files;
-
-if (!class_exists(File::class)) {
-    abstract class File
-    {
-        public $name = null;
-
-        public function name()
-        {
-            return $this->name;
-        }
-
-        public function as($name)
-        {
-            $this->name = $name;
-
-            return $this;
-        }
-    }
-}
-if (!class_exists(Image::class)) {
-    abstract class Image extends File
-    {
-    }
-}
-if (!class_exists(Document::class)) {
-    abstract class Document extends File
-    {
-    }
-}
-
-if (!class_exists(RemoteImage::class)) {
-    class RemoteImage extends Image
-    {
-        public $url;
-        public $mime;
-
-        public function __construct($url, $mime = null)
-        {
-            $this->url = $url;
-            $this->mime = $mime;
-        }
-    }
-}
 
 namespace Sentry\Laravel\Tests\Features\AiStubs;
 
@@ -498,39 +59,22 @@ class TestAgent implements Agent
         return new QueuedAgentResponse();
     }
 }
-if (\PHP_VERSION_ID >= 80000) {
-    eval('
-        namespace Sentry\Laravel\Tests\Features\AiStubs;
 
-        #[\Laravel\Ai\Attributes\Temperature(0.7)]
-        #[\Laravel\Ai\Attributes\MaxTokens(4096)]
-        class TestAgentWithConfig extends \Sentry\Laravel\Tests\Features\AiStubs\TestAgent
-        {
-            public function instructions(): string
-            {
-                return "You are a configured assistant.";
-            }
-
-            public function tools(): array
-            {
-                return [];
-            }
-        }
-    ');
-} else {
-    class TestAgentWithConfig extends TestAgent
+#[Temperature(0.7)]
+#[MaxTokens(4096)]
+class TestAgentWithConfig extends TestAgent
+{
+    public function instructions(): string
     {
-        public function instructions(): string
-        {
-            return 'You are a configured assistant.';
-        }
+        return 'You are a configured assistant.';
+    }
 
-        public function tools(): array
-        {
-            return [];
-        }
+    public function tools(): array
+    {
+        return [];
     }
 }
+
 class WeatherLookup implements Tool
 {
     public function name(): string
@@ -550,6 +94,7 @@ class WeatherLookup implements Tool
         return 'Sunny, 22°C';
     }
 }
+
 class TestProvider extends \Laravel\Ai\Providers\Provider implements TextProvider, EmbeddingProvider
 {
     public function __construct()
@@ -638,6 +183,7 @@ class TestProvider extends \Laravel\Ai\Providers\Provider implements TextProvide
         return 'text-embedding-3-small';
     }
 }
+
 class TestToolCall
 {
     public $name;
@@ -649,6 +195,7 @@ class TestToolCall
         $this->arguments = $arguments;
     }
 }
+
 class TestToolResult
 {
     public $name;
@@ -660,6 +207,7 @@ class TestToolResult
         $this->result = $result;
     }
 }
+
 class TestLocalImage extends \Laravel\Ai\Files\Image
 {
     public $path;
@@ -683,9 +231,11 @@ class TestLocalImage extends \Laravel\Ai\Files\Image
         return ['type' => 'local-image', 'name' => $this->name(), 'path' => $this->path, 'mime' => $this->mime];
     }
 }
+
 class TestRemoteImage extends \Laravel\Ai\Files\RemoteImage
 {
 }
+
 namespace Sentry\Laravel\Tests\Features;
 
 use Illuminate\Http\Client\Events\ConnectionFailed;
@@ -720,12 +270,6 @@ class AiIntegrationTest extends TestCase
     protected $defaultSetupConfig = ['sentry.tracing.http_client_requests' => false];
     protected function setUp(): void
     {
-        if (\PHP_VERSION_ID < 80400) {
-            $this->markTestSkipped('Laravel AI requires PHP 8.4+.');
-        }
-        if (version_compare(\Illuminate\Foundation\Application::VERSION, '12', '<')) {
-            $this->markTestSkipped('Laravel AI requires Laravel 12+.');
-        }
         parent::setUp();
         config(['prism.providers.openai.url' => self::PROVIDER_URL]);
     }
@@ -760,37 +304,10 @@ class AiIntegrationTest extends TestCase
         // Request parameters from attributes
         $spans = $this->runAgentFlow($this->makePromptAndResponse(60, 130, 0, 0, TestAgentWithConfig::class));
         $data = $spans[1]->getData();
-        $reflection = new \ReflectionClass(TestAgentWithConfig::class);
-
-        $temperatureValue = null;
-        $temperatureAttributes = $reflection->getAttributes('Laravel\Ai\Attributes\Temperature');
-        if (!empty($temperatureAttributes)) {
-            try {
-                $temperatureValue = $temperatureAttributes[0]->newInstance()->value ?? null;
-            } catch (\Throwable $e) {
-                $temperatureValue = null;
-            }
-        }
-
-        if ($temperatureValue !== null) {
-            $this->assertArrayHasKey('gen_ai.request.temperature', $data);
-            $this->assertEquals($temperatureValue, $data['gen_ai.request.temperature']);
-        }
-
-        $maxTokensValue = null;
-        $maxTokensAttributes = $reflection->getAttributes('Laravel\Ai\Attributes\MaxTokens');
-        if (!empty($maxTokensAttributes)) {
-            try {
-                $maxTokensValue = $maxTokensAttributes[0]->newInstance()->value ?? null;
-            } catch (\Throwable $e) {
-                $maxTokensValue = null;
-            }
-        }
-
-        if ($maxTokensValue !== null) {
-            $this->assertArrayHasKey('gen_ai.request.max_tokens', $data);
-            $this->assertEquals($maxTokensValue, $data['gen_ai.request.max_tokens']);
-        }
+        $this->assertArrayHasKey('gen_ai.request.temperature', $data);
+        $this->assertEquals(0.7, $data['gen_ai.request.temperature']);
+        $this->assertArrayHasKey('gen_ai.request.max_tokens', $data);
+        $this->assertEquals(4096, $data['gen_ai.request.max_tokens']);
     }
 
     public function testPiiControlsMessageCapture(): void

--- a/test/Sentry/Features/AiIntegrationTest.php
+++ b/test/Sentry/Features/AiIntegrationTest.php
@@ -761,16 +761,35 @@ class AiIntegrationTest extends TestCase
         $spans = $this->runAgentFlow($this->makePromptAndResponse(60, 130, 0, 0, TestAgentWithConfig::class));
         $data = $spans[1]->getData();
         $reflection = new \ReflectionClass(TestAgentWithConfig::class);
-        $hasTemperatureAttribute = !empty($reflection->getAttributes('Laravel\Ai\Attributes\Temperature'));
-        if ($hasTemperatureAttribute) {
-            $this->assertArrayHasKey('gen_ai.request.temperature', $data);
-            $this->assertEquals(0.7, $data['gen_ai.request.temperature']);
+
+        $temperatureValue = null;
+        $temperatureAttributes = $reflection->getAttributes('Laravel\Ai\Attributes\Temperature');
+        if (!empty($temperatureAttributes)) {
+            try {
+                $temperatureValue = $temperatureAttributes[0]->newInstance()->value ?? null;
+            } catch (\Throwable $e) {
+                $temperatureValue = null;
+            }
         }
 
-        $hasMaxTokensAttribute = !empty($reflection->getAttributes('Laravel\Ai\Attributes\MaxTokens'));
-        if ($hasMaxTokensAttribute) {
+        if ($temperatureValue !== null) {
+            $this->assertArrayHasKey('gen_ai.request.temperature', $data);
+            $this->assertEquals($temperatureValue, $data['gen_ai.request.temperature']);
+        }
+
+        $maxTokensValue = null;
+        $maxTokensAttributes = $reflection->getAttributes('Laravel\Ai\Attributes\MaxTokens');
+        if (!empty($maxTokensAttributes)) {
+            try {
+                $maxTokensValue = $maxTokensAttributes[0]->newInstance()->value ?? null;
+            } catch (\Throwable $e) {
+                $maxTokensValue = null;
+            }
+        }
+
+        if ($maxTokensValue !== null) {
             $this->assertArrayHasKey('gen_ai.request.max_tokens', $data);
-            $this->assertEquals(4096, $data['gen_ai.request.max_tokens']);
+            $this->assertEquals($maxTokensValue, $data['gen_ai.request.max_tokens']);
         }
     }
 

--- a/test/Sentry/Features/AiIntegrationTest.php
+++ b/test/Sentry/Features/AiIntegrationTest.php
@@ -91,8 +91,19 @@ namespace Laravel\Ai\Responses\Data;
 if (!class_exists(Usage::class)) {
     class Usage
     {
-        public function __construct(public int $promptTokens = 0, public int $completionTokens = 0, public int $cacheWriteInputTokens = 0, public int $cacheReadInputTokens = 0, public int $reasoningTokens = 0)
+        public $promptTokens;
+        public $completionTokens;
+        public $cacheWriteInputTokens;
+        public $cacheReadInputTokens;
+        public $reasoningTokens;
+
+        public function __construct($promptTokens = 0, $completionTokens = 0, $cacheWriteInputTokens = 0, $cacheReadInputTokens = 0, $reasoningTokens = 0)
         {
+            $this->promptTokens = $promptTokens;
+            $this->completionTokens = $completionTokens;
+            $this->cacheWriteInputTokens = $cacheWriteInputTokens;
+            $this->cacheReadInputTokens = $cacheReadInputTokens;
+            $this->reasoningTokens = $reasoningTokens;
         }
     }
 }
@@ -100,8 +111,13 @@ if (!class_exists(Usage::class)) {
 if (!class_exists(Meta::class)) {
     class Meta
     {
-        public function __construct(public ?string $provider = null, public ?string $model = null)
+        public $provider;
+        public $model;
+
+        public function __construct($provider = null, $model = null)
         {
+            $this->provider = $provider;
+            $this->model = $model;
         }
     }
 }
@@ -111,13 +127,19 @@ namespace Laravel\Ai\Responses;
 if (!class_exists(TextResponse::class)) {
     class TextResponse
     {
+        public $text;
+        public $usage;
+        public $meta;
         public $messages;
         public $toolCalls;
         public $toolResults;
         public $steps;
 
-        public function __construct(public string $text, public object $usage, public object $meta)
+        public function __construct($text = '', $usage = null, $meta = null)
         {
+            $this->text = $text;
+            $this->usage = $usage;
+            $this->meta = $meta;
         }
     }
 }
@@ -125,10 +147,12 @@ if (!class_exists(TextResponse::class)) {
 if (!class_exists(AgentResponse::class)) {
     class AgentResponse extends TextResponse
     {
-        public ?string $conversationId = null;
+        public $conversationId;
+        public $invocationId;
 
-        public function __construct(public string $invocationId, string $text, object $usage, object $meta)
+        public function __construct($invocationId = '', $text = '', $usage = null, $meta = null)
         {
+            $this->invocationId = $invocationId;
             parent::__construct($text, $usage, $meta);
         }
     }
@@ -163,8 +187,19 @@ namespace Laravel\Ai\Prompts;
 if (!class_exists(AgentPrompt::class)) {
     class AgentPrompt
     {
-        public function __construct(public object $agent, public string $prompt, public array $attachments = [], public ?object $provider = null, public ?string $model = null)
+        public $agent;
+        public $prompt;
+        public $attachments;
+        public $provider;
+        public $model;
+
+        public function __construct($agent, $prompt, array $attachments = [], $provider = null, $model = null)
         {
+            $this->agent = $agent;
+            $this->prompt = $prompt;
+            $this->attachments = $attachments;
+            $this->provider = $provider;
+            $this->model = $model;
         }
     }
 }
@@ -172,8 +207,17 @@ if (!class_exists(AgentPrompt::class)) {
 if (!class_exists(EmbeddingsPrompt::class)) {
     class EmbeddingsPrompt
     {
-        public function __construct(public array $inputs = [], public ?int $dimensions = null, public ?object $provider = null, public ?string $model = null)
+        public $inputs;
+        public $dimensions;
+        public $provider;
+        public $model;
+
+        public function __construct(array $inputs = [], $dimensions = null, $provider = null, $model = null)
         {
+            $this->inputs = $inputs;
+            $this->dimensions = $dimensions;
+            $this->provider = $provider;
+            $this->model = $model;
         }
     }
 }
@@ -183,32 +227,68 @@ namespace Laravel\Ai\Events;
 if (!class_exists(PromptingAgent::class)) {
     class PromptingAgent
     {
-        public function __construct(public string $invocationId, public object $prompt)
+        public $invocationId;
+        public $prompt;
+
+        public function __construct($invocationId, $prompt)
         {
+            $this->invocationId = $invocationId;
+            $this->prompt = $prompt;
         }
     }
 }
 if (!class_exists(AgentPrompted::class)) {
     class AgentPrompted
     {
-        public function __construct(public string $invocationId, public object $prompt, public object $response)
+        public $invocationId;
+        public $prompt;
+        public $response;
+
+        public function __construct($invocationId, $prompt, $response)
         {
+            $this->invocationId = $invocationId;
+            $this->prompt = $prompt;
+            $this->response = $response;
         }
     }
 }
 if (!class_exists(InvokingTool::class)) {
     class InvokingTool
     {
-        public function __construct(public string $invocationId, public string $toolInvocationId, public object $agent, public object $tool, public array $arguments)
+        public $invocationId;
+        public $toolInvocationId;
+        public $agent;
+        public $tool;
+        public $arguments;
+
+        public function __construct($invocationId, $toolInvocationId, $agent, $tool, array $arguments)
         {
+            $this->invocationId = $invocationId;
+            $this->toolInvocationId = $toolInvocationId;
+            $this->agent = $agent;
+            $this->tool = $tool;
+            $this->arguments = $arguments;
         }
     }
 }
 if (!class_exists(ToolInvoked::class)) {
     class ToolInvoked
     {
-        public function __construct(public string $invocationId, public string $toolInvocationId, public object $agent, public object $tool, public array $arguments, public $result)
+        public $invocationId;
+        public $toolInvocationId;
+        public $agent;
+        public $tool;
+        public $arguments;
+        public $result;
+
+        public function __construct($invocationId, $toolInvocationId, $agent, $tool, array $arguments, $result)
         {
+            $this->invocationId = $invocationId;
+            $this->toolInvocationId = $toolInvocationId;
+            $this->agent = $agent;
+            $this->tool = $tool;
+            $this->arguments = $arguments;
+            $this->result = $result;
         }
     }
 }
@@ -225,16 +305,36 @@ if (!class_exists(AgentStreamed::class)) {
 if (!class_exists(GeneratingEmbeddings::class)) {
     class GeneratingEmbeddings
     {
-        public function __construct(public string $invocationId, public object $provider, public string $model, public object $prompt)
+        public $invocationId;
+        public $provider;
+        public $model;
+        public $prompt;
+
+        public function __construct($invocationId, $provider, $model, $prompt)
         {
+            $this->invocationId = $invocationId;
+            $this->provider = $provider;
+            $this->model = $model;
+            $this->prompt = $prompt;
         }
     }
 }
 if (!class_exists(EmbeddingsGenerated::class)) {
     class EmbeddingsGenerated
     {
-        public function __construct(public string $invocationId, public object $provider, public string $model, public object $prompt, public object $response)
+        public $invocationId;
+        public $provider;
+        public $model;
+        public $prompt;
+        public $response;
+
+        public function __construct($invocationId, $provider, $model, $prompt, $response)
         {
+            $this->invocationId = $invocationId;
+            $this->provider = $provider;
+            $this->model = $model;
+            $this->prompt = $prompt;
+            $this->response = $response;
         }
     }
 }
@@ -242,18 +342,54 @@ if (!class_exists(EmbeddingsGenerated::class)) {
 namespace Laravel\Ai\Attributes;
 
 if (!class_exists(Temperature::class)) {
-    #[\Attribute(\Attribute::TARGET_CLASS)] class Temperature
-    {
-        public function __construct(public float $value)
+    if (\PHP_VERSION_ID >= 80000) {
+        eval('
+            #[\Attribute(\Attribute::TARGET_CLASS)]
+            class Temperature
+            {
+                public $value;
+
+                public function __construct($value)
+                {
+                    $this->value = $value;
+                }
+            }
+        ');
+    } else {
+        class Temperature
         {
+            public $value;
+
+            public function __construct($value)
+            {
+                $this->value = $value;
+            }
         }
     }
 }
 if (!class_exists(MaxTokens::class)) {
-    #[\Attribute(\Attribute::TARGET_CLASS)] class MaxTokens
-    {
-        public function __construct(public int $value)
+    if (\PHP_VERSION_ID >= 80000) {
+        eval('
+            #[\Attribute(\Attribute::TARGET_CLASS)]
+            class MaxTokens
+            {
+                public $value;
+
+                public function __construct($value)
+                {
+                    $this->value = $value;
+                }
+            }
+        ');
+    } else {
+        class MaxTokens
         {
+            public $value;
+
+            public function __construct($value)
+            {
+                $this->value = $value;
+            }
         }
     }
 }
@@ -263,13 +399,17 @@ namespace Laravel\Ai\Files;
 if (!class_exists(File::class)) {
     abstract class File
     {
-        public ?string $name = null;
-        public function name(): ?string
+        public $name = null;
+
+        public function name()
         {
             return $this->name;
-        } public function as(?string $name): static
+        }
+
+        public function as($name)
         {
             $this->name = $name;
+
             return $this;
         }
     }
@@ -282,6 +422,20 @@ if (!class_exists(Image::class)) {
 if (!class_exists(Document::class)) {
     abstract class Document extends File
     {
+    }
+}
+
+if (!class_exists(RemoteImage::class)) {
+    class RemoteImage extends Image
+    {
+        public $url;
+        public $mime;
+
+        public function __construct($url, $mime = null)
+        {
+            $this->url = $url;
+            $this->mime = $mime;
+        }
     }
 }
 
@@ -307,15 +461,15 @@ class TestAgent implements Agent
     {
         return [new WeatherLookup()];
     }
-    public function prompt(string $prompt, array $attachments = [], array|string|null $provider = null, ?string $model = null): AgentResponse
+    public function prompt(string $prompt, array $attachments = [], $provider = null, ?string $model = null): AgentResponse
     {
         return new AgentResponse();
     }
-    public function stream(string $prompt, array $attachments = [], array|string|null $provider = null, ?string $model = null): StreamableAgentResponse
+    public function stream(string $prompt, array $attachments = [], $provider = null, ?string $model = null): StreamableAgentResponse
     {
         return new StreamableAgentResponse();
     }
-    public function queue(string $prompt, array $attachments = [], array|string|null $provider = null, ?string $model = null): QueuedAgentResponse
+    public function queue(string $prompt, array $attachments = [], $provider = null, ?string $model = null): QueuedAgentResponse
     {
         return new QueuedAgentResponse();
     }
@@ -331,65 +485,48 @@ class TestAgent implements Agent
     {
         return null;
     }
-    public function broadcast(string $prompt, $channels, array $attachments = [], bool $now = false, array|string|null $provider = null, ?string $model = null): StreamableAgentResponse
+    public function broadcast(string $prompt, $channels, array $attachments = [], bool $now = false, $provider = null, ?string $model = null): StreamableAgentResponse
     {
         return new StreamableAgentResponse();
     }
-    public function broadcastNow(string $prompt, $channels, array $attachments = [], array|string|null $provider = null, ?string $model = null): StreamableAgentResponse
+    public function broadcastNow(string $prompt, $channels, array $attachments = [], $provider = null, ?string $model = null): StreamableAgentResponse
     {
         return new StreamableAgentResponse();
     }
-    public function broadcastOnQueue(string $prompt, $channels, array $attachments = [], array|string|null $provider = null, ?string $model = null): QueuedAgentResponse
+    public function broadcastOnQueue(string $prompt, $channels, array $attachments = [], $provider = null, ?string $model = null): QueuedAgentResponse
     {
         return new QueuedAgentResponse();
     }
 }
-#[Temperature(0.7)] #[MaxTokens(4096)]
-class TestAgentWithConfig implements Agent
-{
-    public function instructions(): string
+if (\PHP_VERSION_ID >= 80000) {
+    eval('
+        #[\Laravel\Ai\Attributes\Temperature(0.7)]
+        #[\Laravel\Ai\Attributes\MaxTokens(4096)]
+        class TestAgentWithConfig extends TestAgent
+        {
+            public function instructions(): string
+            {
+                return "You are a configured assistant.";
+            }
+
+            public function tools(): array
+            {
+                return [];
+            }
+        }
+    ');
+} else {
+    class TestAgentWithConfig extends TestAgent
     {
-        return 'You are a configured assistant.';
-    }
-    public function tools(): array
-    {
-        return [];
-    }
-    public function prompt(string $prompt, array $attachments = [], array|string|null $provider = null, ?string $model = null): AgentResponse
-    {
-        return new AgentResponse();
-    }
-    public function stream(string $prompt, array $attachments = [], array|string|null $provider = null, ?string $model = null): StreamableAgentResponse
-    {
-        return new StreamableAgentResponse();
-    }
-    public function queue(string $prompt, array $attachments = [], array|string|null $provider = null, ?string $model = null): QueuedAgentResponse
-    {
-        return new QueuedAgentResponse();
-    }
-    public function respond(...$args)
-    {
-        return null;
-    }
-    public function streamRespond(...$args)
-    {
-        return null;
-    }
-    public function queueRespond(...$args)
-    {
-        return null;
-    }
-    public function broadcast(string $prompt, $channels, array $attachments = [], bool $now = false, array|string|null $provider = null, ?string $model = null): StreamableAgentResponse
-    {
-        return new StreamableAgentResponse();
-    }
-    public function broadcastNow(string $prompt, $channels, array $attachments = [], array|string|null $provider = null, ?string $model = null): StreamableAgentResponse
-    {
-        return new StreamableAgentResponse();
-    }
-    public function broadcastOnQueue(string $prompt, $channels, array $attachments = [], array|string|null $provider = null, ?string $model = null): QueuedAgentResponse
-    {
-        return new QueuedAgentResponse();
+        public function instructions(): string
+        {
+            return 'You are a configured assistant.';
+        }
+
+        public function tools(): array
+        {
+            return [];
+        }
     }
 }
 class WeatherLookup implements Tool
@@ -501,20 +638,35 @@ class TestProvider extends \Laravel\Ai\Providers\Provider implements TextProvide
 }
 class TestToolCall
 {
-    public function __construct(public string $name, public array $arguments = [])
+    public $name;
+    public $arguments;
+
+    public function __construct($name, array $arguments = [])
     {
+        $this->name = $name;
+        $this->arguments = $arguments;
     }
 }
 class TestToolResult
 {
-    public function __construct(public string $name, public $result)
+    public $name;
+    public $result;
+
+    public function __construct($name, $result)
     {
+        $this->name = $name;
+        $this->result = $result;
     }
 }
 class TestLocalImage extends \Laravel\Ai\Files\Image
 {
-    public function __construct(public string $path, public ?string $mime = null)
+    public $path;
+    public $mime;
+
+    public function __construct($path, $mime = null)
     {
+        $this->path = $path;
+        $this->mime = $mime;
     }
     public function mimeType(): ?string
     {
@@ -596,7 +748,7 @@ class AiIntegrationTest extends TestCase
     public function testAgentSpanCapturesTokenUsageAndRequestParams(): void
     {
         // Token usage
-        $spans = $this->runAgentFlow($this->makePromptAndResponse(promptTokens: 100, completionTokens: 50, cacheReadInputTokens: 20, reasoningTokens: 15));
+        $spans = $this->runAgentFlow($this->makePromptAndResponse(100, 50, 20, 15));
         $data = $spans[1]->getData();
         $this->assertEquals(100, $data['gen_ai.usage.input_tokens']);
         $this->assertEquals(50, $data['gen_ai.usage.output_tokens']);
@@ -604,7 +756,7 @@ class AiIntegrationTest extends TestCase
         $this->assertEquals(20, $data['gen_ai.usage.input_tokens.cached']);
         $this->assertEquals(15, $data['gen_ai.usage.output_tokens.reasoning']);
         // Request parameters from attributes
-        $spans = $this->runAgentFlow($this->makePromptAndResponse(agentClass: TestAgentWithConfig::class));
+        $spans = $this->runAgentFlow($this->makePromptAndResponse(60, 130, 0, 0, TestAgentWithConfig::class));
         $data = $spans[1]->getData();
         $this->assertEquals(0.7, $data['gen_ai.request.temperature']);
         $this->assertEquals(4096, $data['gen_ai.request.max_tokens']);
@@ -645,7 +797,7 @@ class AiIntegrationTest extends TestCase
         $this->markTestSkipped('Covered in stacked PR2 (chat spans).');
 
         $transaction = $this->startTransaction();
-        [$prompt, $response] = $this->makePromptAndResponse(promptTokens: 100, completionTokens: 50);
+        [$prompt, $response] = $this->makePromptAndResponse(100, 50);
         $this->dispatchAgentFlow('inv-c', $prompt, $response);
         $chatSpans = $this->findAllSpansByOp($transaction, 'gen_ai.chat');
         $this->assertCount(1, $chatSpans);
@@ -778,7 +930,7 @@ class AiIntegrationTest extends TestCase
 
         $this->resetApplicationWithConfig(['sentry.send_default_pii' => true, 'prism.providers.openai.url' => self::PROVIDER_URL]);
         $dataUri = 'data:image/png;base64,' . str_repeat('iVBORw0KGgoAAAANSUhEUgAA', 100);
-        $spans = $this->runAgentFlow($this->makePromptAndResponse(promptText: $dataUri));
+        $spans = $this->runAgentFlow($this->makePromptAndResponse(60, 130, 0, 0, TestAgent::class, $dataUri));
         $input = json_decode($this->findSpanByOpInSpans($spans, 'gen_ai.invoke_agent')->getData()['gen_ai.input.messages'], true);
         $this->assertEquals('[Blob substitute]', $input[0]['parts'][0]['content']);
     }
@@ -814,8 +966,12 @@ class AiIntegrationTest extends TestCase
         // Disable invoke_agent -> no agent or chat spans
         $this->resetApplicationWithConfig(['sentry.tracing.gen_ai_invoke_agent' => false, 'prism.providers.openai.url' => self::PROVIDER_URL]);
         $spans = $this->runAgentFlow($this->makePromptAndResponse());
-        $this->assertEmpty(array_filter($spans, fn ($s) => $s->getOp() === 'gen_ai.invoke_agent'));
-        $this->assertEmpty(array_filter($spans, fn ($s) => $s->getOp() === 'gen_ai.chat'));
+        $this->assertEmpty(array_filter($spans, function ($s) {
+            return $s->getOp() === 'gen_ai.invoke_agent';
+        }));
+        $this->assertEmpty(array_filter($spans, function ($s) {
+            return $s->getOp() === 'gen_ai.chat';
+        }));
         // Disable chat -> agent span still created, no chat
         $this->resetApplicationWithConfig(['sentry.tracing.gen_ai_chat' => false, 'prism.providers.openai.url' => self::PROVIDER_URL]);
         $transaction = $this->startTransaction();
@@ -970,7 +1126,9 @@ class AiIntegrationTest extends TestCase
 
     private function findAllSpansByOp(object $t, string $op): array
     {
-        return array_values(array_filter($t->getSpanRecorder()->getSpans(), fn (Span $s) => $s->getOp() === $op));
+        return array_values(array_filter($t->getSpanRecorder()->getSpans(), function (Span $s) use ($op) {
+            return $s->getOp() === $op;
+        }));
     }
 
     private function dispatchLlmHttpEvents(): void

--- a/test/Sentry/Features/AiIntegrationTest.php
+++ b/test/Sentry/Features/AiIntegrationTest.php
@@ -760,8 +760,18 @@ class AiIntegrationTest extends TestCase
         // Request parameters from attributes
         $spans = $this->runAgentFlow($this->makePromptAndResponse(60, 130, 0, 0, TestAgentWithConfig::class));
         $data = $spans[1]->getData();
-        $this->assertEquals(0.7, $data['gen_ai.request.temperature']);
-        $this->assertEquals(4096, $data['gen_ai.request.max_tokens']);
+        $reflection = new \ReflectionClass(TestAgentWithConfig::class);
+        $hasTemperatureAttribute = !empty($reflection->getAttributes('Laravel\Ai\Attributes\Temperature'));
+        if ($hasTemperatureAttribute) {
+            $this->assertArrayHasKey('gen_ai.request.temperature', $data);
+            $this->assertEquals(0.7, $data['gen_ai.request.temperature']);
+        }
+
+        $hasMaxTokensAttribute = !empty($reflection->getAttributes('Laravel\Ai\Attributes\MaxTokens'));
+        if ($hasMaxTokensAttribute) {
+            $this->assertArrayHasKey('gen_ai.request.max_tokens', $data);
+            $this->assertEquals(4096, $data['gen_ai.request.max_tokens']);
+        }
     }
 
     public function testPiiControlsMessageCapture(): void

--- a/test/Sentry/Features/AiIntegrationTest.php
+++ b/test/Sentry/Features/AiIntegrationTest.php
@@ -500,9 +500,11 @@ class TestAgent implements Agent
 }
 if (\PHP_VERSION_ID >= 80000) {
     eval('
+        namespace Sentry\Laravel\Tests\Features\AiStubs;
+
         #[\Laravel\Ai\Attributes\Temperature(0.7)]
         #[\Laravel\Ai\Attributes\MaxTokens(4096)]
-        class TestAgentWithConfig extends TestAgent
+        class TestAgentWithConfig extends \Sentry\Laravel\Tests\Features\AiStubs\TestAgent
         {
             public function instructions(): string
             {


### PR DESCRIPTION
Add the initial AI integration wiring that records invoke_agent spans for prompting and prompted lifecycle events, including model/provider and token usage metadata. This establishes the stack base without chat, tool, message, or embeddings instrumentation.


### Included
- Registers `AiIntegration` in the feature list.
- Adds base AI tracing config flags:
  - `tracing.gen_ai`
  - `tracing.gen_ai_invoke_agent`
- Implements agent lifecycle handlers:
  - `PromptingAgent` / `StreamingAgent` -> start `invoke_agent` span
  - `AgentPrompted` / `AgentStreamed` -> finish `invoke_agent` span
- Captures baseline metadata:
  - agent name
  - request/response model
  - provider name
  - token usage
  - streaming flag
  - conversation id

Made-with: Cursor

#### Issues
- Contributes to https://linear.app/getsentry/issue/TET-2064/split-current-pr
- Contributes to https://linear.app/getsentry/issue/TET-1971/laravel-ai-integration
