### PR TITLE
fix(tags): preserve context and tags set in withException(..) callback

### DIFF
--- a/src/Sentry/Laravel/ServiceProvider.php
+++ b/src/Sentry/Laravel/ServiceProvider.php
@@ -32,6 +32,7 @@ use Sentry\SentrySdk;
 use Sentry\Serializer\RepresentationSerializer;
 use Sentry\State\Hub;
 use Sentry\State\HubInterface;
+use Sentry\State\Scope;
 use Sentry\Tracing\TransactionMetadata;
 use Throwable;
 
@@ -416,7 +417,10 @@ class ServiceProvider extends BaseServiceProvider
                 return $integrations;
             });
 
-            $hub = new Hub($clientBuilder->getClient());
+            // Some Laravel versions might run withExceptions(..) before the real Sentry hub is instantiated.
+            // By copying the scope here we can preserve data that was set on the Scope before this
+            // function was executed.
+            $hub = new Hub($clientBuilder->getClient(), $this->cloneCurrentHubScope());
 
             SentrySdk::setCurrentHub($hub);
 
@@ -432,6 +436,23 @@ class ServiceProvider extends BaseServiceProvider
 
             return new BacktraceHelper($options, new RepresentationSerializer($options));
         });
+    }
+
+    private function cloneCurrentHubScope(): ?Scope
+    {
+        $currentHub = SentrySdk::getCurrentHub();
+
+        if ($currentHub->getClient() !== null) {
+            return null;
+        }
+
+        $clonedScope = null;
+
+        $currentHub->configureScope(static function (Scope $scope) use (&$clonedScope): void {
+            $clonedScope = clone $scope;
+        });
+
+        return $clonedScope;
     }
 
     /**

--- a/test/Sentry/Features/ConsoleExceptionScopePropagationTest.php
+++ b/test/Sentry/Features/ConsoleExceptionScopePropagationTest.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace Sentry\Laravel\Tests\Features;
+
+use Illuminate\Config\Repository;
+use Illuminate\Console\Command;
+use Illuminate\Contracts\Console\Kernel as ConsoleKernelContract;
+use Illuminate\Contracts\Debug\ExceptionHandler;
+use Illuminate\Foundation\Application;
+use Illuminate\Foundation\Configuration\ApplicationBuilder;
+use Illuminate\Foundation\Configuration\Exceptions;
+use Illuminate\Foundation\Configuration\Middleware;
+use Sentry\Event;
+use Sentry\EventHint;
+use Sentry\Laravel\Integration;
+use Sentry\Laravel\Tests\TestCase;
+use Sentry\SentrySdk;
+use Sentry\State\Scope;
+use Symfony\Component\Console\Input\ArgvInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+class ConsoleExceptionScopePropagationTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        if (!class_exists(Exceptions::class) || !class_exists(ApplicationBuilder::class) || !method_exists(Application::class, 'configure')) {
+            $this->markTestSkipped('Laravel 11+ exception configuration is required.');
+        }
+
+        parent::setUp();
+    }
+
+    protected function resolveApplication()
+    {
+        return (new ApplicationBuilder(new Application($this->getApplicationBasePath())))
+            ->withProviders()
+            ->withMiddleware(static function (Middleware $middleware): void {
+                //
+            })
+            ->withCommands([
+                ThrowConsoleExceptionCommand::class,
+            ])
+            ->withExceptions(function (Exceptions $exceptions): void {
+                \Sentry\configureScope(static function (Scope $scope): void {
+                    $scope->setContext('Context name', [
+                        'key' => 'value',
+                    ]);
+
+                    $scope->setTag('tag_key', 'tag_value');
+                });
+
+                Integration::handles($exceptions);
+            })
+            ->create();
+    }
+
+    /** @param Application $app */
+    protected function defineEnvironment($app): void
+    {
+        self::$lastSentryEvents = [];
+        SentrySdk::init();
+
+        tap($app['config'], function (Repository $config): void {
+            // This key has no meaning, it's just a randomly generated one but it's required for the app to boot properly
+            $config->set('app.key', 'base64:JfXL2QpYC1+szaw+CdT6SHXG8zjdTkKM/ctPWoTWbXU=');
+
+            $config->set('sentry.before_send', static function (Event $event, ?EventHint $hint) {
+                self::$lastSentryEvents[] = [$event, $hint];
+
+                return null;
+            });
+
+            $config->set('sentry.dsn', 'https://publickey@sentry.dev/123');
+        });
+
+        // This simulates the scenario where Laravel first resolves the exception handler, which will execute the
+        // withExceptions(..) callback and creates the real Sentry hub later.
+        $app->make(ExceptionHandler::class);
+    }
+
+    public function testUnhandledConsoleExceptionKeepsScopeConfiguredThroughWithExceptions(): void
+    {
+        $exitCode = $this->runConsoleCommand('sentry:test-cli-scope-regression');
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSentryEventCount(1);
+
+        $event = $this->getLastSentryEvent();
+
+        $this->assertNotNull($event);
+        $this->assertSame('tag_value', $event->getTags()['tag_key'] ?? null);
+        $this->assertSame('value', $event->getContexts()['Context name']['key'] ?? null);
+    }
+
+    public function testUnhandledConsoleExceptionIsReportedAfterCommandScopeCleanup(): void
+    {
+        $exitCode = $this->runConsoleCommand('sentry:test-cli-scope-regression');
+
+        $this->assertSame(1, $exitCode);
+
+        $event = $this->getLastSentryEvent();
+
+        $this->assertNotNull($event);
+        $this->assertArrayNotHasKey('command', $event->getTags());
+    }
+
+    private function runConsoleCommand(string $command): int
+    {
+        $input = new ArgvInput(['artisan', $command]);
+        $output = new BufferedOutput();
+        $kernel = $this->app->make(ConsoleKernelContract::class);
+
+        try {
+            $exitCode = $kernel->handle($input, $output);
+        } catch (\Throwable $exception) {
+            $this->app->make(ExceptionHandler::class)->report($exception);
+
+            $exitCode = 1;
+        }
+
+        $kernel->terminate($input, $exitCode);
+
+        return $exitCode;
+    }
+}
+
+class ThrowConsoleExceptionCommand extends Command
+{
+    /** @var string */
+    protected $signature = 'sentry:test-cli-scope-regression';
+
+    /** @var string */
+    protected $description = 'Throw an exception to test console scope propagation';
+
+    public function handle()
+    {
+        throw new \RuntimeException('Unhandled console exception for scope propagation regression test.');
+    }
+}


### PR DESCRIPTION
Fixes an issue that causes data set on scopes to be lost because Laravel first resolves the error handler and then it resolves the `HubInterface` callback.
Because we created a fresh hub there, any data set before was lost. By copying the data from the previous scope, we can now preserve the data