### PR TITLE
feat(tracing): Add SentryTracesSampleRate job middleware

### DIFF
--- a/src/Sentry/Laravel/Jobs/Middleware/SentryTracesSampleRate.php
+++ b/src/Sentry/Laravel/Jobs/Middleware/SentryTracesSampleRate.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Sentry\Laravel\Jobs\Middleware;
+
+use Closure;
+use InvalidArgumentException;
+use Sentry\SentrySdk;
+use Sentry\State\HubInterface;
+
+/**
+ * Job middleware that overrides the Sentry trace sampling decision for the job's transaction.
+ *
+ * When applied to a job, this middleware re-samples the transaction at the given rate, allowing
+ * you to control trace volume for specific jobs independently of the global sample rate.
+ *
+ * If the transaction was not sampled by the global `traces_sample_rate` or `traces_sampler`,
+ * this middleware will not force-enable it — it can only downsample, not upsample.
+ *
+ * Usage:
+ *
+ *     public function middleware(): array
+ *     {
+ *         return [
+ *             new SentryTracesSampleRate(0.1), // Sample 10% of this job's traces
+ *         ];
+ *     }
+ *
+ * @param float $sampleRate A value between 0.0 (never sampled) and 1.0 (always sampled)
+ */
+class SentryTracesSampleRate
+{
+    /** @var float */
+    private $sampleRate;
+
+    public function __construct(float $sampleRate)
+    {
+        if ($sampleRate < 0.0 || $sampleRate > 1.0) {
+            throw new InvalidArgumentException('Sample rate must be between 0.0 and 1.0.');
+        }
+
+        $this->sampleRate = $sampleRate;
+    }
+
+    public function handle(object $job, Closure $next): void
+    {
+        if (app()->bound(HubInterface::class)) {
+            $transaction = SentrySdk::getCurrentHub()->getTransaction();
+
+            if ($transaction !== null && $transaction->getSampled()) {
+                $transaction->setSampled($this->shouldSample());
+            }
+        }
+
+        $next($job);
+    }
+
+    private function shouldSample(): bool
+    {
+        if ($this->sampleRate <= 0.0) {
+            return false;
+        }
+
+        if ($this->sampleRate >= 1.0) {
+            return true;
+        }
+
+        /** @noinspection RandomApiMigrationInspection */
+        return mt_rand(0, mt_getrandmax() - 1) / mt_getrandmax() < $this->sampleRate;
+    }
+}

--- a/test/Sentry/Jobs/Middleware/SentryTracesSampleRateTest.php
+++ b/test/Sentry/Jobs/Middleware/SentryTracesSampleRateTest.php
@@ -1,0 +1,175 @@
+<?php
+
+namespace Sentry\Laravel\Tests\Jobs\Middleware;
+
+use Closure;
+use InvalidArgumentException;
+use Orchestra\Testbench\Attributes\DefineEnvironment;
+use Sentry\EventType;
+use Sentry\Laravel\Jobs\Middleware\SentryTracesSampleRate;
+use Sentry\Laravel\Tests\TestCase;
+use Sentry\SentrySdk;
+
+class SentryTracesSampleRateTest extends TestCase
+{
+    protected function withTracingEnabled($app): void
+    {
+        $app['config']->set('sentry.traces_sample_rate', 1.0);
+    }
+
+    protected function withTracingDisabled($app): void
+    {
+        $app['config']->set('sentry.traces_sample_rate', 0.0);
+    }
+
+    public function testConstructorRejectsNegativeSampleRate(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        new SentryTracesSampleRate(-0.1);
+    }
+
+    public function testConstructorRejectsSampleRateGreaterThanOne(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        new SentryTracesSampleRate(1.1);
+    }
+
+    public function testConstructorAcceptsBoundarySampleRates(): void
+    {
+        $zero = new SentryTracesSampleRate(0.0);
+        $one = new SentryTracesSampleRate(1.0);
+
+        $this->assertInstanceOf(SentryTracesSampleRate::class, $zero);
+        $this->assertInstanceOf(SentryTracesSampleRate::class, $one);
+    }
+
+    /**
+     * @define-env withTracingEnabled
+     */
+    #[DefineEnvironment('withTracingEnabled')]
+    public function testZeroSampleRateUnsamplesTransaction(): void
+    {
+        $transaction = $this->startTransaction();
+
+        $this->assertTrue($transaction->getSampled());
+
+        $middleware = new SentryTracesSampleRate(0.0);
+        $middleware->handle(new \stdClass, $this->nextMiddleware());
+
+        $this->assertFalse($transaction->getSampled());
+    }
+
+    /**
+     * @define-env withTracingEnabled
+     */
+    #[DefineEnvironment('withTracingEnabled')]
+    public function testFullSampleRateKeepsTransactionSampled(): void
+    {
+        $transaction = $this->startTransaction();
+
+        $this->assertTrue($transaction->getSampled());
+
+        $middleware = new SentryTracesSampleRate(1.0);
+        $middleware->handle(new \stdClass, $this->nextMiddleware());
+
+        $this->assertTrue($transaction->getSampled());
+    }
+
+    /**
+     * @define-env withTracingEnabled
+     */
+    #[DefineEnvironment('withTracingEnabled')]
+    public function testDoesNotUpsampleUnsampledTransaction(): void
+    {
+        $transaction = $this->startTransaction();
+        $transaction->setSampled(false);
+
+        $middleware = new SentryTracesSampleRate(1.0);
+        $middleware->handle(new \stdClass, $this->nextMiddleware());
+
+        $this->assertFalse($transaction->getSampled());
+    }
+
+    /**
+     * @define-env withTracingEnabled
+     */
+    #[DefineEnvironment('withTracingEnabled')]
+    public function testDoesNotUpsampleNullSampledTransaction(): void
+    {
+        $transaction = $this->startTransaction();
+        $transaction->setSampled(null);
+
+        $middleware = new SentryTracesSampleRate(1.0);
+        $middleware->handle(new \stdClass, $this->nextMiddleware());
+
+        $this->assertNull($transaction->getSampled());
+    }
+
+    public function testMiddlewareCallsNextHandler(): void
+    {
+        $called = false;
+
+        $middleware = new SentryTracesSampleRate(1.0);
+        $middleware->handle(new \stdClass, function () use (&$called) {
+            $called = true;
+        });
+
+        $this->assertTrue($called);
+    }
+
+    public function testMiddlewareHandlesNoTransaction(): void
+    {
+        // No transaction started, should not throw
+        $middleware = new SentryTracesSampleRate(0.5);
+        $middleware->handle(new \stdClass, $this->nextMiddleware());
+
+        // If we get here without exceptions, the test passes
+        $this->assertTrue(true);
+    }
+
+    /**
+     * @define-env withTracingEnabled
+     */
+    #[DefineEnvironment('withTracingEnabled')]
+    public function testPartialSampleRateEventuallyUnsamplesTransaction(): void
+    {
+        // With a very low sample rate, running 100 times should produce at least some unsampled results
+        $unsampledCount = 0;
+
+        for ($i = 0; $i < 100; $i++) {
+            $transaction = $this->startTransaction();
+
+            $middleware = new SentryTracesSampleRate(0.01);
+            $middleware->handle(new \stdClass, $this->nextMiddleware());
+
+            if (!$transaction->getSampled()) {
+                $unsampledCount++;
+            }
+        }
+
+        // With a 1% sample rate, we expect most of the 100 runs to be unsampled
+        $this->assertGreaterThan(80, $unsampledCount);
+    }
+
+    /**
+     * @define-env envWithoutDsnSet
+     */
+    #[DefineEnvironment('envWithoutDsnSet')]
+    public function testMiddlewareHandlesHubNotBound(): void
+    {
+        $middleware = new SentryTracesSampleRate(0.5);
+        $middleware->handle(new \stdClass, $this->nextMiddleware());
+
+        // Should not throw when HubInterface is not bound
+        $this->assertTrue(true);
+    }
+
+    private function nextMiddleware(): Closure
+    {
+        return function () {
+            // no-op
+        };
+    }
+}


### PR DESCRIPTION
Add a Laravel job middleware that allows per-job control over trace sampling. The middleware only downsamples already-sampled transactions and will not upsample transactions that were excluded by the global traces_sample_rate or traces_sampler configuration.

The reason for adding is that I keep copy-pasting this to users on request and I think this can be a useful addition to have in the SDK (and will be documented) to allow users to set some custom sampling rates on high traffic jobs without needing to cook up some traces_sampler or their own middleware.