### PR TITLE
fix(Ai): create proper span hierarchy

### DIFF
--- a/src/Sentry/Laravel/Features/Ai/HttpRequestIntegration.php
+++ b/src/Sentry/Laravel/Features/Ai/HttpRequestIntegration.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Sentry\Laravel\Features\Ai;
+
+use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Http\Client\Events\RequestSending;
+use Sentry\Laravel\Features\AiIntegration;
+use Sentry\Laravel\Features\Feature;
+
+/**
+ * This integration is only used to produce chat spans before http.client spans are emitted
+ * by the generic HTTP integration to create a proper hierarchy
+ *
+ * @internal
+ */
+class HttpRequestIntegration extends Feature
+{
+    public function isApplicable(): bool
+    {
+        return class_exists(RequestSending::class)
+            && $this->container()->make(AiIntegration::class)->isApplicable();
+    }
+
+    public function onBoot(Dispatcher $events): void
+    {
+        $events->listen(RequestSending::class, [AiIntegration::class, 'handleHttpRequestSending']);
+    }
+}

--- a/src/Sentry/Laravel/Features/AiIntegration.php
+++ b/src/Sentry/Laravel/Features/AiIntegration.php
@@ -131,7 +131,6 @@ class AiIntegration extends Feature
         $events->listen(\Laravel\Ai\Events\EmbeddingsGenerated::class, [$this, 'handleEmbeddingsGeneratedForTracing']);
 
         if (class_exists(RequestSending::class)) {
-            $events->listen(RequestSending::class, [$this, 'handleHttpRequestSending']);
             $events->listen(ResponseReceived::class, [$this, 'handleHttpResponseReceived']);
             $events->listen(ConnectionFailed::class, [$this, 'handleHttpConnectionFailed']);
         }

--- a/src/Sentry/Laravel/ServiceProvider.php
+++ b/src/Sentry/Laravel/ServiceProvider.php
@@ -72,6 +72,7 @@ class ServiceProvider extends BaseServiceProvider
         Features\QueueIntegration::class,
         Features\ConsoleIntegration::class,
         Features\Storage\Integration::class,
+        Features\Ai\HttpRequestIntegration::class,
         Features\HttpClientIntegration::class,
         Features\FolioPackageIntegration::class,
         Features\NotificationsIntegration::class,

--- a/test/Sentry/Features/AiIntegrationTest.php
+++ b/test/Sentry/Features/AiIntegrationTest.php
@@ -355,6 +355,27 @@ class AiIntegrationTest extends TestCase
         $this->assertEquals('conv-abc-123', $data['gen_ai.conversation.id']);
     }
 
+    public function testHttpClientSpanIsNestedWithinChatSpan(): void
+    {
+        $this->resetApplicationWithConfig(['sentry.tracing.http_client_requests' => true, 'prism.providers.openai.url' => self::PROVIDER_URL]);
+
+        $transaction = $this->startTransaction();
+        [$prompt, $response] = $this->makePromptAndResponse();
+        $this->dispatchLaravelEvent(new PromptingAgent('inv-hierarchy', $prompt));
+        $this->dispatchLlmRequestSending();
+
+        $agentSpan = $this->findSpanByOp($transaction, 'gen_ai.invoke_agent');
+        $chatSpan = $this->findSpanByOp($transaction, 'gen_ai.chat');
+        $httpSpan = $this->findSpanByOp($transaction, 'http.client');
+
+        $this->assertEquals($chatSpan->getSpanId(), $httpSpan->getParentSpanId());
+
+        $this->dispatchLlmResponseReceived();
+        $this->assertSame($agentSpan, $this->getSentryHubFromContainer()->getSpan());
+
+        $this->dispatchLaravelEvent(new AgentPrompted('inv-hierarchy', $prompt, $this->wrapResponse($response)));
+    }
+
     public function testMultiStepFlowWithToolCalls(): void
     {
         $transaction = $this->startTransaction();
@@ -532,6 +553,23 @@ class AiIntegrationTest extends TestCase
         $chatSpans = $this->findAllSpansByOp($transaction, 'gen_ai.chat');
         $this->assertCount(1, $chatSpans);
         $this->assertEquals(SpanStatus::internalError(), $chatSpans[0]->getStatus());
+    }
+
+    public function testConnectionFailureRestoresAgentSpan(): void
+    {
+        $this->resetApplicationWithConfig(['sentry.tracing.http_client_requests' => true, 'prism.providers.openai.url' => self::PROVIDER_URL]);
+
+        $transaction = $this->startTransaction();
+        [$prompt] = $this->makePromptAndResponse();
+        $this->dispatchLaravelEvent(new PromptingAgent('inv-fh', $prompt));
+        $this->dispatchLlmRequestSending();
+
+        $httpRequest = new HttpRequest(new \GuzzleHttp\Psr7\Request('POST', self::PROVIDER_URL . '/responses', [], '{}'));
+        $this->dispatchLaravelEvent(new ConnectionFailed($httpRequest, new \Illuminate\Http\Client\ConnectionException('timeout')));
+
+        $agentSpan = $this->findSpanByOp($transaction, 'gen_ai.invoke_agent');
+
+        $this->assertSame($agentSpan, $this->getSentryHubFromContainer()->getSpan());
     }
 
     // ---- Helpers ----


### PR DESCRIPTION
Introduces a small feature container that is registered before the regular HTTP feature, which will first create a chat span if a current invocation exist and then the `http.client` span, leading to the desired hierarchy of

```
gen_ai.invoke_agent
    gen_ai.chat
        http.client
```

instead of the current

```
gen_ai.invoke_agent
    http.client
    gen_ai.chat
```