### PR TITLE
Update .gitattributes to exclude dev files from composer dist

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,3 +7,7 @@
 /.php_cs export-ignore
 /Makefile export-ignore
 /phpunit.xml export-ignore
+/phpstan.neon export-ignore
+/phpstan-baseline.neon export-ignore
+/.php-cs-fixer.php export-ignore
+/CONTRIBUTING.md export-ignore


### PR DESCRIPTION
This avoids shipping dev/tooling files in the composer dist that aren't needed at runtime.

Last `.gitattributes` update was 2aa81ac (2022-10-19, #601). The files below have been added or modified since, and are still included in the composer dist:
- `/phpstan.neon export-ignore` — last touched in 1e01c7b 2023-08-03 (#740)
- `/phpstan-baseline.neon export-ignore` — last touched in 1d1a873 2026-03-12 (#1103)
- `/.php-cs-fixer.php export-ignore` — last touched in 5a3f81b 2024-11-24 (#954)
- `/CONTRIBUTING.md export-ignore` — last touched in fbcd9bd 2024-01-23 (#839)

Background reading: https://blog.madewithlove.be/post/gitattributes/