### PR TITLE
feat(queue): Add optional job context to queue job events

### DIFF
--- a/config/sentry.php
+++ b/config/sentry.php
@@ -159,4 +159,25 @@ return [
         'default_integrations' => env('SENTRY_TRACE_DEFAULT_INTEGRATIONS_ENABLED', true),
     ],
 
+    // Attach extra tags and structured context scoped to the currently processing queue job
+    'job_context' => [
+        // Attach PHP memory usage at job start, at capture time, and peak usage (bytes) plus the configured memory_limit
+        'memory_usage' => env('SENTRY_JOB_CONTEXT_MEMORY_USAGE_ENABLED', false),
+
+        // Attach the queue name, queue connection, and resolved job class as searchable tags
+        'queue_name' => env('SENTRY_JOB_CONTEXT_QUEUE_NAME_ENABLED', false),
+
+        // Attach the default database connection and the connections actually queried during the job
+        'database' => env('SENTRY_JOB_CONTEXT_DATABASE_ENABLED', false),
+
+        // Attach the wall-clock time (in milliseconds) from the start of the job until the event is captured
+        'execution_time' => env('SENTRY_JOB_CONTEXT_EXECUTION_TIME_ENABLED', false),
+
+        // Attach the current job attempt number as a searchable tag
+        'attempts' => env('SENTRY_JOB_CONTEXT_ATTEMPTS_ENABLED', false),
+
+        // Attach Laravel Horizon job metadata (tags, type, displayName, supervisor) when the job was queued through Horizon
+        'horizon' => env('SENTRY_JOB_CONTEXT_HORIZON_ENABLED', false),
+    ],
+
 ];

--- a/src/Sentry/Laravel/Features/Concerns/AppliesJobContext.php
+++ b/src/Sentry/Laravel/Features/Concerns/AppliesJobContext.php
@@ -1,0 +1,333 @@
+<?php
+
+namespace Sentry\Laravel\Features\Concerns;
+
+use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Database\Events\QueryExecuted;
+use Illuminate\Queue\Events\JobProcessing;
+use Sentry\Event as SentryEvent;
+use Sentry\EventHint;
+use Sentry\Laravel\Integration;
+use Sentry\SentrySdk;
+use Sentry\State\Scope;
+
+/**
+ * Attaches extra tags and a structured `laravel.job` context (memory usage, queue identity,
+ * database connections, execution time, attempts and Horizon metadata) scoped to the queue
+ * job that is currently being processed.
+ *
+ * @internal
+ */
+trait AppliesJobContext
+{
+    /**
+     * Wall-clock start time (as returned by `microtime(true)`) of the currently processing job.
+     *
+     * @var float|null
+     */
+    private $jobContextStartTime;
+
+    /**
+     * Memory usage (in bytes) at the start of the currently processing job.
+     *
+     * @var int|null
+     */
+    private $jobContextStartMemory;
+
+    /**
+     * Unique database connection names queried during the currently processing job.
+     *
+     * @var array<int, string>
+     */
+    private $jobContextConnectionsUsed = [];
+
+    /**
+     * Whether database queries should currently be recorded for job context purposes.
+     *
+     * @var bool
+     */
+    private $jobContextTrackingDatabase = false;
+
+    /**
+     * Whether the database query listener has already been registered.
+     *
+     * @var bool
+     */
+    private $jobContextDatabaseListenerRegistered = false;
+
+    /**
+     * Horizon specific metadata extracted from the job payload, if any, for the job
+     * currently being processed.
+     *
+     * @var array<string, mixed>|null
+     */
+    private $jobContextHorizonData;
+
+    /**
+     * Register the listener used to track database connections used during a job.
+     *
+     * This is a no-op if it has already been registered or if the `database` job
+     * context feature is not enabled.
+     */
+    protected function registerJobContextDatabaseListener(Dispatcher $events): void
+    {
+        if ($this->jobContextDatabaseListenerRegistered || !$this->isJobContextFeatureEnabled('database')) {
+            return;
+        }
+
+        $events->listen(QueryExecuted::class, function (QueryExecuted $query): void {
+            if (!$this->jobContextTrackingDatabase) {
+                return;
+            }
+
+            if (!in_array($query->connectionName, $this->jobContextConnectionsUsed, true)) {
+                $this->jobContextConnectionsUsed[] = $query->connectionName;
+            }
+        });
+
+        $this->jobContextDatabaseListenerRegistered = true;
+    }
+
+    /**
+     * Snapshot the state of the job at the start of processing and register the tags
+     * and event processor that will enrich any event captured while this job is running.
+     */
+    protected function captureJobContext(JobProcessing $event): void
+    {
+        if (!$this->isAnyJobContextFeatureEnabled()) {
+            return;
+        }
+
+        $job = $event->job;
+
+        if ($this->isJobContextFeatureEnabled('execution_time')) {
+            $this->jobContextStartTime = microtime(true);
+        }
+
+        if ($this->isJobContextFeatureEnabled('memory_usage')) {
+            $this->jobContextStartMemory = memory_get_usage(true);
+
+            // Reset the peak memory marker so `memory_get_peak_usage()` reflects only this
+            // job on long-running workers. Not available before PHP 8.2, and skipped for the
+            // `sync` connection since that runs inline in the current (HTTP/console) process.
+            if ($event->connectionName !== 'sync' && function_exists('memory_reset_peak_usage')) {
+                memory_reset_peak_usage();
+            }
+        }
+
+        if ($this->isJobContextFeatureEnabled('database')) {
+            $this->jobContextConnectionsUsed = [];
+            $this->jobContextTrackingDatabase = true;
+        }
+
+        if ($this->isJobContextFeatureEnabled('horizon')) {
+            $this->jobContextHorizonData = $this->extractHorizonJobData($job->payload());
+        }
+
+        Integration::configureScope(function (Scope $scope) use ($job, $event): void {
+            if ($this->isJobContextFeatureEnabled('queue_name')) {
+                $scope->setTag('queue', $this->normalizeQueueName($job->getQueue()));
+                $scope->setTag('queue.connection', $event->connectionName);
+
+                if (method_exists($job, 'resolveName')) {
+                    $scope->setTag('job', $job->resolveName());
+                }
+            }
+
+            if ($this->isJobContextFeatureEnabled('attempts')) {
+                $scope->setTag('attempts', (string) $job->attempts());
+            }
+
+            if (isset($this->jobContextHorizonData['supervisor'])) {
+                $scope->setTag('horizon.supervisor', $this->jobContextHorizonData['supervisor']);
+            }
+
+            $scope->addEventProcessor(function (SentryEvent $sentryEvent, ?EventHint $hint = null) use ($event): SentryEvent {
+                return $this->applyJobContextToEvent($sentryEvent, $event);
+            });
+        });
+    }
+
+    /**
+     * Merge the collected job context measurements onto the currently active span (if any)
+     * that was pushed for the job that just finished.
+     */
+    protected function finalizeJobContext(): void
+    {
+        $this->jobContextTrackingDatabase = false;
+
+        if (!$this->isAnyJobContextFeatureEnabled()) {
+            return;
+        }
+
+        // Only attach job context to a span if this job actually pushed one onto the hub.
+        // Otherwise (e.g. queue tracing disabled) the "current" span could belong to an
+        // unrelated parent transaction (like an HTTP request running the `sync` driver).
+        if (!$this->hasPushedSpan()) {
+            return;
+        }
+
+        $span = SentrySdk::getCurrentHub()->getSpan();
+
+        if ($span === null) {
+            return;
+        }
+
+        // Existing `messaging.*` span data (queue name, connection, retry count, etc.) is
+        // preserved
+        $data = $this->buildJobContextForSpan();
+
+        if (!empty($data)) {
+            $span->setData($data);
+        }
+    }
+
+    /**
+     * Reset any state left over from a previous job (used before starting a new job).
+     */
+    protected function resetJobContext(): void
+    {
+        $this->jobContextStartTime = null;
+        $this->jobContextStartMemory = null;
+        $this->jobContextConnectionsUsed = [];
+        $this->jobContextTrackingDatabase = false;
+        $this->jobContextHorizonData = null;
+    }
+
+    /**
+     * Build the `laravel.job` structured context for the event currently being captured.
+     */
+    private function applyJobContextToEvent(SentryEvent $event, JobProcessing $jobEvent): SentryEvent
+    {
+        $context = [];
+
+        if ($this->isJobContextFeatureEnabled('queue_name')) {
+            $context['queue'] = $this->normalizeQueueName($jobEvent->job->getQueue());
+            $context['connection'] = $jobEvent->connectionName;
+        }
+
+        if ($this->isJobContextFeatureEnabled('attempts')) {
+            $context['attempts'] = $jobEvent->job->attempts();
+        }
+
+        if ($this->isJobContextFeatureEnabled('execution_time') && $this->jobContextStartTime !== null) {
+            $context['execution_time_ms'] = round((microtime(true) - $this->jobContextStartTime) * 1000, 2);
+        }
+
+        if ($this->isJobContextFeatureEnabled('memory_usage') && $this->jobContextStartMemory !== null) {
+            $context['memory'] = [
+                'start' => $this->jobContextStartMemory,
+                'end' => memory_get_usage(true),
+                'peak' => memory_get_peak_usage(true),
+                'limit' => ini_get('memory_limit'),
+            ];
+        }
+
+        if ($this->isJobContextFeatureEnabled('database')) {
+            $context['database'] = [
+                'default' => $this->container()['config']->get('database.default'),
+                'connections_used' => $this->jobContextConnectionsUsed,
+            ];
+        }
+
+        if ($this->jobContextHorizonData !== null) {
+            $context['horizon'] = $this->jobContextHorizonData;
+        }
+
+        if (empty($context)) {
+            return $event;
+        }
+
+        $event->setContext('laravel.job', $context);
+
+        return $event;
+    }
+
+    /**
+     * Build the flat, namespaced span data additions for the job currently being processed.
+     *
+     * @return array<string, mixed>
+     */
+    private function buildJobContextForSpan(): array
+    {
+        $data = [];
+
+        if ($this->isJobContextFeatureEnabled('execution_time') && $this->jobContextStartTime !== null) {
+            $data['job_context.execution_time_ms'] = round((microtime(true) - $this->jobContextStartTime) * 1000, 2);
+        }
+
+        if ($this->isJobContextFeatureEnabled('memory_usage') && $this->jobContextStartMemory !== null) {
+            $data['job_context.memory.start'] = $this->jobContextStartMemory;
+            $data['job_context.memory.end'] = memory_get_usage(true);
+            $data['job_context.memory.peak'] = memory_get_peak_usage(true);
+            $data['job_context.memory.limit'] = ini_get('memory_limit');
+        }
+
+        if ($this->isJobContextFeatureEnabled('database')) {
+            $data['job_context.db.default_connection'] = $this->container()['config']->get('database.default');
+            $data['job_context.db.connections_used'] = $this->jobContextConnectionsUsed;
+        }
+
+        if ($this->jobContextHorizonData !== null) {
+            $data['job_context.horizon'] = $this->jobContextHorizonData;
+        }
+
+        return $data;
+    }
+
+    /**
+     * Extract Laravel Horizon specific job metadata from the job payload, if present.
+     *
+     * @param array<string, mixed> $payload
+     *
+     * @return array<string, mixed>|null
+     */
+    private function extractHorizonJobData(array $payload): ?array
+    {
+        // `displayName`, `maxTries` and `timeout` are standard Laravel queue payload keys
+        // present on every job regardless of Horizon, so only genuinely Horizon-specific
+        // keys (set by `Laravel\Horizon\JobPayload::prepare()`) are used here.
+        $horizonKeys = ['type', 'tags', 'silenced', 'pushedAt'];
+
+        $horizon = [];
+
+        foreach ($horizonKeys as $key) {
+            if (array_key_exists($key, $payload)) {
+                $horizon[$key] = $payload[$key];
+            }
+        }
+
+        // None of the known Horizon payload keys were present, this job was most likely not
+        // queued through Horizon so there is nothing meaningful to attach.
+        if (empty($horizon)) {
+            return null;
+        }
+
+        $supervisor = $this->resolveHorizonSupervisorName();
+
+        if ($supervisor !== null) {
+            $horizon['supervisor'] = $supervisor;
+        }
+
+        return $horizon;
+    }
+
+    /**
+     * Attempt to resolve the name of the Horizon supervisor managing the current worker
+     * process from the `horizon:work` / `horizon:supervisor` command line arguments.
+     */
+    private function resolveHorizonSupervisorName(): ?string
+    {
+        if (!isset($_SERVER['argv']) || !is_array($_SERVER['argv'])) {
+            return null;
+        }
+
+        foreach ($_SERVER['argv'] as $argument) {
+            if (is_string($argument) && strncmp($argument, '--supervisor=', 13) === 0) {
+                return substr($argument, 13);
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/Sentry/Laravel/Features/Concerns/TracksPushedScopesAndSpans.php
+++ b/src/Sentry/Laravel/Features/Concerns/TracksPushedScopesAndSpans.php
@@ -48,6 +48,14 @@ trait TracksPushedScopesAndSpans
         ++$this->pushedScopeCount;
     }
 
+    /**
+     * Indicates whether a span was pushed onto the hub that has not been popped/finished yet.
+     */
+    protected function hasPushedSpan(): bool
+    {
+        return count($this->currentSpanStack) > 0;
+    }
+
     protected function maybePopSpan(): ?Span
     {
         if (count($this->currentSpanStack) === 0) {

--- a/src/Sentry/Laravel/Features/Feature.php
+++ b/src/Sentry/Laravel/Features/Feature.php
@@ -35,6 +35,13 @@ abstract class Feature
     private $isBreadcrumbFeatureEnabled = [];
 
     /**
+     * In-memory cache for the job context feature flag.
+     *
+     * @var array<string, bool>
+     */
+    private $isJobContextFeatureEnabled = [];
+
+    /**
      * @param Container $container The Laravel application container.
      */
     public function __construct(Container $container)
@@ -143,6 +150,32 @@ abstract class Feature
         }
 
         return $this->isBreadcrumbFeatureEnabled[$feature];
+    }
+
+    /**
+     * Indicates if the given feature is enabled for job context.
+     */
+    protected function isJobContextFeatureEnabled(string $feature, bool $default = false): bool
+    {
+        if (!array_key_exists($feature, $this->isJobContextFeatureEnabled)) {
+            $this->isJobContextFeatureEnabled[$feature] = $this->isFeatureEnabled('job_context', $feature, $default);
+        }
+
+        return $this->isJobContextFeatureEnabled[$feature];
+    }
+
+    /**
+     * Indicates if any job context feature is enabled.
+     */
+    protected function isAnyJobContextFeatureEnabled(): bool
+    {
+        foreach (array_keys($this->getUserConfig()['job_context'] ?? []) as $feature) {
+            if ($this->isJobContextFeatureEnabled($feature)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/src/Sentry/Laravel/Features/QueueIntegration.php
+++ b/src/Sentry/Laravel/Features/QueueIntegration.php
@@ -13,6 +13,7 @@ use Illuminate\Queue\Events\JobQueueing;
 use Illuminate\Queue\Events\WorkerStopping;
 use Illuminate\Queue\Queue;
 use Sentry\Breadcrumb;
+use Sentry\Laravel\Features\Concerns\AppliesJobContext;
 use Sentry\Laravel\Features\Concerns\TracksPushedScopesAndSpans;
 use Sentry\Laravel\Integration;
 use Sentry\SentrySdk;
@@ -32,6 +33,7 @@ class QueueIntegration extends Feature
     use TracksPushedScopesAndSpans {
         pushScope as private pushScopeTrait;
     }
+    use AppliesJobContext;
 
     private const QUEUE_SPAN_OP_QUEUE_PUBLISH = 'queue.publish';
 
@@ -47,7 +49,8 @@ class QueueIntegration extends Feature
 
         return $this->isBreadcrumbFeatureEnabled('queue_info')
             || $this->isTracingFeatureEnabled('queue_jobs')
-            || $this->isTracingFeatureEnabled('queue_job_transactions');
+            || $this->isTracingFeatureEnabled('queue_job_transactions')
+            || $this->isAnyJobContextFeatureEnabled();
     }
 
     public function onBoot(Dispatcher $events): void
@@ -59,6 +62,8 @@ class QueueIntegration extends Feature
         $events->listen(JobProcessing::class, [$this, 'handleJobProcessingQueueEvent']);
         $events->listen(WorkerStopping::class, [$this, 'handleWorkerStoppingQueueEvent']);
         $events->listen(JobExceptionOccurred::class, [$this, 'handleJobExceptionOccurredQueueEvent']);
+
+        $this->registerJobContextDatabaseListener($events);
 
         if ($this->isTracingFeatureEnabled('queue_jobs') || $this->isTracingFeatureEnabled('queue_job_transactions')) {
             Queue::createPayloadUsing(function (?string $connection, ?string $queue, ?array $payload): ?array {
@@ -117,6 +122,8 @@ class QueueIntegration extends Feature
 
     public function handleJobProcessedQueueEvent(JobProcessed $event): void
     {
+        $this->finalizeJobContext();
+
         $this->maybeFinishSpan(SpanStatus::ok());
 
         $this->maybePopScope();
@@ -126,7 +133,11 @@ class QueueIntegration extends Feature
     {
         $this->maybePopScope();
 
+        $this->resetJobContext();
+
         $this->pushScope();
+
+        $this->captureJobContext($event);
 
         if ($this->isBreadcrumbFeatureEnabled('queue_info')) {
             $job = [
@@ -222,6 +233,8 @@ class QueueIntegration extends Feature
 
     public function handleJobExceptionOccurredQueueEvent(JobExceptionOccurred $event): void
     {
+        $this->finalizeJobContext();
+
         $this->maybeFinishSpan(SpanStatus::internalError());
 
         Integration::flushEvents();

--- a/src/Sentry/Laravel/ServiceProvider.php
+++ b/src/Sentry/Laravel/ServiceProvider.php
@@ -45,6 +45,7 @@ class ServiceProvider extends BaseServiceProvider
         // We do not want these settings to hit the PHP SDK because they are Laravel specific and the PHP SDK will throw errors
         'tracing',
         'breadcrumbs',
+        'job_context',
         // We resolve the integrations through the container later, so we initially do not pass it to the SDK yet
         'integrations',
         // We have this setting to allow us to capture the .env LOG_LEVEL for the sentry_logs channel

--- a/test/Sentry/Features/QueueJobContextTest.php
+++ b/test/Sentry/Features/QueueJobContextTest.php
@@ -1,0 +1,303 @@
+<?php
+
+namespace Sentry\Laravel\Tests\Features;
+
+use Exception;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Database\Events\QueryExecuted;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Queue;
+use Sentry\Laravel\Tests\TestCase;
+use function Sentry\captureException;
+
+class QueueJobContextTest extends TestCase
+{
+    public function testNoJobContextIsAttachedWhenAllFeaturesAreDisabled(): void
+    {
+        dispatch(new QueueJobContextTestJobThatReports);
+
+        $event = $this->getLastSentryEvent();
+
+        $this->assertNotNull($event);
+        $this->assertArrayNotHasKey('laravel.job', $event->getContexts());
+        $this->assertArrayNotHasKey('queue', $event->getTags());
+        $this->assertArrayNotHasKey('queue.connection', $event->getTags());
+        $this->assertArrayNotHasKey('job', $event->getTags());
+        $this->assertArrayNotHasKey('attempts', $event->getTags());
+    }
+
+    public function testQueueNameFeatureAttachesTagsAndContext(): void
+    {
+        $this->resetApplicationWithConfig([
+            'sentry.job_context.queue_name' => true,
+        ]);
+
+        dispatch(new QueueJobContextTestJobThatReports);
+
+        $event = $this->getLastSentryEvent();
+
+        $this->assertSame('sync', $event->getTags()['queue.connection']);
+        $this->assertSame(QueueJobContextTestJobThatReports::class, $event->getTags()['job']);
+        $this->assertArrayHasKey('queue', $event->getTags());
+
+        $context = $event->getContexts()['laravel.job'];
+
+        $this->assertSame('sync', $context['connection']);
+        $this->assertArrayHasKey('queue', $context);
+    }
+
+    public function testQueueNameFeatureIsNotAttachedWhenDisabled(): void
+    {
+        $this->resetApplicationWithConfig([
+            'sentry.job_context.queue_name' => false,
+            'sentry.job_context.attempts' => true,
+        ]);
+
+        dispatch(new QueueJobContextTestJobThatReports);
+
+        $event = $this->getLastSentryEvent();
+
+        $this->assertArrayNotHasKey('queue', $event->getTags());
+        $this->assertArrayNotHasKey('queue', $event->getContexts()['laravel.job']);
+    }
+
+    public function testAttemptsFeatureAttachesTagAndContext(): void
+    {
+        $this->resetApplicationWithConfig([
+            'sentry.job_context.attempts' => true,
+        ]);
+
+        dispatch(new QueueJobContextTestJobThatReports);
+
+        $event = $this->getLastSentryEvent();
+
+        $this->assertSame('1', $event->getTags()['attempts']);
+        $this->assertSame(1, $event->getContexts()['laravel.job']['attempts']);
+    }
+
+    public function testMemoryUsageFeatureAttachesContext(): void
+    {
+        $this->resetApplicationWithConfig([
+            'sentry.job_context.memory_usage' => true,
+        ]);
+
+        dispatch(new QueueJobContextTestJobThatReports);
+
+        $memory = $this->getLastSentryEvent()->getContexts()['laravel.job']['memory'];
+
+        $this->assertIsInt($memory['start']);
+        $this->assertIsInt($memory['end']);
+        $this->assertIsInt($memory['peak']);
+        $this->assertNotEmpty($memory['limit']);
+        $this->assertGreaterThanOrEqual($memory['start'], $memory['peak']);
+    }
+
+    public function testMemoryUsageFeatureIsNotAttachedWhenDisabled(): void
+    {
+        $this->resetApplicationWithConfig([
+            'sentry.job_context.attempts' => true,
+        ]);
+
+        dispatch(new QueueJobContextTestJobThatReports);
+
+        $context = $this->getLastSentryEvent()->getContexts()['laravel.job'];
+
+        $this->assertArrayNotHasKey('memory', $context);
+    }
+
+    public function testExecutionTimeFeatureAttachesContext(): void
+    {
+        $this->resetApplicationWithConfig([
+            'sentry.job_context.execution_time' => true,
+        ]);
+
+        dispatch(new QueueJobContextTestJobThatReports);
+
+        $context = $this->getLastSentryEvent()->getContexts()['laravel.job'];
+
+        $this->assertArrayHasKey('execution_time_ms', $context);
+        $this->assertIsFloat($context['execution_time_ms']);
+        $this->assertGreaterThanOrEqual(0, $context['execution_time_ms']);
+    }
+
+    public function testDatabaseFeatureRecordsConnectionUsedDuringJob(): void
+    {
+        $this->resetApplicationWithConfig([
+            'sentry.job_context.database' => true,
+        ]);
+
+        dispatch(new QueueJobContextTestJobThatQueriesDatabaseAndReports);
+
+        $database = $this->getLastSentryEvent()->getContexts()['laravel.job']['database'];
+
+        $this->assertSame(config('database.default'), $database['default']);
+        $this->assertContains(config('database.default'), $database['connections_used']);
+    }
+
+    public function testDatabaseFeatureRecordsNoConnectionsWhenNoQueriesRan(): void
+    {
+        $this->resetApplicationWithConfig([
+            'sentry.job_context.database' => true,
+        ]);
+
+        dispatch(new QueueJobContextTestJobThatReports);
+
+        $database = $this->getLastSentryEvent()->getContexts()['laravel.job']['database'];
+
+        $this->assertSame([], $database['connections_used']);
+    }
+
+    public function testHorizonFeatureIsSkippedWhenPayloadHasNoHorizonKeys(): void
+    {
+        $this->resetApplicationWithConfig([
+            'sentry.job_context.horizon' => true,
+        ]);
+
+        dispatch(new QueueJobContextTestJobThatReports);
+
+        $context = $this->getLastSentryEvent()->getContexts()['laravel.job'] ?? [];
+
+        $this->assertArrayNotHasKey('horizon', $context);
+    }
+
+    public function testHorizonFeatureAttachesTagAndContextWhenPayloadHasHorizonKeys(): void
+    {
+        $this->resetApplicationWithConfig([
+            'sentry.job_context.horizon' => true,
+        ]);
+
+        // Simulate the extra payload keys `Laravel\Horizon\JobPayload::prepare()` adds,
+        // without requiring the `laravel/horizon` package to be installed.
+        Queue::createPayloadUsing(static function ($connection, $queue, $payload) {
+            $payload['type'] = 'job';
+            $payload['tags'] = ['App\\Models\\User:1'];
+            $payload['silenced'] = false;
+            $payload['pushedAt'] = microtime(true);
+
+            return $payload;
+        });
+
+        $_SERVER['argv'][] = '--supervisor=supervisor-1';
+
+        try {
+            dispatch(new QueueJobContextTestJobThatReports);
+        } finally {
+            Queue::createPayloadUsing(null);
+            array_pop($_SERVER['argv']);
+        }
+
+        $event = $this->getLastSentryEvent();
+
+        $this->assertSame('supervisor-1', $event->getTags()['horizon.supervisor']);
+
+        $horizon = $event->getContexts()['laravel.job']['horizon'];
+
+        $this->assertSame('job', $horizon['type']);
+        $this->assertSame(['App\\Models\\User:1'], $horizon['tags']);
+        $this->assertFalse($horizon['silenced']);
+        $this->assertSame('supervisor-1', $horizon['supervisor']);
+    }
+
+    public function testFailedSyncJobAttachesAllEnabledMeasurements(): void
+    {
+        $this->resetApplicationWithConfig([
+            'sentry.job_context.queue_name' => true,
+            'sentry.job_context.attempts' => true,
+            'sentry.job_context.memory_usage' => true,
+            'sentry.job_context.execution_time' => true,
+        ]);
+
+        try {
+            dispatch(new QueueJobContextTestJobThatThrows);
+        } catch (Exception $e) {
+            // The scope pushed for the job is only popped by the next `JobProcessing` event,
+            // so reporting here (as Laravel's queue worker does for a failed job) still runs
+            // within the job's scope and event processor.
+            report($e);
+        }
+
+        $event = $this->getLastSentryEvent();
+
+        $this->assertNotNull($event);
+        $this->assertSame('sync', $event->getTags()['queue.connection']);
+        $this->assertSame('1', $event->getTags()['attempts']);
+
+        $context = $event->getContexts()['laravel.job'];
+
+        $this->assertArrayHasKey('memory', $context);
+        $this->assertArrayHasKey('execution_time_ms', $context);
+        $this->assertSame(1, $context['attempts']);
+    }
+
+    public function testQueueIntegrationStillRecordsBreadcrumbsWhenQueueInfoEnabled(): void
+    {
+        $this->resetApplicationWithConfig([
+            'sentry.breadcrumbs.queue_info' => true,
+            'sentry.job_context.queue_name' => true,
+        ]);
+
+        dispatch(new QueueJobContextTestJobThatReports);
+
+        $event = $this->getLastSentryEvent();
+
+        $this->assertNotEmpty($event->getBreadcrumbs());
+        $this->assertSame('queue.job', $event->getBreadcrumbs()[0]->getCategory());
+    }
+
+    public function testJobContextIsMergedOntoQueueProcessSpanWhenTracingEnabled(): void
+    {
+        $this->resetApplicationWithConfig([
+            'sentry.traces_sample_rate' => 1.0,
+            'sentry.job_context.memory_usage' => true,
+            'sentry.job_context.execution_time' => true,
+        ]);
+
+        dispatch(new QueueJobContextTestJob);
+
+        $transaction = $this->getLastSentryEvent();
+
+        $this->assertNotNull($transaction);
+
+        $traceContext = $transaction->getContexts()['trace'];
+
+        $this->assertSame('queue.process', $traceContext['op']);
+        $this->assertArrayHasKey('job_context.execution_time_ms', $traceContext['data']);
+        $this->assertArrayHasKey('job_context.memory.start', $traceContext['data']);
+
+        // Existing `messaging.*` span data must be preserved alongside our own keys.
+        $this->assertArrayHasKey('messaging.destination.name', $traceContext['data']);
+    }
+}
+
+class QueueJobContextTestJob implements ShouldQueue
+{
+    public function handle(): void
+    {
+    }
+}
+
+class QueueJobContextTestJobThatReports implements ShouldQueue
+{
+    public function handle(): void
+    {
+        captureException(new Exception('This is a test exception'));
+    }
+}
+
+class QueueJobContextTestJobThatThrows implements ShouldQueue
+{
+    public function handle(): void
+    {
+        throw new Exception('This is a test exception');
+    }
+}
+
+class QueueJobContextTestJobThatQueriesDatabaseAndReports implements ShouldQueue
+{
+    public function handle(): void
+    {
+        event(new QueryExecuted('SELECT 1', [], 1, DB::connection()));
+
+        captureException(new Exception('This is a test exception'));
+    }
+}


### PR DESCRIPTION
### Description

Adds an opt-in `job_context` config section that enriches events and spans captured while a queue job is processing. This makes it easier to debug failing jobs by attaching:

- `memory_usage` — memory consumption during job execution
- `queue_name` — the queue/connection identity the job ran on
- `database` — database connections queried during the job
- `execution_time` — how long the job took to run
- `attempts` — the job's attempt count
- `horizon` — Laravel Horizon metadata, when available

All measurements are disabled by default, so existing users see no change in behavior unless they explicitly opt in.

This came out of custom logic I'd written internally for debugging failing jobs — figured it was generally useful enough to contribute.

#### Issues
None