### PR TITLE
Follow-up cleanup of .gitattributes after #1139

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,10 +4,12 @@
 /.craft.yml export-ignore
 /.gitattributes export-ignore
 /.gitignore export-ignore
-/.php_cs export-ignore
 /Makefile export-ignore
 /phpunit.xml export-ignore
 /phpstan.neon export-ignore
 /phpstan-baseline.neon export-ignore
 /.php-cs-fixer.php export-ignore
 /CONTRIBUTING.md export-ignore
+/AGENTS.md export-ignore
+/CLAUDE.md export-ignore
+/codecov.yml export-ignore


### PR DESCRIPTION
This avoids shipping dev/tooling files in the composer dist that aren't needed at runtime.

Last `.gitattributes` update was a1975a8 (2026-05-22, #1139).

### Stale entry to remove
- `/.php_cs export-ignore` - file was renamed to `.php-cs-fixer.php` in 51448d1 (2022-09-30, #576 "Upgrade php-cs-fixer dependency"). The new name is already excluded.

### Entries to add
Files added or modified since the last `.gitattributes` update, still shipped in the composer dist:
- `/AGENTS.md export-ignore` - 6.7 KB dev doc
- `/CLAUDE.md export-ignore` - 6.7 KB dev doc
- `/codecov.yml export-ignore` - CI config

Background reading: https://blog.madewithlove.be/post/gitattributes/