### PR TITLE
fix: replace backslash with dot for feature flag names

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,7 +35,10 @@ env:
       "PKSA-1q6p-sqkj-8mmj",
       "PKSA-mc58-w91n-f5gv",
       "PKSA-t21r-vtr5-3mdz",
-      "PKSA-scnn-p8mm-jbft"
+      "PKSA-scnn-p8mm-jbft",
+      "PKSA-zyf5-hrxv-hrd7",
+      "PKSA-nv44-1b4d-6gjg",
+      "PKSA-9q1p-3s19-bp1q"
     ]
   COMPOSER_ADVISORY_LARAVEL_6_SYMFONY: >-
     [

--- a/src/Sentry/Laravel/Features/PennantPackageIntegration.php
+++ b/src/Sentry/Laravel/Features/PennantPackageIntegration.php
@@ -28,7 +28,7 @@ class PennantPackageIntegration extends Feature
         SentrySdk::getCurrentHub()->configureScope(function (Scope $scope) use ($feature) {
             // backslashes are not allowed as feature flag names so we replace it with dots to allow class
             // based feature flags
-            $featureName = str_replace('\\', '.', $feature->feature);
+            $featureName = str_replace('\\', '.', ltrim($feature->feature, '\\'));
 
             // The value of the feature is not always a bool (Rich Feature Values) but only bools are supported.
             // The feature is considered "active" if its value is not explicitly false following Pennant's logic.

--- a/src/Sentry/Laravel/Features/PennantPackageIntegration.php
+++ b/src/Sentry/Laravel/Features/PennantPackageIntegration.php
@@ -26,9 +26,13 @@ class PennantPackageIntegration extends Feature
     public function handleFeatureRetrieved($feature): void
     {
         SentrySdk::getCurrentHub()->configureScope(function (Scope $scope) use ($feature) {
+            // backslashes are not allowed as feature flag names so we replace it with dots to allow class
+            // based feature flags
+            $featureName = str_replace('\\', '.', $feature->feature);
+
             // The value of the feature is not always a bool (Rich Feature Values) but only bools are supported.
             // The feature is considered "active" if its value is not explicitly false following Pennant's logic.
-            $scope->addFeatureFlag($feature->feature, $feature->value !== false);
+            $scope->addFeatureFlag($featureName, $feature->value !== false);
         });
     }
 }

--- a/test/Sentry/Features/PennantPackageIntegrationTest.php
+++ b/test/Sentry/Features/PennantPackageIntegrationTest.php
@@ -57,6 +57,26 @@ class PennantPackageIntegrationTest extends TestCase
         ], $flags);
     }
 
+    public function testPennantClassBasedFeatureIsRecordedWithNormalizedName(): void
+    {
+        Feature::active(PennantClassBasedFeature::class);
+
+        $scope = $this->getCurrentSentryScope();
+
+        $event = $scope->applyToEvent(Event::createEvent());
+
+        $this->assertArrayHasKey('flags', $event->getContexts());
+
+        $flags = $event->getContexts()['flags']['values'];
+
+        $this->assertEquals([
+            [
+                'flag' => 'Sentry.Laravel.Tests.Features.PennantClassBasedFeature',
+                'result' => true,
+            ]
+        ], $flags);
+    }
+
     public function testPennantRichFeatureIsRecordedAsActive(): void
     {
         Feature::define('dashboard-version', static function () {
@@ -103,5 +123,13 @@ class PennantPackageIntegrationTest extends TestCase
                 'result' => false,
             ]
         ], $flags);
+    }
+}
+
+class PennantClassBasedFeature
+{
+    public function resolve(): bool
+    {
+        return true;
     }
 }

--- a/test/Sentry/Features/PennantPackageIntegrationTest.php
+++ b/test/Sentry/Features/PennantPackageIntegrationTest.php
@@ -57,6 +57,30 @@ class PennantPackageIntegrationTest extends TestCase
         ], $flags);
     }
 
+    public function testPennantFeatureWithLeadingNamespaceSeparatorIsRecordedWithNormalizedName(): void
+    {
+        Feature::define('\\App\\Features\\NewApi', static function () {
+            return true;
+        });
+
+        Feature::active('\\App\\Features\\NewApi');
+
+        $scope = $this->getCurrentSentryScope();
+
+        $event = $scope->applyToEvent(Event::createEvent());
+
+        $this->assertArrayHasKey('flags', $event->getContexts());
+
+        $flags = $event->getContexts()['flags']['values'];
+
+        $this->assertEquals([
+            [
+                'flag' => 'App.Features.NewApi',
+                'result' => true,
+            ]
+        ], $flags);
+    }
+
     public function testPennantClassBasedFeatureIsRecordedWithNormalizedName(): void
     {
         Feature::active(PennantClassBasedFeature::class);


### PR DESCRIPTION
Replaces `\` with `.` so that feature flag names can be processed by relay. When using class based feature flags in Pennant, it will use the full path as name, which is unfortunately not valid as per relay.

We lack official documentation for what characters are allowed (as far as I could tell), but here is the code with allowed characters directly in relay: https://github.com/getsentry/relay/blob/master/relay-event-schema/src/protocol/contexts/flags.rs#L25