### PR TITLE
feat(cron): add override expression for schedules using between

### DIFF
--- a/src/Sentry/Laravel/Features/ConsoleSchedulingIntegration.php
+++ b/src/Sentry/Laravel/Features/ConsoleSchedulingIntegration.php
@@ -50,7 +50,8 @@ class ConsoleSchedulingIntegration extends Feature
             ?int $maxRuntime,
             bool $updateMonitorConfig,
             ?int $failureIssueThreshold,
-            ?int $recoveryThreshold
+            ?int $recoveryThreshold,
+            ?string $schedule
         ) {
             $this->startCheckIn(
                 $slug,
@@ -59,7 +60,8 @@ class ConsoleSchedulingIntegration extends Feature
                 $maxRuntime,
                 $updateMonitorConfig,
                 $failureIssueThreshold,
-                $recoveryThreshold
+                $recoveryThreshold,
+                $schedule
             );
         };
         $finishCheckIn = function (?string $slug, SchedulingEvent $scheduled, CheckInStatus $status) {
@@ -72,7 +74,8 @@ class ConsoleSchedulingIntegration extends Feature
             ?int $maxRuntime = null,
             bool $updateMonitorConfig = true,
             ?int $failureIssueThreshold = null,
-            ?int $recoveryThreshold = null
+            ?int $recoveryThreshold = null,
+            ?string $schedule = null
         ) use ($startCheckIn, $finishCheckIn) {
             /** @var SchedulingEvent $this */
             if ($monitorSlug === null && empty($this->command) && empty($this->description)) {
@@ -87,7 +90,8 @@ class ConsoleSchedulingIntegration extends Feature
                     $maxRuntime,
                     $updateMonitorConfig,
                     $failureIssueThreshold,
-                    $recoveryThreshold
+                    $recoveryThreshold,
+                    $schedule
                 ) {
                     /** @var SchedulingEvent $this */
                     $startCheckIn(
@@ -97,7 +101,8 @@ class ConsoleSchedulingIntegration extends Feature
                         $maxRuntime,
                         $updateMonitorConfig,
                         $failureIssueThreshold,
-                        $recoveryThreshold
+                        $recoveryThreshold,
+                        $schedule
                     );
                 })
                 ->onSuccess(function () use ($finishCheckIn, $monitorSlug) {
@@ -177,7 +182,8 @@ class ConsoleSchedulingIntegration extends Feature
         ?int $maxRuntime,
         bool $updateMonitorConfig,
         ?int $failureIssueThreshold,
-        ?int $recoveryThreshold
+        ?int $recoveryThreshold,
+        ?string $schedule
     ): void {
         if (!$this->shouldHandleCheckIn) {
             return;
@@ -195,7 +201,7 @@ class ConsoleSchedulingIntegration extends Feature
             }
 
             $checkIn->setMonitorConfig(new MonitorConfig(
-                MonitorSchedule::crontab($scheduled->getExpression()),
+                MonitorSchedule::crontab($schedule ?? $scheduled->getExpression()),
                 $checkInMargin,
                 $maxRuntime,
                 $timezone,

--- a/test/Sentry/Features/ConsoleSchedulingIntegrationTest.php
+++ b/test/Sentry/Features/ConsoleSchedulingIntegrationTest.php
@@ -15,6 +15,7 @@ use RuntimeException;
 use Sentry\CheckInStatus;
 use Sentry\Laravel\Features\ConsoleSchedulingIntegration;
 use Sentry\Laravel\Tests\TestCase;
+use Sentry\MonitorSchedule;
 
 class ConsoleSchedulingIntegrationTest extends TestCase
 {
@@ -73,6 +74,34 @@ class ConsoleSchedulingIntegrationTest extends TestCase
 
         $this->assertNotNull($finishCheckInEvent->getCheckIn());
         $this->assertEquals($expectedTimezone, $finishCheckInEvent->getCheckIn()->getMonitorConfig()->getTimezone());
+    }
+
+    public function testScheduleMacroWithScheduleOverride(): void
+    {
+        $expectedSchedule = '*/5 9-17 * * *';
+
+        /** @var Event $scheduledEvent */
+        $scheduledEvent = $this->getScheduler()
+            ->call(function () {})
+            ->everyFiveMinutes()
+            ->between('09:00', '17:59')
+            ->sentryMonitor('test-monitor', null, null, true, null, null, $expectedSchedule);
+
+        $this->assertEquals('*/5 * * * *', $scheduledEvent->getExpression());
+
+        $scheduledEvent->run($this->app);
+
+        // We expect a total of 2 events to be sent to Sentry:
+        // 1. The start check-in event
+        // 2. The finish check-in event
+        $this->assertSentryCheckInCount(2);
+
+        $finishCheckInEvent = $this->getLastSentryEvent();
+
+        $this->assertNotNull($finishCheckInEvent->getCheckIn());
+        $this->assertNotNull($finishCheckInEvent->getCheckIn()->getMonitorConfig());
+        $this->assertEquals(MonitorSchedule::TYPE_CRONTAB, $finishCheckInEvent->getCheckIn()->getMonitorConfig()->getSchedule()->getType());
+        $this->assertEquals($expectedSchedule, $finishCheckInEvent->getCheckIn()->getMonitorConfig()->getSchedule()->getValue());
     }
 
     public function testScheduleMacroAutomaticSlugForCommand(): void


### PR DESCRIPTION
Adds an additional parameter `schedule` that can be used to provide an override schedule that will be used instead of the derived one. The reason for this parameter is that Laravel will not generate proper cron statements when using `between`, it will rather just not run the closure on times outside of specification.
This leads to Sentry reporting missing check ins because we use the generated statement to determine it.

For example, using `->everyFiveMinutes()->between('09:00', '18:00')` will generate `*/5 * * * *`, which means that all runs from 18:05 to 08:55 will be reported as not checked in.

**Important Caveat**: Cron has no possibility to model 09:00 - 18:00 in a single statement, so providing `*/5 9-17 * * *` will ignore the last run of the full hour, but it's probably better than having many missing check ins