### PR TITLE
fix: update sql binding default behaviour

### DIFF
--- a/src/Sentry/Laravel/Tracing/EventHandler.php
+++ b/src/Sentry/Laravel/Tracing/EventHandler.php
@@ -96,7 +96,7 @@ class EventHandler
     public function __construct(array $config)
     {
         $this->traceSqlQueries = ($config['sql_queries'] ?? true) === true;
-        $this->traceSqlBindings = ($config['sql_bindings'] ?? true) === true;
+        $this->traceSqlBindings = ($config['sql_bindings'] ?? false) === true;
         $this->traceSqlQueryOrigin = ($config['sql_origin'] ?? true) === true;
         $this->traceSqlQueryOriginTreshHoldMs = $config['sql_origin_threshold_ms'] ?? 100;
 

--- a/test/Sentry/Features/DatabaseIntegrationTest.php
+++ b/test/Sentry/Features/DatabaseIntegrationTest.php
@@ -119,6 +119,23 @@ class DatabaseIntegrationTest extends TestCase
         $this->assertFalse(isset($span->getData()['db.sql.bindings']));
     }
 
+    public function testSqlBindingsAreNotRecordedWhenConfigKeyIsMissing(): void
+    {
+        $this->resetApplicationWithConfig([
+            'sentry.tracing' => [
+                'sql_queries' => true,
+            ],
+        ]);
+
+        $span = $this->executeQueryAndRetrieveSpan(
+            $query = 'SELECT %',
+            ['1']
+        );
+
+        $this->assertEquals($query, $span->getDescription());
+        $this->assertFalse(isset($span->getData()['db.sql.bindings']));
+    }
+
     public function testSqlOriginIsResolvedWhenEnabledAndOverTreshold(): void
     {
         $this->resetApplicationWithConfig([


### PR DESCRIPTION
update `sql_bindings` so that it's consistent with the default