### PR TITLE
fix(tracing): finish failed agent invocations

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -107,7 +107,6 @@ jobs:
       - name: Configure Composer dependencies
         run: |
           # friendsofphp/php-cs-fixer: No need for this package to run phpunit and it conflicts with older Laravel versions
-          # laravel/ai: Only supports PHP 8.4+ and Laravel 12, remove globally and re-add below where supported
           composer remove friendsofphp/php-cs-fixer laravel/ai --dev --no-interaction --no-update
 
           # laravel/pennant: Does not yet support Laravel 13
@@ -122,7 +121,6 @@ jobs:
             "orchestra/testbench:${{ matrix.packages.testbench }}" \
             --no-interaction --no-update
 
-          # Re-require laravel/ai for supported combinations (PHP 8.4+ and Laravel 12)
           if [ "${{ matrix.packages.laravel }}" == "^12.0" ] && ([ "${{ matrix.php }}" == "8.4" ] || [ "${{ matrix.php }}" == "8.5" ]); then
             composer require "laravel/ai:^0.1.5" --dev --no-interaction --no-update
           elif [ "${{ matrix.packages.laravel }}" == "^13.0" ]; then
@@ -255,7 +253,6 @@ jobs:
           # laravel/folio: Only supported on PHP 8.1 + Laravel 10.0 and above
           # laravel/pennant: Only supported on PHP 8.1 + Laravel 10.0 and above
           # laravel/octane: Only supported on PHP 8.1 + Laravel 10.10.1 and above
-          # laravel/ai: Only supported on PHP 8.4+ and Laravel 12
           composer remove friendsofphp/php-cs-fixer livewire/livewire laravel/folio laravel/pennant laravel/octane laravel/ai --dev --no-interaction --no-update
 
           # Require the correct versions we want to run phpunit for

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -125,6 +125,8 @@ jobs:
           # Re-require laravel/ai for supported combinations (PHP 8.4+ and Laravel 12)
           if [ "${{ matrix.packages.laravel }}" == "^12.0" ] && ([ "${{ matrix.php }}" == "8.4" ] || [ "${{ matrix.php }}" == "8.5" ]); then
             composer require "laravel/ai:^0.1.5" --dev --no-interaction --no-update
+          elif [ "${{ matrix.packages.laravel }}" == "^13.0" ]; then
+            composer require "laravel/ai:^0.11.2" --dev --no-interaction --no-update
           fi
 
       - name: Resolve dependencies

--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
         "livewire/livewire": "^2.0 | ^3.0 | ^4.0",
         "mockery/mockery": "^1.3",
         "orchestra/testbench": "^4.7 | ^5.1 | ^6.0 | ^7.0 | ^8.0 | ^9.0 | ^10.0 | ^11.0",
-        "phpstan/phpstan": "^1.10",
+        "phpstan/phpstan": "^1.10 | ^2.2",
         "phpunit/phpunit": "^8.5 | ^9.6 | ^10.4 | ^11.5"
     },
     "autoload-dev": {

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.11",
         "guzzlehttp/guzzle": "^7.2",
-        "laravel/ai": "^0.1.5",
+        "laravel/ai": "^0.11.2",
         "laravel/folio": "^1.1",
         "laravel/framework": "^6.0 | ^7.0 | ^8.0 | ^9.0 | ^10.0 | ^11.0 | ^12.0 | ^13.0",
         "laravel/octane": "^2.15",

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -16,24 +16,9 @@ parameters:
 			path: src/Sentry/Laravel/Features/LivewirePackageIntegration.php
 
 		-
-			message: "#^Call to protected method resolve\\(\\) of class Illuminate\\\\Filesystem\\\\FilesystemManager\\.$#"
-			count: 1
-			path: src/Sentry/Laravel/Features/Storage/Integration.php
-
-		-
 			message: "#^Class Laravel\\\\Lumen\\\\Application not found\\.$#"
 			count: 3
 			path: src/Sentry/Laravel/ServiceProvider.php
-
-		-
-			message: "#^Class Laravel\\\\Ai\\\\Files\\\\Image not found\\.$#"
-			count: 1
-			path: src/Sentry/Laravel/Features/AiIntegration.php
-
-		-
-			message: "#^Class Laravel\\\\Ai\\\\Files\\\\Document not found\\.$#"
-			count: 1
-			path: src/Sentry/Laravel/Features/AiIntegration.php
 
 		-
 			message: "#^Class GraphQL\\\\Language\\\\AST\\\\DocumentNode not found\\.$#"

--- a/src/Sentry/Laravel/Features/AiIntegration.php
+++ b/src/Sentry/Laravel/Features/AiIntegration.php
@@ -16,6 +16,7 @@ use Laravel\Ai\Contracts\Agent;
 use Laravel\Ai\Contracts\HasTools;
 use Laravel\Ai\Contracts\Providers\TextProvider;
 use Laravel\Ai\Contracts\Tool;
+use Laravel\Ai\Events\AgentFailed;
 use Laravel\Ai\Events\AgentPrompted;
 use Laravel\Ai\Events\EmbeddingsGenerated;
 use Laravel\Ai\Events\GeneratingEmbeddings;
@@ -123,6 +124,7 @@ class AiIntegration extends Feature
     {
         $events->listen(\Laravel\Ai\Events\PromptingAgent::class, [$this, 'handlePromptingAgentForTracing']);
         $events->listen(\Laravel\Ai\Events\AgentPrompted::class, [$this, 'handleAgentPromptedForTracing']);
+        $events->listen(\Laravel\Ai\Events\AgentFailed::class, [$this, 'handleAgentFailedForTracing']);
         $events->listen(\Laravel\Ai\Events\StreamingAgent::class, [$this, 'handlePromptingAgentForTracing']);
         $events->listen(\Laravel\Ai\Events\AgentStreamed::class, [$this, 'handleAgentPromptedForTracing']);
         $events->listen(\Laravel\Ai\Events\InvokingTool::class, [$this, 'handleInvokingToolForTracing']);
@@ -252,6 +254,22 @@ class AiIntegration extends Feature
 
         if ($parentSpan !== null) {
             SentrySdk::getCurrentHub()->setSpan($parentSpan);
+        }
+    }
+
+    public function handleAgentFailedForTracing(AgentFailed $event): void
+    {
+        $invocation = $this->invocations->pull($event->invocationId);
+        if ($invocation === null) {
+            return;
+        }
+
+        try {
+            $invocation->finishActiveChatSpan(SpanStatus::internalError());
+            $invocation->span->setStatus(SpanStatus::internalError());
+            $invocation->span->finish();
+        } finally {
+            SentrySdk::getCurrentHub()->setSpan($invocation->parentSpan);
         }
     }
 

--- a/test/Sentry/Features/AiFailedInvocationTest.php
+++ b/test/Sentry/Features/AiFailedInvocationTest.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace Sentry\Laravel\Tests\Features;
+
+use Illuminate\Http\Client\RequestException;
+use Illuminate\Support\Facades\Http;
+use Laravel\Ai\AiServiceProvider;
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Events\AgentFailed;
+use Laravel\Ai\Promptable;
+use Sentry\Laravel\Tests\TestCase;
+use Sentry\SentrySdk;
+use Sentry\Tracing\Span;
+use Sentry\Tracing\SpanStatus;
+use Sentry\Tracing\Transaction;
+
+class AiFailedInvocationTest extends TestCase
+{
+    protected $defaultSetupConfig = ['sentry.tracing.http_client_requests' => false];
+
+    protected function getPackageProviders($app): array
+    {
+        $providers = parent::getPackageProviders($app);
+        if (class_exists(AiServiceProvider::class)) {
+            $providers[] = AiServiceProvider::class;
+        }
+
+        return $providers;
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        if (!class_exists(AgentFailed::class)) {
+            $this->markTestSkipped('Requires the SDK AgentFailed event.');
+        }
+
+        config(['ai.providers.fixture' => [
+            'driver' => 'openai-compatible',
+            'url' => 'https://model.test/v1',
+            'key' => 'fixture-key',
+        ]]);
+        Http::preventStrayRequests();
+    }
+
+    public function testFailureClosesTheInvocationAndRestoresTheParentForTheNextRequest(): void
+    {
+        Http::fakeSequence()
+            ->push($this->answer(), 200)
+            ->push(['error' => ['message' => 'upstream failed']], 500)
+            ->push($this->answer(), 200);
+
+        $failure = null;
+        $this->app['events']->listen(AgentFailed::class, function (AgentFailed $event) use (&$failure): void {
+            $failure = $event;
+        });
+        $transaction = $this->startTransaction();
+        $hub = SentrySdk::getCurrentHub();
+        $agent = $this->agent();
+
+        $agent->prompt('first', [], 'fixture', 'test-model');
+        $this->assertSame($transaction, $hub->getSpan());
+
+        try {
+            $agent->prompt('second', [], 'fixture', 'test-model');
+            $this->fail('Expected the upstream exception.');
+        } catch (RequestException $exception) {
+            $this->assertSame(500, $exception->response->status());
+        }
+
+        $this->assertSame($transaction, $hub->getSpan());
+        $invocations = $this->spans($transaction, 'gen_ai.invoke_agent');
+        $this->assertCount(2, $invocations);
+        $this->assertEquals(SpanStatus::internalError(), $invocations[1]->getStatus());
+        $this->assertNotNull($invocations[1]->getEndTimestamp());
+
+        $this->assertInstanceOf(AgentFailed::class, $failure);
+        $beforeRepeat = count($transaction->getSpanRecorder()->getSpans());
+        $this->dispatchLaravelEvent($failure);
+        $this->assertCount($beforeRepeat, $transaction->getSpanRecorder()->getSpans());
+        $this->assertSame($transaction, $hub->getSpan());
+
+        $agent->prompt('third', [], 'fixture', 'test-model');
+        $this->assertSame($transaction, $hub->getSpan());
+        $this->assertCount(3, $this->spans($transaction, 'gen_ai.chat'));
+        foreach ($this->spans($transaction, 'gen_ai.invoke_agent') as $span) {
+            $this->assertNotNull($span->getEndTimestamp());
+            $this->assertEquals($transaction->getSpanId(), $span->getParentSpanId());
+        }
+        Http::assertSentCount(3);
+    }
+
+    private function agent(): Agent
+    {
+        return new class implements Agent {
+            use Promptable;
+
+            public function instructions(): string
+            {
+                return '';
+            }
+
+            public function maxSteps(): int
+            {
+                return 1;
+            }
+        };
+    }
+
+    private function answer(): array
+    {
+        return ['model' => 'test-model', 'choices' => [[
+            'message' => ['role' => 'assistant', 'content' => 'ok'],
+            'finish_reason' => 'stop',
+        ]], 'usage' => ['prompt_tokens' => 3, 'completion_tokens' => 5]];
+    }
+
+    private function spans(Transaction $transaction, string $operation): array
+    {
+        return array_values(array_filter($transaction->getSpanRecorder()->getSpans(), function (Span $span) use ($operation): bool {
+            return $span->getOp() === $operation;
+        }));
+    }
+}


### PR DESCRIPTION
### Description

A terminal `AgentFailed` event leaves the tracked agent invocation unfinished and its span on the hub. A later request can therefore inherit the failed invocation instead of the caller's span.

- Pull the failed invocation, finish its active chat and agent spans with `internal_error`, and restore the saved parent in `finally`.
- Treat repeated or untracked failure events as no-ops. The handler creates no additional spans.
- Exercise success → HTTP 500 → success through the real SDK with faked HTTP responses, preserving exception propagation and one automatic chat span per request.

### Verified compatibility

Each dependency set was resolved with Composer on its own PHP runtime. The comparison checkouts used the same production and regression-test files.

| Runtime | SDK | Verification |
| --- | --- | --- |
| PHP 8.3.31 / Laravel 13 | 0.11.2 | Full `composer check`: 230 tests / 678 assertions; PHP-CS-Fixer and PHPStan pass |
| PHP 8.4.21 / Laravel 13 | 0.11.2 | Full `composer check`: 230 tests / 678 assertions; PHP-CS-Fixer and PHPStan pass |
| PHP 8.4.21 / Laravel 12 | 0.1.5 | Main suite: 229 passed, 1 skipped, 660 assertions; explicit legacy integration suite: 16 passed / 79 assertions |
| PHP 8.3.31 / Laravel 12 | Not installed | Main suite: 229 passed, 1 skipped, 660 assertions |

The skipped test is the new regression, because those older/absent SDK sets do not provide `AgentFailed`. Both classes load successfully without that optional event or the SDK agent interface. The main suites report 13 existing PHPUnit deprecations. The complete upstream PHP/Laravel matrix remains subject to GitHub Actions approval.

SDK 0.11.2 requires PHP `^8.3`; the older Laravel 12 lane retains 0.1.5. Obsolete comments describing every SDK lane as PHP 8.4/Laravel 12 only have been removed. Runtime package requirements are unchanged. The development analyzer range admits PHPStan 2.2 for current dependency syntax, with obsolete baseline entries removed.

No linked issue. Release-note updates are left to the maintainers in accordance with `AGENTS.md`.
