### PR TITLE
Fix recursive loop when detecting the session key

### DIFF
--- a/src/Sentry/Laravel/Features/CacheIntegration.php
+++ b/src/Sentry/Laravel/Features/CacheIntegration.php
@@ -24,6 +24,13 @@ class CacheIntegration extends Feature
     use WorksWithSpans, TracksPushedScopesAndSpans, ResolvesEventOrigin;
 
     /**
+     * Indicates whether the cache integration is currently trying to detect the session key.
+     *
+     * @var bool
+     */
+    private $isDetectingSessionKey = false;
+
+    /**
      * Indicates whether to attempt to detect the session key when running in the console.
      *
      * @internal this is mainly intended for testing purposes.
@@ -280,21 +287,72 @@ class CacheIntegration extends Feature
                 return null;
             }
 
-            /** @var Session $sessionStore */
-            $sessionStore = $this->container()->make('session.store');
+            if ($this->isDetectingSessionKey) {
+                return null;
+            }
 
-            // It is safe for us to get the session ID here without checking if the session is started
-            // because getting the session ID does not start the session. In addition we need the ID before
-            // the session is started because the cache will retrieve the session ID from the cache before the session
-            // is considered started. So if we wait for the session to be started, we will not be able to replace the
-            // session key in the cache operation that is being executed to retrieve the session data from the cache.
-            return $sessionStore->getId();
-        } catch (\Exception $e) {
+            $this->isDetectingSessionKey = true;
+
+            try {
+                if ($container->resolved('session.store')) {
+                    /** @var Session $sessionStore */
+                    $sessionStore = $this->container()->make('session.store');
+
+                    return $sessionStore->getId();
+                }
+
+                $sessionKey = $this->getSessionKeyFromCurrentRequest();
+
+                if ($sessionKey !== null) {
+                    return $sessionKey;
+                }
+
+                /** @var Session $sessionStore */
+                $sessionStore = $this->container()->make('session.store');
+
+                // It is safe for us to get the session ID here without checking if the session is started
+                // because getting the session ID does not start the session. In addition we need the ID before
+                // the session is started because the cache will retrieve the session ID from the cache before the session
+                // is considered started. So if we wait for the session to be started, we will not be able to replace the
+                // session key in the cache operation that is being executed to retrieve the session data from the cache.
+                return $sessionStore->getId();
+            } finally {
+                $this->isDetectingSessionKey = false;
+            }
+        } catch (\Throwable $e) {
             // We can assume the session store is not available here so there is no session key to retrieve
             // We capture a generic exception to avoid breaking the application because some code paths can
             // result in an exception other than the expected `Illuminate\Contracts\Container\BindingResolutionException`
             return null;
         }
+    }
+
+    /**
+     * Retrieve the session key from the current request cookie if available.
+     */
+    private function getSessionKeyFromCurrentRequest(): ?string
+    {
+        $container = $this->container();
+
+        if (!$container->bound('config') || !$container->bound('request')) {
+            return null;
+        }
+
+        $sessionCookieName = $container->make('config')->get('session.cookie');
+
+        if (!is_string($sessionCookieName) || $sessionCookieName === '') {
+            return null;
+        }
+
+        $request = $container->make('request');
+
+        if (!isset($request->cookies) || !method_exists($request->cookies, 'get')) {
+            return null;
+        }
+
+        $sessionKey = $request->cookies->get($sessionCookieName);
+
+        return is_string($sessionKey) && $sessionKey !== '' ? $sessionKey : null;
     }
 
     /**

--- a/test/Sentry/Features/CacheIntegrationTest.php
+++ b/test/Sentry/Features/CacheIntegrationTest.php
@@ -3,10 +3,13 @@
 namespace Sentry\Laravel\Tests\Features;
 
 use Illuminate\Cache\Events\RetrievingKey;
+use Illuminate\Session\NullSessionHandler;
+use Illuminate\Session\Store;
 use Illuminate\Support\Facades\Cache;
 use Sentry\Laravel\Tests\TestCase;
 use Sentry\Tracing\Span;
 use Sentry\Laravel\Features\CacheIntegration;
+use RuntimeException;
 
 class CacheIntegrationTest extends TestCase
 {
@@ -219,6 +222,58 @@ class CacheIntegrationTest extends TestCase
         $this->assertEquals(['{sessionKey}', 'regular-key', $sessionId . '_another'], $span->getData()['cache.key']);
     }
 
+    public function testCacheBreadcrumbReplacesSessionKeyFromRequestCookieWithoutResolvingSessionStore(): void
+    {
+        $sessionId = str_repeat('a', 40);
+
+        $this->app['request']->cookies->set($this->app['config']->get('session.cookie'), $sessionId);
+
+        CacheIntegrationCacheAccessingSessionStore::$constructionCount = 0;
+
+        $this->app->singleton('session.store', static function () {
+            CacheIntegrationCacheAccessingSessionStore::$constructionCount++;
+
+            throw new RuntimeException('The session store should not be resolved when the request cookie is available.');
+        });
+
+        Cache::get($sessionId);
+
+        $this->assertSame(0, CacheIntegrationCacheAccessingSessionStore::$constructionCount);
+        $this->assertEquals('Missed: {sessionKey}', $this->getLastSentryBreadcrumb()->getMessage());
+    }
+
+    public function testCacheBreadcrumbUsesResolvedSessionStoreBeforeRequestCookie(): void
+    {
+        $cookieSessionId = str_repeat('a', 40);
+
+        $this->app['request']->cookies->set($this->app['config']->get('session.cookie'), $cookieSessionId);
+
+        $this->startSession();
+
+        $sessionStoreSessionId = $this->app['session.store']->getId();
+
+        $this->assertNotSame($cookieSessionId, $sessionStoreSessionId);
+
+        Cache::get($sessionStoreSessionId);
+
+        $this->assertEquals('Missed: {sessionKey}', $this->getLastSentryBreadcrumb()->getMessage());
+    }
+
+    public function testCacheSessionKeyDetectionDoesNotReenterSessionStoreConstruction(): void
+    {
+        CacheIntegrationCacheAccessingSessionStore::$cacheKey = 'browser-detect-like-cache-key';
+        CacheIntegrationCacheAccessingSessionStore::$constructionCount = 0;
+
+        $this->app->singleton('session.store', static function () {
+            return new CacheIntegrationCacheAccessingSessionStore();
+        });
+
+        Cache::get('outer-cache-key');
+
+        $this->assertSame(1, CacheIntegrationCacheAccessingSessionStore::$constructionCount);
+        $this->assertEquals('Missed: outer-cache-key', $this->getLastSentryBreadcrumb()->getMessage());
+    }
+
     public function testCacheOperationDoesNotStartSessionPrematurely(): void
     {
         $this->markSkippedIfTracingEventsNotAvailable();
@@ -256,5 +311,29 @@ class CacheIntegrationTest extends TestCase
         $this->assertTrue(count($spans) >= 2);
 
         return array_pop($spans);
+    }
+}
+
+class CacheIntegrationCacheAccessingSessionStore extends Store
+{
+    /** @var int */
+    public static $constructionCount = 0;
+
+    /** @var string */
+    public static $cacheKey = 'browser-detect-like-cache-key';
+
+    public function __construct()
+    {
+        self::$constructionCount++;
+
+        if (self::$constructionCount > 3) {
+            throw new RuntimeException('Session store construction re-entered too many times.');
+        }
+
+        Cache::remember(self::$cacheKey, 60, static function () {
+            return 'bot-detection-result';
+        });
+
+        parent::__construct('laravel_session', new NullSessionHandler);
     }
 }


### PR DESCRIPTION
### Description
When the constructor of the session store performs a cache operation a infinite loop can occur where the session store causes a cache lookup which causes a session store creation which causes a cache operation etc.

This aims to solve this by tracking if we are looking up the session key and return early to prevent looping and also optimizing the way we do by not creation the session store before the framework and instead reading it from the cookie if there is no session store yet and if the store was already resolved we just use that.

This should be both more correct, faster and safer ✨ 

#### Issues
* resolves: #1127
* resolves: LARAVEL-62